### PR TITLE
Few improvements, fix PTR

### DIFF
--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -12,6 +12,14 @@ namespace DnsClientX.Examples {
             data.DisplayTable();
         }
 
+        public static async Task ExamplePTR() {
+            var domains = new[] { "1.1.1.1" };
+            HelpersSpectre.AddLine("QueryDns", "1.1.1.1", DnsRecordType.A, "1.1.1.1");
+            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            data.DisplayTable();
+        }
+
+
 
         public static async Task Example1() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.CloudflareWireFormat);

--- a/DnsClientX.Examples/Program.cs
+++ b/DnsClientX.Examples/Program.cs
@@ -3,6 +3,9 @@ using System.Threading.Tasks;
 namespace DnsClientX.Examples {
     public static class Program {
         public static async Task Main() {
+            await DemoQuery.ExamplePTR(); 
+            return;
+
             // await ConvertToDnsClient.ExampleConvertToDnsClientFromX();
             // await ConvertToDnsClient.ExampleConvertFromDnsClientToX();
             //await DemoQuery.ExampleTesting();

--- a/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
+++ b/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            netstandard2.0;net472;net6.0;net7.0;net8.0
+            netstandard2.0;net472;net8.0
         </TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net6.0;net7.0;net8.0
+            net8.0
         </TargetFrameworks>
         <Description>PowerShell Module for working with Event Logs</Description>
         <AssemblyName>DnsClientX.PowerShell</AssemblyName>
         <AssemblyTitle>DnsClientX.PowerShell</AssemblyTitle>
-        <VersionPrefix>0.3.1</VersionPrefix>
+        <VersionPrefix>0.3.2</VersionPrefix>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>

--- a/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
+++ b/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
@@ -3,8 +3,7 @@
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             netstandard2.0;net472;net6.0;net7.0;net8.0
         </TargetFrameworks>
-        <TargetFrameworks
-            Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
             net6.0;net7.0;net8.0
         </TargetFrameworks>
         <Description>PowerShell Module for working with Event Logs</Description>
@@ -24,7 +23,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.5.1">
+        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.6.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            net472;net6.0;net7.0;net8.0
+            net472;net8.0;net9.0
         </TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net6.0;net7.0;net8.0
+            net8.0;net9.0
         </TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/DnsClientX.Tests/QueryDnsByEndpoint.cs
+++ b/DnsClientX.Tests/QueryDnsByEndpoint.cs
@@ -49,5 +49,31 @@ namespace DnsClientX.Tests {
                 Assert.True(answer.Data.Length > 0);
             }
         }
+
+        [Theory]
+        [InlineData(DnsEndpoint.System)]
+        [InlineData(DnsEndpoint.SystemTcp)]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.CloudflareFamily)]
+        [InlineData(DnsEndpoint.CloudflareSecurity)]
+        [InlineData(DnsEndpoint.CloudflareWireFormat)]
+        [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
+        [InlineData(DnsEndpoint.Google)]
+        [InlineData(DnsEndpoint.GoogleWireFormat)]
+        [InlineData(DnsEndpoint.GoogleWireFormatPost)]
+        [InlineData(DnsEndpoint.Quad9)]
+        [InlineData(DnsEndpoint.Quad9ECS)]
+        [InlineData(DnsEndpoint.Quad9Unsecure)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public async void ShouldWorkForPTR(DnsEndpoint endpoint) {
+            var response = await ClientX.QueryDns("1.1.1.1", DnsRecordType.PTR, endpoint);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Data == "one.one.one.one");
+                Assert.True(answer.Name == "1.1.1.1.in-addr.arpa");
+                Assert.True(answer.Type == DnsRecordType.PTR);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
     }
 }

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -65,7 +65,7 @@ namespace DnsClientX {
         public string[] DataStrings => ConvertToMultiString();
 
         /// <summary>
-        /// The value of the DNS record for the given name and type, escaped if necessary removing the quotes completely. 
+        /// The value of the DNS record for the given name and type, escaped if necessary removing the quotes completely.
         /// </summary>
         [JsonIgnore]
         public string[] DataStringsEscaped {
@@ -211,8 +211,18 @@ namespace DnsClientX {
                 //Console.WriteLine($"{certificateUsage} {selector} {matchingType} {certificateAssociationData}");
                 return $"{certificateUsage} {selector} {matchingType} {certificateAssociationData}";
 
+            } else if (Type == DnsRecordType.PTR) {
+                // For PTR records, decode the domain name from the record data
+                try {
+                    var output = Encoding.UTF8.GetString(Convert.FromBase64String(DataRaw));
+                    return output.EndsWith(".") ? output.TrimEnd('.').ToLower() : output.ToLower();
+                } catch (FormatException) {
+                    // If it's not Base64, return the raw data as is
+                    return DataRaw.EndsWith(".") ? DataRaw.TrimEnd('.').ToLower() : DataRaw.ToLower();
+                }
             } else {
-                return DataRaw;
+                // Some records return the data in a higher case (microsoft.com/NS/Quad9ECS) which needs to be fixed
+                return DataRaw.ToLower();
             }
         }
     }

