### PR TITLE
Add synchronous DNS query capability

### DIFF
--- a/DnsClientX.Tests/QueryDnsByEndpoint.cs
+++ b/DnsClientX.Tests/QueryDnsByEndpoint.cs
@@ -41,6 +41,31 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9Unsecure)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public void ShouldWorkForTXTSync(DnsEndpoint endpoint) {
+            var response = ClientX.QueryDnsSync("github.com", DnsRecordType.TXT, endpoint);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Name == "github.com");
+                Assert.True(answer.Type == DnsRecordType.TXT);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.System)]
+        [InlineData(DnsEndpoint.SystemTcp)]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.CloudflareFamily)]
+        [InlineData(DnsEndpoint.CloudflareSecurity)]
+        [InlineData(DnsEndpoint.CloudflareWireFormat)]
+        [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
+        [InlineData(DnsEndpoint.Google)]
+        [InlineData(DnsEndpoint.GoogleWireFormat)]
+        [InlineData(DnsEndpoint.GoogleWireFormatPost)]
+        [InlineData(DnsEndpoint.Quad9)]
+        [InlineData(DnsEndpoint.Quad9ECS)]
+        [InlineData(DnsEndpoint.Quad9Unsecure)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async void ShouldWorkForA(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint);
             foreach (DnsAnswer answer in response.Answers) {
@@ -66,8 +91,59 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9Unsecure)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public void ShouldWorkForASync(DnsEndpoint endpoint) {
+            var response = ClientX.QueryDnsSync("evotec.pl", DnsRecordType.A, endpoint);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Name == "evotec.pl");
+                Assert.True(answer.Type == DnsRecordType.A);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.System)]
+        [InlineData(DnsEndpoint.SystemTcp)]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.CloudflareFamily)]
+        [InlineData(DnsEndpoint.CloudflareSecurity)]
+        [InlineData(DnsEndpoint.CloudflareWireFormat)]
+        [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
+        [InlineData(DnsEndpoint.Google)]
+        [InlineData(DnsEndpoint.GoogleWireFormat)]
+        [InlineData(DnsEndpoint.GoogleWireFormatPost)]
+        [InlineData(DnsEndpoint.Quad9)]
+        [InlineData(DnsEndpoint.Quad9ECS)]
+        [InlineData(DnsEndpoint.Quad9Unsecure)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async void ShouldWorkForPTR(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("1.1.1.1", DnsRecordType.PTR, endpoint);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Data == "one.one.one.one");
+                Assert.True(answer.Name == "1.1.1.1.in-addr.arpa");
+                Assert.True(answer.Type == DnsRecordType.PTR);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.System)]
+        [InlineData(DnsEndpoint.SystemTcp)]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.CloudflareFamily)]
+        [InlineData(DnsEndpoint.CloudflareSecurity)]
+        [InlineData(DnsEndpoint.CloudflareWireFormat)]
+        [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
+        [InlineData(DnsEndpoint.Google)]
+        [InlineData(DnsEndpoint.GoogleWireFormat)]
+        [InlineData(DnsEndpoint.GoogleWireFormatPost)]
+        [InlineData(DnsEndpoint.Quad9)]
+        [InlineData(DnsEndpoint.Quad9ECS)]
+        [InlineData(DnsEndpoint.Quad9Unsecure)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public void ShouldWorkForPTRSync(DnsEndpoint endpoint) {
+            var response = ClientX.QueryDnsSync("1.1.1.1", DnsRecordType.PTR, endpoint);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Data == "one.one.one.one");
                 Assert.True(answer.Name == "1.1.1.1.in-addr.arpa");

--- a/DnsClientX.Tests/QueryDnsByHostName.cs
+++ b/DnsClientX.Tests/QueryDnsByHostName.cs
@@ -18,6 +18,21 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("family.cloudflare-dns.com", DnsRequestFormat.DnsOverHttpsJSON)]
+        // Google contrary to the other endpoints does not work with /dns-query but with /resolve
+        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
+        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
+        public void ShouldWorkForTXTSync(string hostName, DnsRequestFormat requestFormat) {
+            var response = ClientX.QueryDnsSync("github.com", DnsRecordType.TXT, hostName, requestFormat);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Name == "github.com");
+                Assert.True(answer.Type == DnsRecordType.TXT);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("family.cloudflare-dns.com", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverUDP)]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverTCP)]
         // Google contrary to the other endpoints does not work with /dns-query but with /resolve
