### PR TITLE
Fix ptr & bump version

### DIFF
--- a/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
+++ b/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
@@ -9,7 +9,7 @@
         <Description>PowerShell Module for working with Event Logs</Description>
         <AssemblyName>DnsClientX.PowerShell</AssemblyName>
         <AssemblyTitle>DnsClientX.PowerShell</AssemblyTitle>
-        <VersionPrefix>0.3.2</VersionPrefix>
+        <VersionPrefix>0.3.3</VersionPrefix>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -15,7 +15,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
         <PackageReference Include="SemanticComparison" Version="4.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -10,9 +10,9 @@
         </Description>
         <AssemblyName>DnsClientX</AssemblyName>
         <AssemblyTitle>DnsClientX</AssemblyTitle>
-        <VersionPrefix>0.3.2</VersionPrefix>
-        <AssemblyVersion>0.3.2</AssemblyVersion>
-        <FileVersion>0.3.2</FileVersion>
+        <VersionPrefix>0.3.3</VersionPrefix>
+        <AssemblyVersion>0.3.3</AssemblyVersion>
+        <FileVersion>0.3.3</FileVersion>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             netstandard2.0;net472;net8.0;net9.0
         </TargetFrameworks>

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -75,7 +75,7 @@ Build-Module -ModuleName 'DnsClientX' {
         NETProjectName                    = 'DnsClientX.PowerShell'
         NETBinaryModule                   = 'DnsClientX.PowerShell.dll'
         NETConfiguration                  = 'Release'
-        NETFramework                      = 'net472', 'net6.0'
+        NETFramework                      = 'net472', 'net8.0'
         DotSourceLibraries                = $true
         NETSearchClass                    = 'DnsClientX.PowerShell.CmdletResolveDnsQuery'
     }
@@ -83,7 +83,7 @@ Build-Module -ModuleName 'DnsClientX' {
     New-ConfigurationBuild @newConfigurationBuildSplat
 
     New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" -RequiredModulesPath "$PSScriptRoot\..\Artefacts\Unpacked\Modules"
-    New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName
+    New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName -ArtefactName "DnsClientX-PowerShellModule.<TagModuleVersionWithPreRelease>.zip" -ID 'ToGitHub'
 
     # global options for publishing to github/psgallery
     #New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$true

--- a/Module/DnsClientX.psd1
+++ b/Module/DnsClientX.psd1
@@ -8,7 +8,7 @@
     Description          = 'DnsClientX is PowerShell module that allows you to query DNS servers for information. It supports DNS over UDP, TCP and DNS over HTTPS (DoH) and DNS over TLS (DoT). It supports multiple types of DNS queries and can be used to query public DNS servers, private DNS servers and has built-in DNS Providers.'
     FunctionsToExport    = @()
     GUID                 = '77fa806c-70b7-48d9-8b88-942ed73f24ed'
-    ModuleVersion        = '0.3.1'
+    ModuleVersion        = '0.3.2'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{


### PR DESCRIPTION
This pull request includes several changes to the `DnsClientX` project, focusing on version updates, dependency adjustments, and improvements to DNS record handling.

### Version Updates:
* Updated `VersionPrefix`, `AssemblyVersion`, and `FileVersion` to `0.3.3` in `DnsClientX.PowerShell.csproj` and `DnsClientX.csproj` files. [[1]](diffhunk://#diff-e6386a5654873426b0b5a8d71021cc419552a5989419c1e62b96d56968460217L12-R12) [[2]](diffhunk://#diff-f6899525b2452dca9943eda77dbd5cf6d7c9890c14a08422d6b0f598b27e3dffL13-R15)
* Updated `ModuleVersion` to `0.3.2` in `DnsClientX.psd1`.

### Dependency Adjustments:
* Removed the `AutoFixture` package reference from `DnsClientX.Tests.csproj`.

### DNS Record Handling Improvements:
* Enhanced the `ConvertData` method in `DnsAnswer.cs` to handle PTR records more robustly by first attempting to decode as Base64 and then converting special formats to a standard dotted format. Added a new helper method `ConvertSpecialFormatToDotted` for this purpose.

### Build Configuration:
* Updated the target .NET framework versions in `Build-Module.ps1` to include `net8.0`.