--- a/DnsClientX/Definitions/DnsRecordType.cs
+++ b/DnsClientX/Definitions/DnsRecordType.cs
@@ -1,280 +1,279 @@
-namespace DnsClientX {
+namespace DnsClientX;
+/// <summary>
+/// Type of DNS record as defined in RFC 1035.
+/// c.f. https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
+/// </summary>
+public enum DnsRecordType : ushort {
     /// <summary>
-    /// Type of DNS record as defined in RFC 1035.
-    /// c.f. https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
+    /// The reserved record type.
     /// </summary>
-    public enum DnsRecordType : ushort {
-        /// <summary>
-        /// The reserved record type.
-        /// </summary>
-        Reserved = 0,
-        /// <summary>
-        /// A host address.
-        /// </summary>
-        A = 1,
-        /// <summary>
-        /// An authoritative name server.
-        /// </summary>
-        NS = 2,
-        /// <summary>
-        /// A mail destination (OBSOLETE - use MX).
-        /// </summary>
-        MD = 3,
-        /// <summary>
-        /// A mail forwarder (OBSOLETE - use MX).
-        /// </summary>
-        MF = 4,
-        /// <summary>
-        /// The canonical name for an alias.
-        /// </summary>
-        CNAME = 5,
-        /// <summary>
-        /// Marks the start of a zone of authority.
-        /// </summary>
-        SOA = 6,
-        /// <summary>
-        /// A mailbox domain name (EXPERIMENTAL).
-        /// </summary>
-        MB = 7,
-        /// <summary>
-        /// A mail group member (EXPERIMENTAL).
-        /// </summary>
-        MG = 8,
-        /// <summary>
-        /// A mail rename domain name (EXPERIMENTAL).
-        /// </summary>
-        MR = 9,
-        /// <summary>
-        /// A null RR (EXPERIMENTAL).
-        /// </summary>
-        NULL = 10,
-        /// <summary>
-        /// A well known service description.
-        /// </summary>
-        WKS = 11,
-        /// <summary>
-        /// A domain name pointer.
-        /// </summary>
-        PTR = 12,
-        /// <summary>
-        /// Host information.
-        /// </summary>
-        HINFO = 13,
-        /// <summary>
-        /// Mailbox or mail list information.
-        /// </summary>
-        MINFO = 14,
-        /// <summary>
-        /// Mail exchange.
-        /// </summary>
-        MX = 15,
-        /// <summary>
-        /// Text strings.
-        /// </summary>
-        TXT = 16,
-        /// <summary>
-        /// For responsible person.
-        /// </summary>
-        RP = 17,
-        /// <summary>
-        /// AFS Data Base location.
-        /// </summary>
-        AFSDB = 18,
-        /// <summary>
-        /// for X.25 PSDN address 
-        /// </summary>
-        X25 = 19,
-        /// <summary>
-        /// ISDN address.
-        /// </summary>
-        ISDN = 20,
-        /// <summary>
-        /// for Route Through.
-        /// </summary>
-        RT = 21,
-        /// <summary>
-        /// for NSAP address, NSAP style A record (DEPRECATED)
-        /// </summary>
-        NSAP = 22,
-        /// <summary>
-        /// for domain name pointer, NSAP style (DEPRECATED)
-        /// </summary>
-        NSAP_PTR = 23,
-        /// <summary>
-        /// For a security signature.
-        /// </summary>
-        SIG = 24,
-        /// <summary>
-        /// IPv6 Address.
-        /// </summary>
-        AAAA = 28,
-        /// <summary>
-        /// Location information.
-        /// </summary>
-        LOC = 29,
-        /// <summary>
-        /// Server selection.
-        /// </summary>
-        SRV = 33,
-        /// <summary>
-        /// ATM Address
-        /// </summary>
-        ATMA = 34,
-        /// <summary>
-        /// Naming Authority Pointer.
-        /// </summary>
-        NAPTR = 35,
-        /// <summary>
-        /// Key Exchanger.
-        /// </summary>
-        KX = 36,
-        /// <summary>
-        /// CERT
-        /// </summary>
-        CERT = 37,
-        /// <summary>
-        /// A6 (OBSOLETE - use AAAA).
-        /// </summary>
-        A6 = 38,
-        /// <summary>
-        /// DNAME Record.
-        /// </summary>
-        DNAME = 39,
-        /// <summary>
-        /// The sink
-        /// </summary>
-        SINK = 40,
-        /// <summary>
-        /// The opt
-        /// </summary>
-        OPT = 41,
-        /// <summary>
-        /// The apl
-        /// </summary>
-        APL = 42,
-        /// <summary>
-        /// The ds
-        /// </summary>
-        DS = 43,
-        /// <summary>
-        /// The SSHFP
-        /// </summary>
-        SSHFP = 44,
-        /// <summary>
-        /// IPSECKEY Record.
-        /// </summary>
-        IPSECKEY = 45,
-        /// <summary>
-        /// RRset Signature.
-        /// </summary>
-        RRSIG = 46,
-        /// <summary>
-        /// NSEC
-        /// </summary>
-        NSEC = 47,
-        /// <summary>
-        /// DNSKEY Record.
-        /// </summary>
-        DNSKEY = 48,
-        /// <summary>
-        /// The dhcid
-        /// </summary>
-        DHCID = 49,
-        /// <summary>
-        /// The nse c3
-        /// </summary>
-        NSEC3 = 50,
-        /// <summary>
-        /// The nse c3 parameter
-        /// </summary>
-        NSEC3PARAM = 51,
-        /// <summary>
-        /// The tlsa
-        /// </summary>
-        TLSA = 52,
-        /// <summary>
-        /// The smimea
-        /// </summary>
-        SMIMEA = 53,
-        /// <summary>
-        /// The hip
-        /// </summary>
-        HIP = 55,
-        /// <summary>
-        /// The ninfo
-        /// </summary>
-        NINFO = 56,
-        /// <summary>
-        /// The rkey
-        /// </summary>
-        RKEY = 57,
-        /// <summary>
-        /// Trust Anchor LINK.
-        /// </summary>
-        TALINK = 58,
-        /// <summary>
-        /// Child DS.
-        /// </summary>
-        CDS = 59,
-        /// <summary>
-        /// DNSKEY(s) the Child wants reflected in DS.
-        /// </summary>
-        CDNSKEY = 60,
-        /// <summary>
-        /// OpenPGP public key record.
-        /// </summary>
-        OPENPGPKEY = 61,
-        /// <summary>
-        /// Child to Parent Synchronization.
-        /// </summary>
-        CSYNC = 62,
-        /// <summary>
-        /// Message Digest for DNS Zones.
-        /// </summary>
-        ZONEMD = 63,
-        /// <summary>
-        /// Service Binding.
-        /// </summary>
-        SVCB = 64,
-        /// <summary>
-        /// Service Binding compatible type for us with HTTP
-        /// </summary>
-        HTTPS = 65,
-        /// <summary>
-        /// For the sender policy framework.
-        /// </summary>
-        SPF = 99,
-        /// <summary>
-        /// URI
-        /// </summary>
-        URI = 256,
-        /// <summary>
-        /// Certification Authority Authorization.
-        /// </summary>
-        CAA = 257,
-        /// <summary>
-        /// Application Visibility and Control.
-        /// </summary>
-        AVC = 258,
-        /// <summary>
-        /// Digital Object Architecture.
-        /// </summary>
-        DOA = 259,
-        /// <summary>
-        /// Automatic Multicast Tunneling Relay.
-        /// </summary>
-        AMTRELAY = 260,
-        /// <summary>
-        /// Resolver information as KEY/VALUE pairs.
-        /// </summary>
-        RESINFO = 261,
-        /// <summary>
-        /// DNSSEC Trust Authorities.
-        /// </summary>
-        TA = 32768,
-        /// <summary>
-        /// DNSSEC Lookaside Validation. (OBSOLETE)
-        /// </summary>
-        DLV = 32769
-    }
+    Reserved = 0,
+    /// <summary>
+    /// A host address.
+    /// </summary>
+    A = 1,
+    /// <summary>
+    /// An authoritative name server.
+    /// </summary>
+    NS = 2,
+    /// <summary>
+    /// A mail destination (OBSOLETE - use MX).
+    /// </summary>
+    MD = 3,
+    /// <summary>
+    /// A mail forwarder (OBSOLETE - use MX).
+    /// </summary>
+    MF = 4,
+    /// <summary>
+    /// The canonical name for an alias.
+    /// </summary>
+    CNAME = 5,
+    /// <summary>
+    /// Marks the start of a zone of authority.
+    /// </summary>
+    SOA = 6,
+    /// <summary>
+    /// A mailbox domain name (EXPERIMENTAL).
+    /// </summary>
+    MB = 7,
+    /// <summary>
+    /// A mail group member (EXPERIMENTAL).
+    /// </summary>
+    MG = 8,
+    /// <summary>
+    /// A mail rename domain name (EXPERIMENTAL).
+    /// </summary>
+    MR = 9,
+    /// <summary>
+    /// A null RR (EXPERIMENTAL).
+    /// </summary>
+    NULL = 10,
+    /// <summary>
+    /// A well known service description.
+    /// </summary>
+    WKS = 11,
+    /// <summary>
+    /// A domain name pointer.
+    /// </summary>
+    PTR = 12,
+    /// <summary>
+    /// Host information.
+    /// </summary>
+    HINFO = 13,
+    /// <summary>
+    /// Mailbox or mail list information.
+    /// </summary>
+    MINFO = 14,
+    /// <summary>
+    /// Mail exchange.
+    /// </summary>
+    MX = 15,
+    /// <summary>
+    /// Text strings.
+    /// </summary>
+    TXT = 16,
+    /// <summary>
+    /// For responsible person.
+    /// </summary>
+    RP = 17,
+    /// <summary>
+    /// AFS Data Base location.
+    /// </summary>
+    AFSDB = 18,
+    /// <summary>
+    /// for X.25 PSDN address
+    /// </summary>
+    X25 = 19,
+    /// <summary>
+    /// ISDN address.
+    /// </summary>
+    ISDN = 20,
+    /// <summary>
+    /// for Route Through.
+    /// </summary>
+    RT = 21,
+    /// <summary>
+    /// for NSAP address, NSAP style A record (DEPRECATED)
+    /// </summary>
+    NSAP = 22,
+    /// <summary>
+    /// for domain name pointer, NSAP style (DEPRECATED)
+    /// </summary>
+    NSAP_PTR = 23,
+    /// <summary>
+    /// For a security signature.
+    /// </summary>
+    SIG = 24,
+    /// <summary>
+    /// IPv6 Address.
+    /// </summary>
+    AAAA = 28,
+    /// <summary>
+    /// Location information.
+    /// </summary>
+    LOC = 29,
+    /// <summary>
+    /// Server selection.
+    /// </summary>
+    SRV = 33,
+    /// <summary>
+    /// ATM Address
+    /// </summary>
+    ATMA = 34,
+    /// <summary>
+    /// Naming Authority Pointer.
+    /// </summary>
+    NAPTR = 35,
+    /// <summary>
+    /// Key Exchanger.
+    /// </summary>
+    KX = 36,
+    /// <summary>
+    /// CERT
+    /// </summary>
+    CERT = 37,
+    /// <summary>
+    /// A6 (OBSOLETE - use AAAA).
+    /// </summary>
+    A6 = 38,
+    /// <summary>
+    /// DNAME Record.
+    /// </summary>
+    DNAME = 39,
+    /// <summary>
+    /// The sink
+    /// </summary>
+    SINK = 40,
+    /// <summary>
+    /// The opt
+    /// </summary>
+    OPT = 41,
+    /// <summary>
+    /// The apl
+    /// </summary>
+    APL = 42,
+    /// <summary>
+    /// The ds
+    /// </summary>
+    DS = 43,
+    /// <summary>
+    /// The SSHFP
+    /// </summary>
+    SSHFP = 44,
+    /// <summary>
+    /// IPSECKEY Record.
+    /// </summary>
+    IPSECKEY = 45,
+    /// <summary>
+    /// RRset Signature.
+    /// </summary>
+    RRSIG = 46,
+    /// <summary>
+    /// NSEC
+    /// </summary>
+    NSEC = 47,
+    /// <summary>
+    /// DNSKEY Record.
+    /// </summary>
+    DNSKEY = 48,
+    /// <summary>
+    /// The dhcid
+    /// </summary>
+    DHCID = 49,
+    /// <summary>
+    /// The nse c3
+    /// </summary>
+    NSEC3 = 50,
+    /// <summary>
+    /// The nse c3 parameter
+    /// </summary>
+    NSEC3PARAM = 51,
+    /// <summary>
+    /// The tlsa
+    /// </summary>
+    TLSA = 52,
+    /// <summary>
+    /// The smimea
+    /// </summary>
+    SMIMEA = 53,
+    /// <summary>
+    /// The hip
+    /// </summary>
+    HIP = 55,
+    /// <summary>
+    /// The ninfo
+    /// </summary>
+    NINFO = 56,
+    /// <summary>
+    /// The rkey
+    /// </summary>
+    RKEY = 57,
+    /// <summary>
+    /// Trust Anchor LINK.
+    /// </summary>
+    TALINK = 58,
+    /// <summary>
+    /// Child DS.
+    /// </summary>
+    CDS = 59,
+    /// <summary>
+    /// DNSKEY(s) the Child wants reflected in DS.
+    /// </summary>
+    CDNSKEY = 60,
+    /// <summary>
+    /// OpenPGP public key record.
+    /// </summary>
+    OPENPGPKEY = 61,
+    /// <summary>
+    /// Child to Parent Synchronization.
+    /// </summary>
+    CSYNC = 62,
+    /// <summary>
+    /// Message Digest for DNS Zones.
+    /// </summary>
+    ZONEMD = 63,
+    /// <summary>
+    /// Service Binding.
+    /// </summary>
+    SVCB = 64,
+    /// <summary>
+    /// Service Binding compatible type for us with HTTP
+    /// </summary>
+    HTTPS = 65,
+    /// <summary>
+    /// For the sender policy framework.
+    /// </summary>
+    SPF = 99,
+    /// <summary>
+    /// URI
+    /// </summary>
+    URI = 256,
+    /// <summary>
+    /// Certification Authority Authorization.
+    /// </summary>
+    CAA = 257,
+    /// <summary>
+    /// Application Visibility and Control.
+    /// </summary>
+    AVC = 258,
+    /// <summary>
+    /// Digital Object Architecture.
+    /// </summary>
+    DOA = 259,
+    /// <summary>
+    /// Automatic Multicast Tunneling Relay.
+    /// </summary>
+    AMTRELAY = 260,
+    /// <summary>
+    /// Resolver information as KEY/VALUE pairs.
+    /// </summary>
+    RESINFO = 261,
+    /// <summary>
+    /// DNSSEC Trust Authorities.
+    /// </summary>
+    TA = 32768,
+    /// <summary>
+    /// DNSSEC Lookaside Validation. (OBSOLETE)
+    /// </summary>
+    DLV = 32769
 }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
@@ -26,6 +27,11 @@ namespace DnsClientX {
             // Get the HttpClient for the current strategy
             Client = GetClient(EndpointConfiguration.SelectionStrategy);
 
+            if (type == DnsRecordType.PTR) {
+                // if we have PTR we need to convert it to proper format, just in case user didn't provide as with one
+                name = ConvertToPtrFormat(name);
+            }
+            // Convert the domain name to punycode if it contains non-ASCII characters
             name = ConvertToPunycode(name);
 
             DnsResponse response;

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -188,6 +189,27 @@ namespace DnsClientX {
         private static string ConvertToPunycode(string domainName) {
             IdnMapping idn = new IdnMapping();
             return idn.GetAscii(domainName);
+        }
+
+        /// <summary>
+        /// Converts an IP address to its PTR format. This is useful for reverse DNS lookups.
+        /// </summary>
+        /// <param name="ipAddress"></param>
+        /// <returns></returns>
+        private string ConvertToPtrFormat(string ipAddress) {
+            if (IPAddress.TryParse(ipAddress, out IPAddress? ip)) {
+                if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork) {
+                    // IPv4
+                    return string.Join(".", ip.GetAddressBytes().Reverse()) + ".in-addr.arpa";
+                } else if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6) {
+                    // IPv6
+                    return string.Join(".", ip.GetAddressBytes()
+                        .SelectMany(b => b.ToString("x2"))
+                        .Reverse()) + ".ip6.arpa";
+                }
+            }
+            // Invalid IP address, we return as is
+            return ipAddress;
         }
     }
 }

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -1,18 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Title>DnsClientX</Title>
-        <Description>DnsClientX is an async C# library for DNS over UDP, TCP, HTTPS (DoH), and TLS
+        <Description>
+            DnsClientX is an async C# library for DNS over UDP, TCP, HTTPS (DoH), and TLS
             (DoT). It also has a PowerShell module that can be used to query DNS records. It
             provides a simple way to query DNS records using multiple DNS providers. It supports
             multiple DNS record types and parallel queries. It's available for .NET 6, .NET 7, .NET