@@ -40,9 +55,47 @@ namespace DnsClientX.Tests {
         // Google contrary to the other endpoints does not work with /dns-query but with /resolve
         // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
         [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
+        public void ShouldWorkForASync(string hostName, DnsRequestFormat requestFormat) {
+            var response = ClientX.QueryDnsSync("evotec.pl", DnsRecordType.A, hostName, requestFormat);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Name == "evotec.pl");
+                Assert.True(answer.Type == DnsRecordType.A);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("family.cloudflare-dns.com", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("1.1.1.1", DnsRequestFormat.DnsOverUDP)]
+        [InlineData("1.1.1.1", DnsRequestFormat.DnsOverTCP)]
+        // Google contrary to the other endpoints does not work with /dns-query but with /resolve
+        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
+        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
         public async void ShouldWorkForMultipleDomains(string hostName, DnsRequestFormat requestFormat) {
             var domains = new[] { "evotec.pl", "google.com" };
             var responses = await ClientX.QueryDns(domains, DnsRecordType.A, hostName, requestFormat);
+            foreach (var domain in domains) {
+                var response = responses.First(r => r.Questions.Any(q => q.Name == domain));
+                foreach (DnsAnswer answer in response.Answers) {
+                    Assert.True(answer.Name == domain);
+                    Assert.True(answer.Type == DnsRecordType.A);
+                    Assert.True(answer.Data.Length > 0);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("family.cloudflare-dns.com", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("1.1.1.1", DnsRequestFormat.DnsOverUDP)]
+        [InlineData("1.1.1.1", DnsRequestFormat.DnsOverTCP)]
+        // Google contrary to the other endpoints does not work with /dns-query but with /resolve
+        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
+        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
+        public void ShouldWorkForMultipleDomainsSync(string hostName, DnsRequestFormat requestFormat) {
+            var domains = new[] { "evotec.pl", "google.com" };
+            var responses = ClientX.QueryDnsSync(domains, DnsRecordType.A, hostName, requestFormat);
             foreach (var domain in domains) {
                 var response = responses.First(r => r.Questions.Any(q => q.Name == domain));
                 foreach (DnsAnswer answer in response.Answers) {

--- a/DnsClientX.Tests/QueryDnsByUri.cs
+++ b/DnsClientX.Tests/QueryDnsByUri.cs
@@ -20,12 +20,43 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://9.9.9.11:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://208.67.222.123/dns-query", DnsRequestFormat.DnsOverHttps)]
+        public void ShouldWorkForTXTSync(string baseUri, DnsRequestFormat requestFormat) {
+            Uri uri = new Uri(baseUri);
+            var response = ClientX.QueryDnsSync("github.com", DnsRecordType.TXT, uri, requestFormat);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Name == "github.com");
+                Assert.True(answer.Type == DnsRecordType.TXT);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://9.9.9.10:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://doh.opendns.com/dns-query", DnsRequestFormat.DnsOverHttps)]
         [InlineData("https://dns.adguard.com/dns-query", DnsRequestFormat.DnsOverHttps)]
         public async void ShouldWorkForA(string baseUri, DnsRequestFormat requestFormat) {
             Uri uri = new Uri(baseUri);
             var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, uri, requestFormat);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Name == "evotec.pl");
+                Assert.True(answer.Type == DnsRecordType.A);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://9.9.9.10:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://doh.opendns.com/dns-query", DnsRequestFormat.DnsOverHttps)]
+        [InlineData("https://dns.adguard.com/dns-query", DnsRequestFormat.DnsOverHttps)]
+        public void ShouldWorkForASync(string baseUri, DnsRequestFormat requestFormat) {
+            Uri uri = new Uri(baseUri);
+            var response = ClientX.QueryDnsSync("evotec.pl", DnsRecordType.A, uri, requestFormat);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "evotec.pl");
                 Assert.True(answer.Type == DnsRecordType.A);

--- a/DnsClientX.Tests/ResolveSync.cs
+++ b/DnsClientX.Tests/ResolveSync.cs
@@ -1,0 +1,117 @@
+using DnsClientX;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveSync {
+        [Theory]
+        [InlineData(DnsEndpoint.System)]
+        [InlineData(DnsEndpoint.SystemTcp)]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.CloudflareFamily)]
+        [InlineData(DnsEndpoint.CloudflareSecurity)]
+        [InlineData(DnsEndpoint.CloudflareWireFormat)]
+        [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
+        [InlineData(DnsEndpoint.Google)]
+        [InlineData(DnsEndpoint.GoogleWireFormat)]
+        [InlineData(DnsEndpoint.GoogleWireFormatPost)]
+        [InlineData(DnsEndpoint.Quad9)]
+        [InlineData(DnsEndpoint.Quad9ECS)]
+        [InlineData(DnsEndpoint.Quad9Unsecure)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public void ShouldWorkForTXTSync(DnsEndpoint endpoint) {
+            var client = new ClientX(endpoint);
+            var response = client.ResolveSync("github.com", DnsRecordType.TXT);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Name == "github.com");
+                Assert.True(answer.Type == DnsRecordType.TXT);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.System)]
+        [InlineData(DnsEndpoint.SystemTcp)]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.CloudflareFamily)]
+        [InlineData(DnsEndpoint.CloudflareSecurity)]
+        [InlineData(DnsEndpoint.CloudflareWireFormat)]
+        [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
+        [InlineData(DnsEndpoint.Google)]
+        [InlineData(DnsEndpoint.GoogleWireFormat)]
+        [InlineData(DnsEndpoint.GoogleWireFormatPost)]
+        [InlineData(DnsEndpoint.Quad9)]
+        [InlineData(DnsEndpoint.Quad9ECS)]
+        [InlineData(DnsEndpoint.Quad9Unsecure)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public void ShouldWorkForASync(DnsEndpoint endpoint) {
+            var client = new ClientX(endpoint);
+            var response = client.ResolveSync("evotec.pl", DnsRecordType.A);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Name == "evotec.pl");
+                Assert.True(answer.Type == DnsRecordType.A);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.System)]
+        [InlineData(DnsEndpoint.SystemTcp)]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.CloudflareFamily)]
+        [InlineData(DnsEndpoint.CloudflareSecurity)]
+        [InlineData(DnsEndpoint.CloudflareWireFormat)]
+        [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
+        [InlineData(DnsEndpoint.Google)]
+        [InlineData(DnsEndpoint.GoogleWireFormat)]
+        [InlineData(DnsEndpoint.GoogleWireFormatPost)]
+        [InlineData(DnsEndpoint.Quad9)]
+        [InlineData(DnsEndpoint.Quad9ECS)]
+        [InlineData(DnsEndpoint.Quad9Unsecure)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public void ShouldWorkForPTRSync(DnsEndpoint endpoint) {
+            var client = new ClientX(endpoint);
+            var response = client.ResolveSync("1.1.1.1", DnsRecordType.PTR);
+            foreach (DnsAnswer answer in response.Answers) {
+                Assert.True(answer.Data == "one.one.one.one");
+                Assert.True(answer.Name == "1.1.1.1.in-addr.arpa");
+                Assert.True(answer.Type == DnsRecordType.PTR);
+                Assert.True(answer.Data.Length > 0);
+            }
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        public void ShouldWorkForMultipleDomainsSync(DnsEndpoint endpoint) {
+            var client = new ClientX(endpoint);
+            var domains = new[] { "evotec.pl", "google.com" };
+            var responses = client.ResolveSync(domains, DnsRecordType.A);
+            foreach (var domain in domains) {
+                var response = responses.First(r => r.Questions.Any(q => q.Name == domain));
+                foreach (DnsAnswer answer in response.Answers) {
+                    Assert.True(answer.Name == domain);
+                    Assert.True(answer.Type == DnsRecordType.A);
+                    Assert.True(answer.Data.Length > 0);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        public void ShouldWorkForMultipleTypesSync(DnsEndpoint endpoint) {
+            var client = new ClientX(endpoint);
+            var types = new[] { DnsRecordType.A, DnsRecordType.TXT };
+            var responses = client.ResolveSync("evotec.pl", types);
+            foreach (var type in types) {
+                var response = responses.First(r => r.Questions.Any(q => q.Type == type));
+                foreach (DnsAnswer answer in response.Answers) {
+                    Assert.True(answer.Name == "evotec.pl");
+                    Assert.True(answer.Type == type);
+                    Assert.True(answer.Data.Length > 0);
+                }
+            }
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -24,6 +24,23 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Sends a DNS query for a specific record type to a DNS server. Synchronous version.
+        /// This method allows you to specify the DNS endpoint from a predefined list of endpoints.
+        /// </summary>
+        /// <param name="name">The domain name to query.</param>
+        /// <param name="recordType">The type of DNS record to query.</param>
+        /// <param name="dnsEndpoint">The DNS endpoint to use for the query. Defaults to Cloudflare.</param>
+        /// <param name="dnsSelectionStrategy">The DNS selection strategy. Defaults to First</param>
+        /// <param name="timeOutMilliseconds"></param>
+        /// <returns>The DNS response.</returns>
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000) {
+            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
+            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
+            var data = client.ResolveSync(name, recordType);
+            return data;
+        }
+
+        /// <summary>
         /// Sends a DNS query for multiple names for a specific record type to a DNS server.
         /// This method allows you to specify the DNS endpoint from a predefined list of endpoints.
         /// </summary>
@@ -40,6 +57,26 @@ namespace DnsClientX {
                 }
             };
             var data = await client.Resolve(name, recordType);
+            return data;
+        }
+
+        /// <summary>
+        /// Sends a DNS query for multiple names for a specific record type to a DNS server. Synchronous version.
+        /// This method allows you to specify the DNS endpoint from a predefined list of endpoints.
+        /// </summary>
+        /// <param name="name">The domain names to query.</param>
+        /// <param name="recordType">The type of DNS record to query.</param>
+        /// <param name="dnsEndpoint">The DNS endpoint to use for the query. Defaults to Cloudflare.</param>
+        /// <param name="dnsSelectionStrategy">The DNS selection strategy. Defaults to First</param>
+        /// <param name="timeOutMilliseconds"></param>
+        /// <returns>The DNS response.</returns>
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000) {
+            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy) {
+                EndpointConfiguration = {
+                    TimeOut = timeOutMilliseconds
+                }
+            };
+            var data = client.ResolveSync(name, recordType);
             return data;
         }
 
@@ -64,6 +101,26 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Sends a DNS query for a specific record type to a DNS server. Synchronous version.
+        /// This method allows you to specify the DNS endpoint by providing a full URI and request format (JSON, WireFormatGet).
+        /// </summary>
+        /// <param name="name">The domain name to query.</param>
+        /// <param name="recordType">The type of DNS record to query.</param>
+        /// <param name="dnsUri">The full URI of the DNS server to query.</param>
+        /// <param name="requestFormat">The format of the DNS request.</param>
+        /// <param name="timeOutMilliseconds"></param>
+        /// <returns>The DNS response.</returns>
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000) {
+            ClientX client = new ClientX(dnsUri, requestFormat) {
+                EndpointConfiguration = {
+                    TimeOut = timeOutMilliseconds
+                }
+            };
+            var data = client.ResolveSync(name, recordType);
+            return data;
+        }
+
+        /// <summary>
         /// Sends a DNS query for multiple domain names and multiple record types to a DNS server using a full URI and request format.
         /// </summary>
         /// <param name="name">The name.</param>
@@ -79,6 +136,25 @@ namespace DnsClientX {
                 }
             };
             var data = await client.Resolve(name, recordType);
+            return data;
+        }
+
+        /// <summary>
+        /// Sends a DNS query for multiple domain names and multiple record types to a DNS server using a full URI and request format. Synchronous version.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="recordType">Type of the record.</param>
+        /// <param name="dnsUri">The DNS URI.</param>
+        /// <param name="requestFormat">The request format.</param>
+        /// <param name="timeOutMilliseconds"></param>
+        /// <returns></returns>
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000) {
+            ClientX client = new ClientX(dnsUri, requestFormat) {
+                EndpointConfiguration = {
+                    TimeOut = timeOutMilliseconds
+                }
+            };
+            var data = client.ResolveSync(name, recordType);
             return data;
         }
 
