### PR TITLE
Fix Quad9 endpoints

### DIFF
--- a/DnsClientX.Tests/CompareJsonWithDnsWire.cs
+++ b/DnsClientX.Tests/CompareJsonWithDnsWire.cs
@@ -3,7 +3,7 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData("evotec.pl", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.A)]
         [InlineData("reddit.com", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.A)]
-        [InlineData("www.example.com", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.A)]
+        [InlineData("www.evotec.pl", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.A)]
         [InlineData("evotec.pl", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.AAAA)]
         [InlineData("www.microsoft.com", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.CNAME)]
         public async void CompareAnswersRecord(string name, DnsEndpoint endpoint, DnsEndpoint endpointCompare, DnsRecordType resourceRecordType) {

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -209,18 +209,18 @@ namespace DnsClientX {
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.Quad9:
-                    hostnames = new List<string> { "9.9.9.9:5053", "149.112.112.112:5053" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+                    hostnames = new List<string> { "9.9.9.9", "149.112.112.112" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.Quad9ECS:
-                    hostnames = new List<string> { "9.9.9.11:5053", "149.112.112.11:5053" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+                    hostnames = new List<string> { "9.9.9.11", "149.112.112.11" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.Quad9Unsecure:
-                    hostnames = new List<string> { "9.9.9.10:5053", "149.112.112.10:5053" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+                    hostnames = new List<string> { "9.9.9.10", "149.112.112.10" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.OpenDNS:


### PR DESCRIPTION
* Changed hostnames to remove port numbers for Quad9, Quad9ECS, and Quad9Unsecure.
* Updated `RequestFormat` to use `DnsOverHttps` instead of `DnsOverHttpsJSON` for better compatibility.

Resolves:
- https://github.com/EvotecIT/DnsClientX/issues/17