-            8, .NET Standard 2.0, and .NET 4.7.2.</Description>
+            8, .NET Standard 2.0, and .NET 4.7.2.
+        </Description>
         <AssemblyName>DnsClientX</AssemblyName>
         <AssemblyTitle>DnsClientX</AssemblyTitle>
-        <VersionPrefix>0.3.1</VersionPrefix>
-        <AssemblyVersion>0.3.1</AssemblyVersion>
-        <FileVersion>0.3.1</FileVersion>
+        <VersionPrefix>0.3.2</VersionPrefix>
+        <AssemblyVersion>0.3.2</AssemblyVersion>
+        <FileVersion>0.3.2</FileVersion>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            netstandard2.0;net472;net6.0;net7.0;net8.0
+            netstandard2.0;net472;net8.0;net9.0
         </TargetFrameworks>
         <TargetFrameworks
             Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
@@ -27,7 +29,7 @@
         <PackageId>DnsClientX</PackageId>
         <PackageIcon>DnsClientX.png</PackageIcon>
         <PackageTags>
-            dns;https;dns-over-https;net472;net48;netstandard;netstandard2.0,netstandard2.1;net70;net80
+            dns;https;dns-over-https;net472;net48;netstandard;netstandard2.0,netstandard2.1;net80;net90
         </PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/DnsClientX</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -45,14 +47,6 @@
         <SignAssembly>False</SignAssembly>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <NeutralLanguage>en</NeutralLanguage>