@@ -103,6 +179,26 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Sends a DNS query for a specific record type to a DNS server. Synchronous version.
+        /// This method allows you to specify the DNS endpoint by providing a hostname and request format (JSON, WireFormatGet).
+        /// </summary>
+        /// <param name="name">The domain name to query.</param>
+        /// <param name="recordType">The type of DNS record to query.</param>
+        /// <param name="hostName">The hostname of the DNS server to query.</param>
+        /// <param name="requestFormat">The format of the DNS request.</param>
+        /// <param name="timeOutMilliseconds"></param>
+        /// <returns>The DNS response.</returns>
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000) {
+            ClientX client = new ClientX(hostName, requestFormat) {
+                EndpointConfiguration = {
+                    TimeOut = timeOutMilliseconds
+                }
+            };
+            var data = client.ResolveSync(name, recordType);
+            return data;
+        }
+
+        /// <summary>
         /// Sends a DNS query for multiple domain names and multiple record types to a DNS server using HostName and RequestFormat.
         /// </summary>
         /// <param name="name">The name.</param>
@@ -118,6 +214,25 @@ namespace DnsClientX {
                 }
             };
             var data = await client.Resolve(name, recordType);
+            return data;
+        }
+
+        /// <summary>
+        /// Sends a DNS query for multiple domain names and multiple record types to a DNS server using HostName and RequestFormat. Synchronous version.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="recordType">Type of the record.</param>
+        /// <param name="hostName">Name of the host.</param>
+        /// <param name="requestFormat">The request format.</param>
+        /// <param name="timeOutMilliseconds"></param>
+        /// <returns></returns>
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000) {
+            ClientX client = new ClientX(hostName, requestFormat) {
+                EndpointConfiguration = {
+                    TimeOut = timeOutMilliseconds
+                }
+            };
+            var data = client.ResolveSync(name, recordType);
             return data;
         }
 
