### PR TITLE
Further changes to PTR (I'm pretty bad at this), changes default provider from Cloudflare to System

### DIFF
--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -19,6 +19,26 @@ namespace DnsClientX.Examples {
             data.DisplayTable();
         }
 
+        public static async Task ExamplePTR1() {
+            var domains = new[] { "1.1.1.1", "192.168.241.5", "192.168.241.108" };
+            HelpersSpectre.AddLine("QueryDns", "1.1.1.1", DnsRecordType.A, "192.168.241.5");
+            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "192.168.241.5", DnsRequestFormat.DnsOverUDP);
+            data.DisplayTable();
+        }
+
+        public static async Task ExamplePTR2() {
+            var domains = new[] { "1.1.1.1", "192.168.241.5", "192.168.241.108" };
+            HelpersSpectre.AddLine("QueryDns", "1.1.1.1", DnsRecordType.A, "192.168.241.5");
+            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "192.168.241.5", DnsRequestFormat.DnsOverTCP);
+            data.DisplayTable();
+        }
+
+        public static async Task ExamplePTR3() {
+            var domains = new[] { "1.1.1.1", "108.138.7.68" };
+            HelpersSpectre.AddLine("QueryDns", "1.1.1.1", DnsRecordType.A, "1.1.1.1");
+            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            data.DisplayTable();
+        }
 
 
         public static async Task Example1() {

--- a/DnsClientX.Examples/Program.cs
+++ b/DnsClientX.Examples/Program.cs
@@ -3,7 +3,10 @@ using System.Threading.Tasks;
 namespace DnsClientX.Examples {
     public static class Program {
         public static async Task Main() {
-            await DemoQuery.ExamplePTR(); 
+            await DemoQuery.ExamplePTR();
+            await DemoQuery.ExamplePTR1();
+            await DemoQuery.ExamplePTR2();
+            await DemoQuery.ExamplePTR3();
             return;
 
             // await ConvertToDnsClient.ExampleConvertToDnsClientFromX();

--- a/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
+++ b/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
@@ -9,7 +9,7 @@
         <Description>PowerShell Module for working with Event Logs</Description>
         <AssemblyName>DnsClientX.PowerShell</AssemblyName>
         <AssemblyTitle>DnsClientX.PowerShell</AssemblyTitle>
-        <VersionPrefix>0.3.3</VersionPrefix>
+        <VersionPrefix>0.3.4</VersionPrefix>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>

--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -31,6 +31,8 @@ namespace DnsClientX.Tests {
         [InlineData("microsoft.com", DnsRecordType.NS)]
 
         [InlineData("google.com", DnsRecordType.MX)]
+        [InlineData("1.1.1.1", DnsRecordType.PTR)]
+        [InlineData("108.138.7.68", DnsRecordType.PTR)]
         public async void CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -16,7 +16,7 @@ namespace DnsClientX {
         /// <param name="dnsSelectionStrategy">The DNS selection strategy. Defaults to First</param>
         /// <param name="timeOutMilliseconds"></param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.Cloudflare, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000) {
+        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000) {
             ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             var data = await client.Resolve(name, recordType);
@@ -33,7 +33,7 @@ namespace DnsClientX {
         /// <param name="dnsSelectionStrategy">The DNS selection strategy. Defaults to First</param>
         /// <param name="timeOutMilliseconds"></param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.Cloudflare, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000) {
             ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -149,7 +149,7 @@ namespace DnsClientX {
         /// <param name="dnsEndpoint">The DNS endpoint. Default endpoint is Cloudflare</param>
         /// <param name="timeOutMilliseconds"></param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.Cloudflare, int timeOutMilliseconds = 1000) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = 1000) {
             ClientX client = new ClientX(endpoint: dnsEndpoint) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -10,9 +10,9 @@
         </Description>
         <AssemblyName>DnsClientX</AssemblyName>
         <AssemblyTitle>DnsClientX</AssemblyTitle>
-        <VersionPrefix>0.3.3</VersionPrefix>
-        <AssemblyVersion>0.3.3</AssemblyVersion>
-        <FileVersion>0.3.3</FileVersion>
+        <VersionPrefix>0.3.4</VersionPrefix>
+        <AssemblyVersion>0.3.4</AssemblyVersion>
+        <FileVersion>0.3.4</FileVersion>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             netstandard2.0;net472;net8.0;net9.0
         </TargetFrameworks>

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -3,7 +3,7 @@
 Build-Module -ModuleName 'DnsClientX' {
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
-        ModuleVersion        = '0.3.X'
+        ModuleVersion        = '0.3.4'
         CompatiblePSEditions = @('Desktop', 'Core')
         GUID                 = '77fa806c-70b7-48d9-8b88-942ed73f24ed'
         Author               = 'Przemyslaw Klys'

--- a/Module/DnsClientX.psd1
+++ b/Module/DnsClientX.psd1
@@ -8,7 +8,7 @@
     Description          = 'DnsClientX is PowerShell module that allows you to query DNS servers for information. It supports DNS over UDP, TCP and DNS over HTTPS (DoH) and DNS over TLS (DoT). It supports multiple types of DNS queries and can be used to query public DNS servers, private DNS servers and has built-in DNS Providers.'
     FunctionsToExport    = @()
     GUID                 = '77fa806c-70b7-48d9-8b88-942ed73f24ed'
-    ModuleVersion        = '0.3.2'
+    ModuleVersion        = '0.3.4'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{


### PR DESCRIPTION
This pull request includes several changes to the `DnsClientX` project, focusing on adding new examples, updating version numbers, and improving DNS query functionality. The most important changes include adding new example methods for PTR record queries, updating the DNS endpoint defaults, and enhancing the `ConvertSpecialFormatToDotted` method for better data handling.

### New Example Methods for PTR Record Queries:
* [`DnsClientX.Examples/DemoQuery.cs`](diffhunk://#diff-c6151895776aa65c3dfd10fd61ec85e472e7aed5dcf9a72bd9fdcd7a60b7ec19R22-R41): Added `ExamplePTR1`, `ExamplePTR2`, and `ExamplePTR3` methods to demonstrate querying PTR records using different DNS request formats.
* [`DnsClientX.Examples/Program.cs`](diffhunk://#diff-31be81efa234a452fa8df75da1aa01a531ec6ddac4775afd519698b3814d187fR7-R9): Updated `Main` method to call the new example methods.

### DNS Endpoint Default Updates:
* [`DnsClientX/DnsClientX.QueryDns.cs`](diffhunk://#diff-c6879078fa2329b9f19c5790e846e614be2855f6f44d8fa6b654021fef39f012L19-R19): Changed default `dnsEndpoint` from `DnsEndpoint.Cloudflare` to `DnsEndpoint.System` in multiple `QueryDns` methods. [[1]](diffhunk://#diff-c6879078fa2329b9f19c5790e846e614be2855f6f44d8fa6b654021fef39f012L19-R19) [[2]](diffhunk://#diff-c6879078fa2329b9f19c5790e846e614be2855f6f44d8fa6b654021fef39f012L36-R36) [[3]](diffhunk://#diff-c6879078fa2329b9f19c5790e846e614be2855f6f44d8fa6b654021fef39f012L152-R152)

### Data Handling Improvements:
* [`DnsClientX/Definitions/DnsAnswer.cs`](diffhunk://#diff-f5c23683a0e4198a1fb85346d17e91c240063a5045a4744a06b3ba20e5d69811L238-R266): Enhanced `ConvertSpecialFormatToDotted` method to handle data more robustly by checking if the data is already in a standard format and processing it accordingly.

### Version Number Updates:
* [`DnsClientX.PowerShell/DnsClientX.PowerShell.csproj`](diffhunk://#diff-e6386a5654873426b0b5a8d71021cc419552a5989419c1e62b96d56968460217L12-R12): Updated `VersionPrefix` to `0.3.4`.
* [`DnsClientX/DnsClientX.csproj`](diffhunk://#diff-f6899525b2452dca9943eda77dbd5cf6d7c9890c14a08422d6b0f598b27e3dffL13-R15): Updated `VersionPrefix`, `AssemblyVersion`, and `FileVersion` to `0.3.4`.
* [`Module/Build/Build-Module.ps1`](diffhunk://#diff-1fe8f431e4f90001c7718ca294eabeee23f831020db0192e7babb9ce663c26afL6-R6): Updated `ModuleVersion` to `0.3.4`.
* [`Module/DnsClientX.psd1`](diffhunk://#diff-84906d86dfba23f4562f87cac627a431283eb8566189a8029d603d44730ef64dL11-R11): Updated `ModuleVersion` to `0.3.4`.

### Test Enhancements:
* [`DnsClientX.Tests/CompareProvidersResolve.cs`](diffhunk://#diff-4aa821cb12589b5e50a00919328950dcc9c5947f6ea0b126bd5c82e19f70e97aR34-R35): Added new test cases for PTR records.