-    </PropertyGroup>
-
-    <PropertyGroup
-        Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netcoreapp2.2' OR '$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
-        <DefineConstants>NETCOREAPP2_1_OR_GREATER</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
-        <DefineConstants>NET5_0_OR_GREATER</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -18,7 +18,7 @@
         </TargetFrameworks>
         <TargetFrameworks
             Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net6.0;net7.0;net8.0
+            net8.0;net9.0
         </TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>

--- a/DnsClientX/ProtocolDnsWire/DnsMessage.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsMessage.cs
@@ -143,49 +143,5 @@ namespace DnsClientX {
                 return ms.ToArray();
             }
         }
-
-        //public byte[] SerializeDnsWireFormat() {
-        //    using (var ms = new MemoryStream()) {
-        //        using (var writer = new BinaryWriter(ms)) {
-        //            // Transaction ID
-        //            Random random = new Random();
-        //            ushort randomId = (ushort)random.Next(ushort.MinValue, ushort.MaxValue);
-        //            writer.Write((ushort)randomId);
-        //            //writer.Write((ushort)1);
-
-        //            // Flags
-        //            writer.Write((ushort)0x0100); // Standard query
-        //            //writer.Write((ushort)0x0000);
-
-        //            // Questions
-        //            writer.Write((ushort)1);
-
-        //            // Answer RRs
-        //            writer.Write((ushort)0);
-
-        //            // Authority RRs
-        //            writer.Write((ushort)0);
-
-        //            // Additional RRs
-        //            writer.Write((ushort)0);
-
-        //            // Queries
-        //            foreach (var part in _name.Split('.')) {
-        //                writer.Write((byte)part.Length);
-        //                writer.Write(Encoding.ASCII.GetBytes(part));
-        //            }
-
-        //            writer.Write((byte)0); // End of name
-
-        //            // Type
-        //            writer.Write((ushort)_type);
-
-        //            // Class
-        //            writer.Write((ushort)1); // IN
-        //        }
-
-        //        return ms.ToArray();
-        //    }
-        //}
     }
 }