@@ -141,6 +256,25 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Sends a DNS query for multiple domain names and single record types to a DNS server using HostName and RequestFormat. Synchronous version.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="recordType">Type of the record.</param>
+        /// <param name="hostName">Name of the host.</param>
+        /// <param name="requestFormat">The request format.</param>
+        /// <param name="timeOutMilliseconds"></param>
+        /// <returns></returns>
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000) {
+            ClientX client = new ClientX(hostName, requestFormat) {
+                EndpointConfiguration = {
+                    TimeOut = timeOutMilliseconds
+                }
+            };
+            var data = client.ResolveSync(name, recordType);
+            return data;
+        }
+
+        /// <summary>
         /// Sends a DNS query to multiple domains and multiple record types to a DNS server.
         /// This method allows you to specify the DNS endpoint by providing a hostname and request format (JSON, WireFormatGet).
         /// </summary>
@@ -156,6 +290,25 @@ namespace DnsClientX {
                 }
             };
             var data = await client.Resolve(name, recordType);
+            return data;
+        }
+
+        /// <summary>
+        /// Sends a DNS query to multiple domains and multiple record types to a DNS server. Synchronous version.
+        /// This method allows you to specify the DNS endpoint by providing a hostname and request format (JSON, WireFormatGet).
+        /// </summary>
+        /// <param name="name">Multiple domain names to check for given type</param>
+        /// <param name="recordType">Multiple types to check for given name.</param>
+        /// <param name="dnsEndpoint">The DNS endpoint. Default endpoint is Cloudflare</param>
+        /// <param name="timeOutMilliseconds"></param>
+        /// <returns></returns>
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = 1000) {
+            ClientX client = new ClientX(endpoint: dnsEndpoint) {
+                EndpointConfiguration = {
+                    TimeOut = timeOutMilliseconds
+                }
+            };
+            var data = client.ResolveSync(name, recordType);
             return data;
         }
     }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -64,6 +64,21 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Resolves a domain name using DNS over HTTPS. This method provides full control over the output. Synchronous version.
+        /// </summary>
+        /// <param name="name">The fully qualified domain name (FQDN) to resolve. Example: <c>foo.bar.example.com</c></param>
+        /// <param name="type">The DNS resource type to resolve. By default, this is the <c>A</c> record.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data in the response. When requested, it will be accessible under the <see cref="DnsAnswer"/> array.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="returnAllTypes">Whether to return all DNS record types in the response as returned by provider. When set to <c>true</c>, the <see cref="DnsResponse.Answers"/> array will contain all types.</param>
+        /// <returns>The DNS response.</returns>
+        /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
+        public DnsResponse ResolveSync(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false) {
+            return Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Resolves multiple DNS resource types for a domain name in parallel using DNS over HTTPS.
         /// </summary>
         /// <param name="name">The fully qualified domain name (FQDN) to resolve. Example: <c>foo.bar.example.com</c></param>
@@ -91,6 +106,20 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Resolves multiple DNS resource types for a domain name in parallel using DNS over HTTPS. Synchronous version.
+        /// </summary>
+        /// <param name="name">The fully qualified domain name (FQDN) to resolve. Example: <c>foo.bar.example.com</c></param>
+        /// <param name="types">The array of DNS resource record types to resolve. By default, this is the <c>A</c> record.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data in the response. When requested, it will be accessible under the <see cref="DnsAnswer"/> array.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <returns>An array of DNS responses.</returns>
+        /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
+        public DnsResponse[] ResolveSync(string name, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false) {
+            return Resolve(name, types, requestDnsSec, validateDnsSec).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Resolves multiple domain names for multiple DNS record types in parallel using DNS over HTTPS.
         /// </summary>
         /// <param name="names">The array of domain names to resolve.</param>
@@ -113,6 +142,18 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Resolves multiple domain names for multiple DNS record types in parallel using DNS over HTTPS. Synchronous version.
+        /// </summary>
+        /// <param name="names">The array of domain names to resolve.</param>
+        /// <param name="types">The array of DNS resource record types to resolve.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data in the response. When requested, it will be accessible under the <see cref="DnsAnswer"/> array.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <returns>An array of DNS responses.</returns>
+        public DnsResponse[] ResolveSync(string[] names, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false) {
+            return Resolve(names, types, requestDnsSec, validateDnsSec).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Resolves multiple domain names for single DNS record type in parallel using DNS over HTTPS.
         /// </summary>
         /// <param name="names">The names.</param>
@@ -130,6 +171,18 @@ namespace DnsClientX {
             await Task.WhenAll(tasks);
 
             return tasks.Select(task => task.Result).ToArray();
+        }
+
+        /// <summary>
+        /// Resolves multiple domain names for single DNS record type in parallel using DNS over HTTPS. Synchronous version.
+        /// </summary>
+        /// <param name="names">The names.</param>
+        /// <param name="type">The type.</param>
+        /// <param name="requestDnsSec">if set to <c>true</c> [request DNS sec].</param>
+        /// <param name="validateDnsSec">if set to <c>true</c> [validate DNS sec].</param>
+        /// <returns>An array of DNS responses.</returns>
+        public DnsResponse[] ResolveSync(string[] names, DnsRecordType type, bool requestDnsSec = false, bool validateDnsSec = false) {
+            return Resolve(names, type, requestDnsSec, validateDnsSec).GetAwaiter().GetResult();
         }
     }
 }


### PR DESCRIPTION
This commit introduces synchronous alternatives for the existing asynchronous DNS query methods.

New synchronous methods:
- `ClientX.ResolveSync(...)` methods were added as wrappers to the async `ClientX.Resolve(...)` methods.
- Static `ClientX.QueryDnsSync(...)` methods were added, which utilize the new `ResolveSync` methods.

These changes allow users of the library to perform DNS queries synchronously if needed, while reusing all the existing core asynchronous logic and protocol implementations.

Added unit tests for all new synchronous methods to ensure they function correctly and mirror the behavior of their asynchronous counterparts.