### PR DESCRIPTION
This pull request introduces several significant changes to the `DnsClientX` project, including the addition of PTR record support, updates to target frameworks, and improvements to DNS record handling. Below is a summary of the most important changes:

### Addition of PTR Record Support:
* Added `ExamplePTR` method in `DnsClientX.Examples/DemoQuery.cs` to demonstrate querying PTR records.
* Updated `DnsClientX.Examples/Program.cs` to call the new `ExamplePTR` method.
* Added `ShouldWorkForPTR` test method in `DnsClientX.Tests/QueryDnsByEndpoint.cs` to verify PTR record queries.
* Enhanced `ConvertData` method in `DnsClientX/Definitions/DnsAnswer.cs` to handle PTR records.
* Added `ConvertToPtrFormat` method in `DnsClientX/DnsClientX.cs` to convert IP addresses to PTR format.

### Updates to Target Frameworks:
* Updated target frameworks in `DnsClientX.PowerShell/DnsClientX.PowerShell.csproj` to support only `net8.0` on non-Windows platforms. [[1]](diffhunk://#diff-e6386a5654873426b0b5a8d71021cc419552a5989419c1e62b96d56968460217L4-R12) [[2]](diffhunk://#diff-e6386a5654873426b0b5a8d71021cc419552a5989419c1e62b96d56968460217L27-R26)
* Updated target frameworks in `DnsClientX.Tests/DnsClientX.Tests.csproj` to include `net9.0`.
* Updated target frameworks in `DnsClientX/DnsClientX.csproj` to include `net9.0`. [[1]](diffhunk://#diff-f6899525b2452dca9943eda77dbd5cf6d7c9890c14a08422d6b0f598b27e3dffL4-R21) [[2]](diffhunk://#diff-f6899525b2452dca9943eda77dbd5cf6d7c9890c14a08422d6b0f598b27e3dffL50-L57)

### Improvements to DNS Record Handling:
* Modified `Resolve` method in `DnsClientX/DnsClientX.Resolve.cs` to convert domain names to PTR format for PTR record queries.
* Updated `DnsRecordType` namespace declaration to use file-scoped namespace.

### Miscellaneous:
* Updated package reference for `MatejKafka.XmlDoc2CmdletDoc` in `DnsClientX.PowerShell/DnsClientX.PowerShell.csproj`.
* Removed commented-out code from `DnsClientX/ProtocolDnsWire/DnsMessage.cs`.