### PR TITLE
Fix: Correctly parse Google DoH JSON TXT records

### DIFF
--- a/DnsClientX.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/DnsClientX.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -1,162 +1,162 @@
 using System;
 using System.Management.Automation;
 
-namespace DnsClientX.PowerShell {
+namespace DnsClientX.PowerShell;
+
+/// <summary>
+/// This class allow connecting to the InternalLogger class of ADPlayground and act on events from it in different streams
+/// </summary>
+public class InternalLoggerPowerShell {
+    private readonly InternalLogger _logger;
+    private readonly Action<string> _writeVerboseAction;
+    private readonly Action<string> _writeDebugAction;
+    private readonly Action<InformationRecord> _writeInformationAction;
+    private readonly Action<string> _writeWarningAction;
+    private readonly Action<ErrorRecord> _writeErrorAction;
+    private readonly Action<ProgressRecord> _writeProgressAction;
+
     /// <summary>
-    /// This class allow connecting to the InternalLogger class of ADPlayground and act on events from it in different streams
+    /// Initialize the InternalLoggerPowerShell class
     /// </summary>
-    public class InternalLoggerPowerShell {
-        private readonly InternalLogger _logger;
-        private readonly Action<string> _writeVerboseAction;
-        private readonly Action<string> _writeDebugAction;
-        private readonly Action<InformationRecord> _writeInformationAction;
-        private readonly Action<string> _writeWarningAction;
-        private readonly Action<ErrorRecord> _writeErrorAction;
-        private readonly Action<ProgressRecord> _writeProgressAction;
+    /// <param name="logger"></param>
+    /// <param name="writeVerboseAction"></param>
+    /// <param name="writeWarningAction"></param>
+    /// <param name="writeDebugAction"></param>
+    /// <param name="writeErrorAction"></param>
+    /// <param name="writeProgressAction"></param>
+    /// <param name="writeInformationAction"></param>
+    public InternalLoggerPowerShell(InternalLogger logger, Action<string> writeVerboseAction = null, Action<string> writeWarningAction = null, Action<string> writeDebugAction = null, Action<ErrorRecord> writeErrorAction = null, Action<ProgressRecord> writeProgressAction = null, Action<InformationRecord> writeInformationAction = null) {
+        _logger = logger;
 
-        /// <summary>
-        /// Initialize the InternalLoggerPowerShell class
-        /// </summary>
-        /// <param name="logger"></param>
-        /// <param name="writeVerboseAction"></param>
-        /// <param name="writeWarningAction"></param>
-        /// <param name="writeDebugAction"></param>
-        /// <param name="writeErrorAction"></param>
-        /// <param name="writeProgressAction"></param>
-        /// <param name="writeInformationAction"></param>
-        public InternalLoggerPowerShell(InternalLogger logger, Action<string> writeVerboseAction = null, Action<string> writeWarningAction = null, Action<string> writeDebugAction = null, Action<ErrorRecord> writeErrorAction = null, Action<ProgressRecord> writeProgressAction = null, Action<InformationRecord> writeInformationAction = null) {
-            _logger = logger;
-
-            if (writeVerboseAction != null) {
-                _writeVerboseAction = writeVerboseAction;
-                _logger.OnVerboseMessage += Logger_OnVerboseMessage;
-            }
-
-            if (writeWarningAction != null) {
-                _writeWarningAction = writeWarningAction;
-                _logger.OnWarningMessage += Logger_OnWarningMessage;
-            }
-
-            if (writeDebugAction != null) {
-                _writeDebugAction = writeDebugAction;
-                _logger.OnDebugMessage += Logger_OnDebugMessage;
-            }
-
-            if (writeErrorAction != null) {
-                _writeErrorAction = writeErrorAction;
-                _logger.OnErrorMessage += Logger_OnErrorMessage;
-            }
-
-            if (writeProgressAction != null) {
-                _writeProgressAction = writeProgressAction;
-                _logger.OnProgressMessage += Logger_OnProgressMessage;
-            }
-
-            if (writeInformationAction != null) {
-                _writeInformationAction = writeInformationAction;
-                _logger.OnInformationMessage += Logger_OnInformationMessage;
-            }
+        if (writeVerboseAction != null) {
+            _writeVerboseAction = writeVerboseAction;
+            _logger.OnVerboseMessage += Logger_OnVerboseMessage;
         }
 
-        /// <summary>
-        /// Message event handler
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void Logger_OnVerboseMessage(object sender, LogEventArgs e) {
-            if (e.Args != null && e.Args.Length > 0) {
-                WriteVerbose(e.Message, e.Args);
+        if (writeWarningAction != null) {
+            _writeWarningAction = writeWarningAction;
+            _logger.OnWarningMessage += Logger_OnWarningMessage;
+        }
+
+        if (writeDebugAction != null) {
+            _writeDebugAction = writeDebugAction;
+            _logger.OnDebugMessage += Logger_OnDebugMessage;
+        }
+
+        if (writeErrorAction != null) {
+            _writeErrorAction = writeErrorAction;
+            _logger.OnErrorMessage += Logger_OnErrorMessage;
+        }
+
+        if (writeProgressAction != null) {
+            _writeProgressAction = writeProgressAction;
+            _logger.OnProgressMessage += Logger_OnProgressMessage;
+        }
+
+        if (writeInformationAction != null) {
+            _writeInformationAction = writeInformationAction;
+            _logger.OnInformationMessage += Logger_OnInformationMessage;
+        }
+    }
+
+    /// <summary>
+    /// Message event handler
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void Logger_OnVerboseMessage(object sender, LogEventArgs e) {
+        if (e.Args != null && e.Args.Length > 0) {
+            WriteVerbose(e.Message, e.Args);
+        } else {
+            WriteVerbose(e.Message);
+        }
+    }
+    private void Logger_OnDebugMessage(object sender, LogEventArgs e) {
+        WriteDebug(e.Message);
+    }
+    private void Logger_OnWarningMessage(object sender, LogEventArgs e) {
+        WriteWarning(e.Message);
+    }
+    private void Logger_OnErrorMessage(object sender, LogEventArgs e) {
+        ErrorRecord errorRecord = new ErrorRecord(new Exception(e.Message), "1", ErrorCategory.NotSpecified, null);
+        WriteError(errorRecord);
+    }
+    private int _activityIdCounter = 0;
+
+    private int _currentActivityId = 1;
+    private bool _isCurrentActivityCompleted = true;
+
+    private int GetNextActivityId() {
+        return ++_activityIdCounter;
+    }
+    private void Logger_OnProgressMessage(object sender, LogEventArgs e) {
+        if (_isCurrentActivityCompleted) {
+            _currentActivityId = GetNextActivityId();
+            _isCurrentActivityCompleted = false;
+        }
+        var progressMessage = e.ProgressCurrentOperation ?? "Processing...: ";
+        var progressRecord = new ProgressRecord(_currentActivityId, e.ProgressActivity, progressMessage);
+        if (e.ProgressPercentage.HasValue) {
+            if (e.ProgressPercentage.Value >= 0 && e.ProgressPercentage.Value <= 100) {
+                progressRecord.PercentComplete = e.ProgressPercentage.Value;
             } else {
-                WriteVerbose(e.Message);
+                progressRecord.PercentComplete = 100;
             }
+        } else {
+            progressRecord.PercentComplete = 50;
         }
-        private void Logger_OnDebugMessage(object sender, LogEventArgs e) {
-            WriteDebug(e.Message);
+        if (progressRecord.PercentComplete == 100) {
+            progressRecord.RecordType = ProgressRecordType.Completed;
+            _isCurrentActivityCompleted = true;
         }
-        private void Logger_OnWarningMessage(object sender, LogEventArgs e) {
-            WriteWarning(e.Message);
-        }
-        private void Logger_OnErrorMessage(object sender, LogEventArgs e) {
-            ErrorRecord errorRecord = new ErrorRecord(new Exception(e.Message), "1", ErrorCategory.NotSpecified, null);
-            WriteError(errorRecord);
-        }
-        private int _activityIdCounter = 0;
+        WriteProgress(progressRecord);
+    }
+    private void Logger_OnInformationMessage(object sender, LogEventArgs e) {
+        WriteInformation(e.Message);
+    }
 
-        private int _currentActivityId = 1;
-        private bool _isCurrentActivityCompleted = true;
+    private void WriteVerbose(string message) {
+        _writeVerboseAction?.Invoke(message);
+    }
 
-        private int GetNextActivityId() {
-            return ++_activityIdCounter;
-        }
-        private void Logger_OnProgressMessage(object sender, LogEventArgs e) {
-            if (_isCurrentActivityCompleted) {
-                _currentActivityId = GetNextActivityId();
-                _isCurrentActivityCompleted = false;
-            }
-            var progressMessage = e.ProgressCurrentOperation ?? "Processing...: ";
-            var progressRecord = new ProgressRecord(_currentActivityId, e.ProgressActivity, progressMessage);
-            if (e.ProgressPercentage.HasValue) {
-                if (e.ProgressPercentage.Value >= 0 && e.ProgressPercentage.Value <= 100) {
-                    progressRecord.PercentComplete = e.ProgressPercentage.Value;
-                } else {
-                    progressRecord.PercentComplete = 100;
-                }
-            } else {
-                progressRecord.PercentComplete = 50;
-            }
-            if (progressRecord.PercentComplete == 100) {
-                progressRecord.RecordType = ProgressRecordType.Completed;
-                _isCurrentActivityCompleted = true;
-            }
-            WriteProgress(progressRecord);
-        }
-        private void Logger_OnInformationMessage(object sender, LogEventArgs e) {
-            WriteInformation(e.Message);
-        }
+    /// <summary>
+    /// Method to write verbose message to PowerShell
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="eArgs"></param>
+    private void WriteVerbose(string message, object[] eArgs) {
+        // Write to PowerShell verbose stream
+        var fullMessage = string.Format(message, eArgs);
+        _writeVerboseAction?.Invoke(fullMessage);
+    }
 
-        private void WriteVerbose(string message) {
-            _writeVerboseAction?.Invoke(message);
-        }
+    private void WriteDebug(string message) {
+        // Write to PowerShell debug stream
+        _writeDebugAction?.Invoke(message);
+    }
 
-        /// <summary>
-        /// Method to write verbose message to PowerShell
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="eArgs"></param>
-        private void WriteVerbose(string message, object[] eArgs) {
-            // Write to PowerShell verbose stream
-            var fullMessage = string.Format(message, eArgs);
-            _writeVerboseAction?.Invoke(fullMessage);
-        }
+    private void WriteInformation(string message) {
+        InformationRecord informationRecord = new InformationRecord(message, "DnsClientX");
+        // Write to PowerShell information stream
+        _writeInformationAction?.Invoke(informationRecord);
+    }
 
-        private void WriteDebug(string message) {
-            // Write to PowerShell debug stream
-            _writeDebugAction?.Invoke(message);
-        }
+    private void WriteWarning(string message) {
+        // Write to PowerShell warning stream
+        _writeWarningAction?.Invoke(message);
+    }
 
-        private void WriteInformation(string message) {
-            InformationRecord informationRecord = new InformationRecord(message, "DnsClientX");
-            // Write to PowerShell information stream
-            _writeInformationAction?.Invoke(informationRecord);
-        }
+    //private void WriteError(string message) {
+    //    // Write to PowerShell error stream
+    //    _writeErrorAction?.Invoke(message);
+    //}
+    private void WriteError(ErrorRecord errorRecord) {
+        // Write to PowerShell error stream
+        _writeErrorAction?.Invoke(errorRecord);
+    }
 
-        private void WriteWarning(string message) {
-            // Write to PowerShell warning stream
-            _writeWarningAction?.Invoke(message);
-        }
-
-        //private void WriteError(string message) {
-        //    // Write to PowerShell error stream
-        //    _writeErrorAction?.Invoke(message);
-        //}
-        private void WriteError(ErrorRecord errorRecord) {
-            // Write to PowerShell error stream
-            _writeErrorAction?.Invoke(errorRecord);
-        }
-
-        private void WriteProgress(ProgressRecord progressRecord) {
-            // Write to PowerShell progress stream
-            _writeProgressAction?.Invoke(progressRecord);
-        }
+    private void WriteProgress(ProgressRecord progressRecord) {
+        // Write to PowerShell progress stream
+        _writeProgressAction?.Invoke(progressRecord);
     }
 }

--- a/DnsClientX.Tests/AssemblyInfo.cs
+++ b/DnsClientX.Tests/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+// DISABLE parallel test execution globally:
+// [assembly: Xunit.CollectionBehavior(Xunit.CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]

--- a/DnsClientX.Tests/CompareJsonWithDnsWire.cs
+++ b/DnsClientX.Tests/CompareJsonWithDnsWire.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class CompareJsonWithDnsWire {
         [Theory]
@@ -6,7 +8,7 @@ namespace DnsClientX.Tests {
         [InlineData("www.evotec.pl", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.A)]
         [InlineData("evotec.pl", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.AAAA)]
         [InlineData("www.microsoft.com", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.CNAME)]
-        public async void CompareAnswersRecord(string name, DnsEndpoint endpoint, DnsEndpoint endpointCompare, DnsRecordType resourceRecordType) {
+        public async Task CompareAnswersRecord(string name, DnsEndpoint endpoint, DnsEndpoint endpointCompare, DnsRecordType resourceRecordType) {
             var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll(name, resourceRecordType);
 

--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -33,7 +33,7 @@ namespace DnsClientX.Tests {
         [InlineData("google.com", DnsRecordType.MX)]
         [InlineData("1.1.1.1", DnsRecordType.PTR)]
         [InlineData("108.138.7.68", DnsRecordType.PTR)]
-        public async void CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
+        public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
             var primaryEndpoint = DnsEndpoint.Cloudflare;

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -30,7 +30,8 @@ namespace DnsClientX.Tests {
         [InlineData("microsoft.com", DnsRecordType.MX)]
         [InlineData("microsoft.com", DnsRecordType.NS)]
 
-        [InlineData("google.com", DnsRecordType.MX)]        [InlineData("_25._tcp.mail.ietf.org", DnsRecordType.TLSA)]
+        [InlineData("google.com", DnsRecordType.MX)]
+        [InlineData("_25._tcp.mail.ietf.org", DnsRecordType.TLSA)]
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -78,7 +79,8 @@ namespace DnsClientX.Tests {
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.Quad9ECS)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.Quad9Unsecure)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.CloudflareWireFormat)]
-        [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS)]        [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNSFamily)]
+        [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS)]
+        [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNSFamily)]
         public async Task CompareRecordTextMultiline(string name, DnsRecordType resourceRecordType, DnsEndpoint primaryEndpoint, DnsEndpoint endpointCompare) {
             var Client = new ClientX(primaryEndpoint);
             DnsAnswer[] aAnswersPrimary = await Client.ResolveAll(name, resourceRecordType);

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -1,4 +1,5 @@
 using Xunit.Abstractions;
+using System.Threading.Tasks;
 
 namespace DnsClientX.Tests {
     public class CompareProviders(ITestOutputHelper output) {
@@ -29,9 +30,8 @@ namespace DnsClientX.Tests {
         [InlineData("microsoft.com", DnsRecordType.MX)]
         [InlineData("microsoft.com", DnsRecordType.NS)]
 
-        [InlineData("google.com", DnsRecordType.MX)]
-        [InlineData("_25._tcp.mail.ietf.org", DnsRecordType.TLSA)]
-        public async void CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
+        [InlineData("google.com", DnsRecordType.MX)]        [InlineData("_25._tcp.mail.ietf.org", DnsRecordType.TLSA)]
+        public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
             var primaryEndpoint = DnsEndpoint.Cloudflare;
@@ -78,9 +78,8 @@ namespace DnsClientX.Tests {
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.Quad9ECS)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.Quad9Unsecure)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.CloudflareWireFormat)]
-        [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS)]
-        [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNSFamily)]
-        public async void CompareRecordTextMultiline(string name, DnsRecordType resourceRecordType, DnsEndpoint primaryEndpoint, DnsEndpoint endpointCompare) {
+        [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS)]        [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNSFamily)]
+        public async Task CompareRecordTextMultiline(string name, DnsRecordType resourceRecordType, DnsEndpoint primaryEndpoint, DnsEndpoint endpointCompare) {
             var Client = new ClientX(primaryEndpoint);
             DnsAnswer[] aAnswersPrimary = await Client.ResolveAll(name, resourceRecordType);
             var ClientToCompare = new ClientX(endpointCompare);

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -1,12 +1,13 @@
 using Xunit.Abstractions;
 
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class CompareProvidersResolveFilter(ITestOutputHelper output) {
         [Theory]
         [InlineData("evotec.pl", DnsRecordType.TXT)]
-        [InlineData("microsoft.com", DnsRecordType.TXT)]
-        [InlineData("disneyplus.com", DnsRecordType.TXT)]
-        public async void CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
+        [InlineData("microsoft.com", DnsRecordType.TXT)]        [InlineData("disneyplus.com", DnsRecordType.TXT)]
+        public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
             string filter = "v=spf1";
@@ -80,9 +81,8 @@ namespace DnsClientX.Tests {
             }
         }
 
-        [Theory]
-        [InlineData(new[] { "evotec.pl", "microsoft.com", "disneyplus.com" }, DnsRecordType.TXT)]
-        public async void CompareRecordsMulti(string[] names, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
+        [Theory]        [InlineData(new[] { "evotec.pl", "microsoft.com", "disneyplus.com" }, DnsRecordType.TXT)]
+        public async Task CompareRecordsMulti(string[] names, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             string filter = "v=spf1";
             var primaryEndpoint = DnsEndpoint.Cloudflare;
             var Client = new ClientX(primaryEndpoint);

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -6,7 +6,8 @@ namespace DnsClientX.Tests {
     public class CompareProvidersResolveFilter(ITestOutputHelper output) {
         [Theory]
         [InlineData("evotec.pl", DnsRecordType.TXT)]
-        [InlineData("microsoft.com", DnsRecordType.TXT)]        [InlineData("disneyplus.com", DnsRecordType.TXT)]
+        [InlineData("microsoft.com", DnsRecordType.TXT)]
+        [InlineData("disneyplus.com", DnsRecordType.TXT)]
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -81,7 +82,8 @@ namespace DnsClientX.Tests {
             }
         }
 
-        [Theory]        [InlineData(new[] { "evotec.pl", "microsoft.com", "disneyplus.com" }, DnsRecordType.TXT)]
+        [Theory]
+        [InlineData(new[] { "evotec.pl", "microsoft.com", "disneyplus.com" }, DnsRecordType.TXT)]
         public async Task CompareRecordsMulti(string[] names, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             string filter = "v=spf1";
             var primaryEndpoint = DnsEndpoint.Cloudflare;

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -31,7 +31,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Include="TxtRecordParsingTests.cs" />
     </ItemGroup>
 
 </Project>

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -18,14 +18,11 @@
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
         <PackageReference Include="SemanticComparison" Version="4.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
         <PackageReference Include="coverlet.collector" Version="6.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
@@ -34,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit" />
+        <Compile Include="TxtRecordParsingTests.cs" />
     </ItemGroup>
 
 </Project>

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -3,7 +3,8 @@
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             net472;net8.0;net9.0
         </TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+        <TargetFrameworks
+            Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
             net8.0;net9.0
         </TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -15,14 +16,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
+        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0"
+            Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
         <PackageReference Include="SemanticComparison" Version="4.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+        <PackageReference Include="xunit" Version="2.7.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
@@ -31,6 +36,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Using Include="Xunit" />
     </ItemGroup>
 
 </Project>

--- a/DnsClientX.Tests/QueryDnsByEndpoint.cs
+++ b/DnsClientX.Tests/QueryDnsByEndpoint.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class QueryDnsByEndpoint {
         [Theory]
@@ -16,7 +18,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9Unsecure)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        public async void ShouldWorkForTXT(DnsEndpoint endpoint) {
+        public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, endpoint);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "github.com");
@@ -41,7 +43,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9Unsecure)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        public async void ShouldWorkForA(DnsEndpoint endpoint) {
+        public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "evotec.pl");
@@ -66,7 +68,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9Unsecure)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        public async void ShouldWorkForPTR(DnsEndpoint endpoint) {
+        public async Task ShouldWorkForPTR(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("1.1.1.1", DnsRecordType.PTR, endpoint);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Data == "one.one.one.one");

--- a/DnsClientX.Tests/QueryDnsByHostName.cs
+++ b/DnsClientX.Tests/QueryDnsByHostName.cs
@@ -1,12 +1,13 @@
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class QueryDnsByHostName {
         [Theory]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("family.cloudflare-dns.com", DnsRequestFormat.DnsOverHttpsJSON)]
         // Google contrary to the other endpoints does not work with /dns-query but with /resolve
-        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
-        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
-        public async void ShouldWorkForTXT(string hostName, DnsRequestFormat requestFormat) {
+        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
+        public async Task ShouldWorkForTXT(string hostName, DnsRequestFormat requestFormat) {
             var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, hostName, requestFormat);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "github.com");
@@ -21,9 +22,8 @@ namespace DnsClientX.Tests {
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverUDP)]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverTCP)]
         // Google contrary to the other endpoints does not work with /dns-query but with /resolve
-        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
-        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
-        public async void ShouldWorkForA(string hostName, DnsRequestFormat requestFormat) {
+        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
+        public async Task ShouldWorkForA(string hostName, DnsRequestFormat requestFormat) {
             var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, hostName, requestFormat);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "evotec.pl");
@@ -38,9 +38,8 @@ namespace DnsClientX.Tests {
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverUDP)]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverTCP)]
         // Google contrary to the other endpoints does not work with /dns-query but with /resolve
-        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
-        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
-        public async void ShouldWorkForMultipleDomains(string hostName, DnsRequestFormat requestFormat) {
+        // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]        [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
+        public async Task ShouldWorkForMultipleDomains(string hostName, DnsRequestFormat requestFormat) {
             var domains = new[] { "evotec.pl", "google.com" };
             var responses = await ClientX.QueryDns(domains, DnsRecordType.A, hostName, requestFormat);
             foreach (var domain in domains) {

--- a/DnsClientX.Tests/QueryDnsByUri.cs
+++ b/DnsClientX.Tests/QueryDnsByUri.cs
@@ -7,7 +7,8 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
-        [InlineData("https://9.9.9.11:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]        [InlineData("https://208.67.222.123/dns-query", DnsRequestFormat.DnsOverHttps)]
+        [InlineData("https://9.9.9.11:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://208.67.222.123/dns-query", DnsRequestFormat.DnsOverHttps)]
         public async Task ShouldWorkForTXT(string baseUri, DnsRequestFormat requestFormat) {
             Uri uri = new Uri(baseUri);
             var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, uri, requestFormat);
@@ -22,7 +23,8 @@ namespace DnsClientX.Tests {
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://9.9.9.10:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
-        [InlineData("https://doh.opendns.com/dns-query", DnsRequestFormat.DnsOverHttps)]        [InlineData("https://dns.adguard.com/dns-query", DnsRequestFormat.DnsOverHttps)]
+        [InlineData("https://doh.opendns.com/dns-query", DnsRequestFormat.DnsOverHttps)]
+        [InlineData("https://dns.adguard.com/dns-query", DnsRequestFormat.DnsOverHttps)]
         public async Task ShouldWorkForA(string baseUri, DnsRequestFormat requestFormat) {
             Uri uri = new Uri(baseUri);
             var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, uri, requestFormat);

--- a/DnsClientX.Tests/QueryDnsByUri.cs
+++ b/DnsClientX.Tests/QueryDnsByUri.cs
@@ -1,13 +1,14 @@
 using System;
 
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class QueryDnsByUri {
         [Theory]
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
-        [InlineData("https://9.9.9.11:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
-        [InlineData("https://208.67.222.123/dns-query", DnsRequestFormat.DnsOverHttps)]
-        public async void ShouldWorkForTXT(string baseUri, DnsRequestFormat requestFormat) {
+        [InlineData("https://9.9.9.11:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]        [InlineData("https://208.67.222.123/dns-query", DnsRequestFormat.DnsOverHttps)]
+        public async Task ShouldWorkForTXT(string baseUri, DnsRequestFormat requestFormat) {
             Uri uri = new Uri(baseUri);
             var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, uri, requestFormat);
             foreach (DnsAnswer answer in response.Answers) {
@@ -21,9 +22,8 @@ namespace DnsClientX.Tests {
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://9.9.9.10:5053/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
-        [InlineData("https://doh.opendns.com/dns-query", DnsRequestFormat.DnsOverHttps)]
-        [InlineData("https://dns.adguard.com/dns-query", DnsRequestFormat.DnsOverHttps)]
-        public async void ShouldWorkForA(string baseUri, DnsRequestFormat requestFormat) {
+        [InlineData("https://doh.opendns.com/dns-query", DnsRequestFormat.DnsOverHttps)]        [InlineData("https://dns.adguard.com/dns-query", DnsRequestFormat.DnsOverHttps)]
+        public async Task ShouldWorkForA(string baseUri, DnsRequestFormat requestFormat) {
             Uri uri = new Uri(baseUri);
             var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, uri, requestFormat);
             foreach (DnsAnswer answer in response.Answers) {

--- a/DnsClientX.Tests/QueryDnsFailing.cs
+++ b/DnsClientX.Tests/QueryDnsFailing.cs
@@ -1,18 +1,18 @@
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class QueryDnsFailing {
         [Theory]
-        [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]
-        [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
-        public async void ShouldFailWithTimeout(string hostName, DnsRequestFormat requestFormat) {
+        [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]        [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
+        public async Task ShouldFailWithTimeout(string hostName, DnsRequestFormat requestFormat) {
             var response = await ClientX.QueryDns("github.com", DnsRecordType.A, hostName, requestFormat, timeOutMilliseconds: 500);
             Assert.True(response.Status != DnsResponseCode.NoError);
         }
 
 
         [Theory]
-        [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]
-        [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
-        public async void ShouldFailWithTimeoutResolve(string hostName, DnsRequestFormat requestFormat) {
+        [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]        [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
+        public async Task ShouldFailWithTimeoutResolve(string hostName, DnsRequestFormat requestFormat) {
             ClientX client = new ClientX(hostName, requestFormat) {
                 Debug = true
             };

--- a/DnsClientX.Tests/QueryDnsFailing.cs
+++ b/DnsClientX.Tests/QueryDnsFailing.cs
@@ -3,7 +3,8 @@ using System.Threading.Tasks;
 namespace DnsClientX.Tests {
     public class QueryDnsFailing {
         [Theory]
-        [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]        [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
+        [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]
+        [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
         public async Task ShouldFailWithTimeout(string hostName, DnsRequestFormat requestFormat) {
             var response = await ClientX.QueryDns("github.com", DnsRecordType.A, hostName, requestFormat, timeOutMilliseconds: 500);
             Assert.True(response.Status != DnsResponseCode.NoError);
@@ -11,7 +12,8 @@ namespace DnsClientX.Tests {
 
 
         [Theory]
-        [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]        [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
+        [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]
+        [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
         public async Task ShouldFailWithTimeoutResolve(string hostName, DnsRequestFormat requestFormat) {
             ClientX client = new ClientX(hostName, requestFormat) {
                 Debug = true

--- a/DnsClientX.Tests/QueryDnsIDN.cs
+++ b/DnsClientX.Tests/QueryDnsIDN.cs
@@ -16,7 +16,8 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9)]
         [InlineData(DnsEndpoint.Quad9ECS)]
         [InlineData(DnsEndpoint.Quad9Unsecure)]
-        [InlineData(DnsEndpoint.OpenDNS)]        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("www.bücher.de", DnsRecordType.A, endpoint);
             foreach (DnsAnswer answer in response.Answers) {

--- a/DnsClientX.Tests/QueryDnsIDN.cs
+++ b/DnsClientX.Tests/QueryDnsIDN.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class QueryDnsIDN {
         [Theory]
@@ -14,9 +16,8 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9)]
         [InlineData(DnsEndpoint.Quad9ECS)]
         [InlineData(DnsEndpoint.Quad9Unsecure)]
-        [InlineData(DnsEndpoint.OpenDNS)]
-        [InlineData(DnsEndpoint.OpenDNSFamily)]
-        public async void ShouldWorkForA(DnsEndpoint endpoint) {
+        [InlineData(DnsEndpoint.OpenDNS)]        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("www.bücher.de", DnsRecordType.A, endpoint);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "www.xn--bcher-kva.de");

--- a/DnsClientX.Tests/QueryDnsSpecialCases.cs
+++ b/DnsClientX.Tests/QueryDnsSpecialCases.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class QueryDnsSpecialCases {
         [Theory]
@@ -17,9 +19,8 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         /// <summary>
-        /// This test case is for a special case where the query is expected to fail.
-        /// </summary>
-        public async void ShouldDeliverResponseOnFailedQueries(DnsEndpoint endpoint) {
+        /// This test case is for a special case where the query is expected to fail.        /// </summary>
+        public async Task ShouldDeliverResponseOnFailedQueries(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("spf-a.anotherexample.com", DnsRecordType.A, endpoint);
             Assert.True(response.Questions.Length == 1);
             Assert.True(response.Answers.Length == 0);

--- a/DnsClientX.Tests/QueryDnsSpecialCases.cs
+++ b/DnsClientX.Tests/QueryDnsSpecialCases.cs
@@ -19,7 +19,8 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         /// <summary>
-        /// This test case is for a special case where the query is expected to fail.        /// </summary>
+        /// This test case is for a special case where the query is expected to fail.
+        /// </summary>
         public async Task ShouldDeliverResponseOnFailedQueries(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("spf-a.anotherexample.com", DnsRecordType.A, endpoint);
             Assert.True(response.Questions.Length == 1);

--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -16,7 +16,8 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9)]
         [InlineData(DnsEndpoint.Quad9ECS)]
         [InlineData(DnsEndpoint.Quad9Unsecure)]
-        [InlineData(DnsEndpoint.OpenDNS)]        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        [InlineData(DnsEndpoint.OpenDNS)]
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             var Client = new ClientX(endpoint);
             var answer = await Client.ResolveFirst("github.com", DnsRecordType.TXT);
@@ -42,7 +43,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9Unsecure)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        public async void ShouldWorkForA(DnsEndpoint endpoint) {
+        public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             var Client = new ClientX(endpoint);
             var answer = await Client.ResolveFirst("evotec.pl", DnsRecordType.A);
             Assert.True(answer != null);

--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class ResolveFirst {
         [Theory]
@@ -14,9 +16,8 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9)]
         [InlineData(DnsEndpoint.Quad9ECS)]
         [InlineData(DnsEndpoint.Quad9Unsecure)]
-        [InlineData(DnsEndpoint.OpenDNS)]
-        [InlineData(DnsEndpoint.OpenDNSFamily)]
-        public async void ShouldWorkForTXT(DnsEndpoint endpoint) {
+        [InlineData(DnsEndpoint.OpenDNS)]        [InlineData(DnsEndpoint.OpenDNSFamily)]
+        public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             var Client = new ClientX(endpoint);
             var answer = await Client.ResolveFirst("github.com", DnsRecordType.TXT);
             Assert.True(answer != null);

--- a/DnsClientX.Tests/ResolveFirst.cs
+++ b/DnsClientX.Tests/ResolveFirst.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace DnsClientX.Tests {
     public class ResolveAll {
         [Theory]
@@ -16,7 +18,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9Unsecure)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        public async void ShouldWorkForTXT(DnsEndpoint endpoint) {
+        public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll("github.com", DnsRecordType.TXT);
             foreach (DnsAnswer answer in aAnswers) {
@@ -42,7 +44,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Quad9Unsecure)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        public async void ShouldWorkForA(DnsEndpoint endpoint) {
+        public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll("evotec.pl", DnsRecordType.A);
             foreach (DnsAnswer answer in aAnswers) {

--- a/DnsClientX.Tests/TxtRecordParsingTests.cs
+++ b/DnsClientX.Tests/TxtRecordParsingTests.cs
@@ -1,0 +1,111 @@
+using DnsClientX;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using System;
+
+namespace DnsClientX.Tests {
+    [TestClass]
+    public class TxtRecordParsingTests {
+        [TestMethod]
+        public void TestGoogleJsonNewlineDelimited() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = "v=spf1 include:_spf.google.com ~all\ngoogle-site-verification=xxxxxxxx"
+            };
+            var expected = new[] { "\"v=spf1 include:_spf.google.com ~all\"", "\"google-site-verification=xxxxxxxx\"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestGoogleJsonNewlineDelimitedWithBlankLines() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = "\nv=spf1\n\ngoogle-site-verification=abc\n  \n"
+            };
+            var expected = new[] { "\"v=spf1\"", "\"google-site-verification=abc\"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestGoogleJsonSingleEntryNoNewline() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = "google-site-verification=yyyyyyyy"
+            };
+            var expected = new[] { "\"google-site-verification=yyyyyyyy\"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestGoogleJsonConcatenatedWithoutNewline() {
+            // This scenario, without quotes and newlines, is treated as a single TXT record.
+            // The Google-specific logic is only for newline-separated values.
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = "item1item2item3"
+            };
+            var expected = new[] { "\"item1item2item3\"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestWireFormatConcatenatedDoubleQuotes() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = "\"v=spf1\"\"record2\"\"\"\"record3 with space\""
+            };
+            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"\"", "\"record3 with space\"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestWireFormatConcatenatedSpacedQuotes() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = "\"v=spf1\" \"record2\" \"record3 with space\""
+            };
+            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"record3 with space\"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestSingleStandardQuotedTxt() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = "\"single record text\""
+            };
+            var expected = new[] { "\"single record text\"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestEmptyDataRaw() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = ""
+            };
+            var expected = new[] { "\"\"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestNullDataRaw() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = null
+            };
+            var expected = Array.Empty<string>();
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+
+        [TestMethod]
+        public void TestTxtDataRawOnlyWhitespace() {
+            var answer = new DnsAnswer {
+                Type = DnsRecordType.TXT,
+                DataRaw = "   "
+            };
+            var expected = new[] { "\"   \"" };
+            CollectionAssert.AreEqual(expected, answer.DataStrings);
+        }
+    }
+}

--- a/DnsClientX.Tests/TxtRecordParsingTests.cs
+++ b/DnsClientX.Tests/TxtRecordParsingTests.cs
@@ -9,7 +9,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "v=spf1 include:_spf.google.com ~all\ngoogle-site-verification=xxxxxxxx"
-            };            var expected = new[] { "\"v=spf1 include:_spf.google.com ~all\"", "\"google-site-verification=xxxxxxxx\"" };
+            };
+            var expected = new[] { "\"v=spf1 include:_spf.google.com ~all\"", "\"google-site-verification=xxxxxxxx\"" };
             Assert.Equal(expected, answer.DataStrings);
         }
 
@@ -18,7 +19,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "\nv=spf1\n\ngoogle-site-verification=abc\n  \n"
-            };            var expected = new[] { "\"v=spf1\"", "\"google-site-verification=abc\"" };
+            };
+            var expected = new[] { "\"v=spf1\"", "\"google-site-verification=abc\"" };
             Assert.Equal(expected, answer.DataStrings);
         }
 
@@ -27,7 +29,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "google-site-verification=yyyyyyyy"
-            };            var expected = new[] { "\"google-site-verification=yyyyyyyy\"" };
+            };
+            var expected = new[] { "\"google-site-verification=yyyyyyyy\"" };
             Assert.Equal(expected, answer.DataStrings);
         }
 
@@ -47,7 +50,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "\"v=spf1\"\"record2\"\"\"\"record3 with space\""
-            };            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"\"", "\"record3 with space\"" };
+            };
+            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"\"", "\"record3 with space\"" };
             Assert.Equal(expected, answer.DataStrings);
         }
 
@@ -56,7 +60,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "\"v=spf1\" \"record2\" \"record3 with space\""
-            };            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"record3 with space\"" };
+            };
+            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"record3 with space\"" };
             Assert.Equal(expected, answer.DataStrings);
         }
 
@@ -65,7 +70,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "\"single record text\""
-            };            var expected = new[] { "\"single record text\"" };
+            };
+            var expected = new[] { "\"single record text\"" };
             Assert.Equal(expected, answer.DataStrings);
         }
 
@@ -74,7 +80,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = ""
-            };            var expected = new[] { "\"\"" };
+            };
+            var expected = new[] { "\"\"" };
             Assert.Equal(expected, answer.DataStrings);
         }
 
@@ -83,7 +90,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = null
-            };            var expected = Array.Empty<string>();
+            };
+            var expected = Array.Empty<string>();
             Assert.Equal(expected, answer.DataStrings);
         }
 
@@ -92,7 +100,8 @@ namespace DnsClientX.Tests {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "   "
-            };            var expected = new[] { "\"   \"" };
+            };
+            var expected = new[] { "\"   \"" };
             Assert.Equal(expected, answer.DataStrings);
         }
     }

--- a/DnsClientX.Tests/TxtRecordParsingTests.cs
+++ b/DnsClientX.Tests/TxtRecordParsingTests.cs
@@ -1,111 +1,99 @@
-using DnsClientX;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Linq;
 using System;
+using System.Linq;
+using Xunit;
 
 namespace DnsClientX.Tests {
-    [TestClass]
     public class TxtRecordParsingTests {
-        [TestMethod]
+        [Fact]
         public void TestGoogleJsonNewlineDelimited() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "v=spf1 include:_spf.google.com ~all\ngoogle-site-verification=xxxxxxxx"
-            };
-            var expected = new[] { "\"v=spf1 include:_spf.google.com ~all\"", "\"google-site-verification=xxxxxxxx\"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = new[] { "\"v=spf1 include:_spf.google.com ~all\"", "\"google-site-verification=xxxxxxxx\"" };
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGoogleJsonNewlineDelimitedWithBlankLines() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "\nv=spf1\n\ngoogle-site-verification=abc\n  \n"
-            };
-            var expected = new[] { "\"v=spf1\"", "\"google-site-verification=abc\"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = new[] { "\"v=spf1\"", "\"google-site-verification=abc\"" };
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGoogleJsonSingleEntryNoNewline() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "google-site-verification=yyyyyyyy"
-            };
-            var expected = new[] { "\"google-site-verification=yyyyyyyy\"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = new[] { "\"google-site-verification=yyyyyyyy\"" };
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
-        public void TestGoogleJsonConcatenatedWithoutNewline() {
-            // This scenario, without quotes and newlines, is treated as a single TXT record.
+        [Fact]
+        public void TestGoogleJsonConcatenatedWithoutNewline() {            // This scenario, without quotes and newlines, is treated as a single TXT record.
             // The Google-specific logic is only for newline-separated values.
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "item1item2item3"
             };
             var expected = new[] { "\"item1item2item3\"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestWireFormatConcatenatedDoubleQuotes() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "\"v=spf1\"\"record2\"\"\"\"record3 with space\""
-            };
-            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"\"", "\"record3 with space\"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"\"", "\"record3 with space\"" };
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestWireFormatConcatenatedSpacedQuotes() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "\"v=spf1\" \"record2\" \"record3 with space\""
-            };
-            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"record3 with space\"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = new[] { "\"v=spf1\"", "\"record2\"", "\"record3 with space\"" };
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSingleStandardQuotedTxt() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "\"single record text\""
-            };
-            var expected = new[] { "\"single record text\"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = new[] { "\"single record text\"" };
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestEmptyDataRaw() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = ""
-            };
-            var expected = new[] { "\"\"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = new[] { "\"\"" };
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNullDataRaw() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = null
-            };
-            var expected = Array.Empty<string>();
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = Array.Empty<string>();
+            Assert.Equal(expected, answer.DataStrings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTxtDataRawOnlyWhitespace() {
             var answer = new DnsAnswer {
                 Type = DnsRecordType.TXT,
                 DataRaw = "   "
-            };
-            var expected = new[] { "\"   \"" };
-            CollectionAssert.AreEqual(expected, answer.DataStrings);
+            };            var expected = new[] { "\"   \"" };
+            Assert.Equal(expected, answer.DataStrings);
         }
     }
 }

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -103,7 +103,7 @@ namespace DnsClientX {
                     foreach (var line in lines) {
                         if (!string.IsNullOrWhiteSpace(line)) {
                             // Each line from Google is an individual TXT record, add quotes for consistency.
-                            resultList.Add($"\"{line.Trim()}\"");
+                            resultList.Add($"\"{line}\"");
                         }
                     }
                     // If splitting by \n actually yielded results, return them.
@@ -141,7 +141,7 @@ namespace DnsClientX {
                 // (e.g. single Google entry without \n, or a standard single unquoted TXT record)
                 // then quote it for consistency with how other segments are produced.
                 if (Type == DnsRecordType.TXT && !(segmentValue.StartsWith("\"") && segmentValue.EndsWith("\""))) {
-                    resultList.Add($"\"{segmentValue.Trim()}\"");
+                    resultList.Add($"\"{segmentValue}\"");
                 } else {
                     // For non-TXT types, or already quoted TXT segments.
                     resultList.Add(segmentValue);

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -85,38 +85,79 @@ namespace DnsClientX {
         /// </summary>
         /// <returns></returns>
         private string[] ConvertToMultiString() {
-            // I'm not sure if this is the best way to do this, but it works for now.
-            // This method searches for quotes with space between them or quotes without space
-            // Then it splits the string into multiple strings, adding back the quotes that we split on
-            var data = new List<string>();
-            var temp = new StringBuilder();
-            if (DataRaw != null) {
-                for (int i = 0; i < DataRaw.Length; i++) {
-                    if (i < DataRaw.Length - 1 && DataRaw[i] == '"' && DataRaw[i + 1] == '"') {
-                        temp.Append(DataRaw[i]);
-                        data.Add(temp.ToString());
-                        temp.Clear();
-                        temp.Append("\""); // Add quotes back
-                        i++; // Skip the next character as it's part of the split
-                    } else if (i < DataRaw.Length - 2 && DataRaw[i] == '"' && DataRaw[i + 1] == ' ' && DataRaw[i + 2] == '"') {
-                        temp.Append(DataRaw[i]);
-                        data.Add(temp.ToString());
-                        temp.Clear();
-                        temp.Append("\""); // Add quotes back
-                        i += 2; // Skip the next two characters as they're part of the split
-                    } else {
-                        temp.Append(DataRaw[i]);
+            if (DataRaw == null) return Array.Empty<string>();
+
+            var resultList = new List<string>();
+
+            if (Type == DnsRecordType.TXT) {
+                // Heuristic for Google DoH JSON: DataRaw is not quoted like "foo" AND contains \n.
+                // This indicates multiple TXT entries concatenated by Google, separated by newlines.
+                // It also must not end with a quote, otherwise it could be a legitimate quoted string with a newline.
+                bool isLikelyGoogleNewlineDelimited = !DataRaw.StartsWith("\"") &&
+                                                      !DataRaw.EndsWith("\"") &&
+                                                      DataRaw.Contains("\n");
+
+                if (isLikelyGoogleNewlineDelimited) {
+                    var lines = DataRaw.Split('\n');
+                    foreach (var line in lines) {
+                        if (!string.IsNullOrWhiteSpace(line)) {
+                            // Each line from Google is an individual TXT record, add quotes for consistency.
+                            resultList.Add($"\"{line.Trim()}\"");
+                        }
+                    }
+                    // If splitting by \n actually yielded results, return them.
+                    // Otherwise, fall through to the standard parsing logic below.
+                    if (resultList.Any()) {
+                        return resultList.ToArray();
                     }
                 }
-
-                if (temp.Length > 0) {
-                    data.Add(temp.ToString());
-                }
-
-                return data.ToArray();
-            } else {
-                return new string[] { };
             }
+
+            // Standard logic for TXT (handles "seg1""seg2", "seg1" "seg2")
+            // and for other types (where it effectively returns DataRaw as a single element array).
+            // Also handles single TXT records (quoted or unquoted).
+            var currentSegment = new StringBuilder();
+            for (int i = 0; i < DataRaw.Length; i++) {
+                // This condition is specific to how TXT records concatenate multiple strings using quotes.
+                if (Type == DnsRecordType.TXT && i < DataRaw.Length - 1 && DataRaw[i] == '"' && DataRaw[i + 1] == '"') { // "" delimiter
+                    currentSegment.Append(DataRaw[i]); // Append the first quote of the pair
+                    resultList.Add(currentSegment.ToString());
+                    currentSegment.Clear().Append('"'); // Start next segment with a quote
+                    i++; // Skip the second quote of the pair
+                } else if (Type == DnsRecordType.TXT && i < DataRaw.Length - 2 && DataRaw[i] == '"' && DataRaw[i + 1] == ' ' && DataRaw[i + 2] == '"') { // " " delimiter
+                    currentSegment.Append(DataRaw[i]); // Append the first quote of the " "
+                    resultList.Add(currentSegment.ToString());
+                    currentSegment.Clear().Append('"'); // Start next segment with a quote
+                    i += 2; // Skip space and the following quote
+                } else {
+                    currentSegment.Append(DataRaw[i]);
+                }
+            }
+
+            if (currentSegment.Length > 0) {
+                string segmentValue = currentSegment.ToString();
+                // If it's TXT and this segment is unquoted
+                // (e.g. single Google entry without \n, or a standard single unquoted TXT record)
+                // then quote it for consistency with how other segments are produced.
+                if (Type == DnsRecordType.TXT && !(segmentValue.StartsWith("\"") && segmentValue.EndsWith("\""))) {
+                    resultList.Add($"\"{segmentValue.Trim()}\"");
+                } else {
+                    // For non-TXT types, or already quoted TXT segments.
+                    resultList.Add(segmentValue);
+                }
+            }
+
+            // If resultList is still empty at this point AND DataRaw was not null or empty,
+            // it means DataRaw was a string that didn't get processed by the loop logic into any segments.
+            // This could happen if DataRaw was empty after trimming for TXT, or it was an empty string for non-TXT.
+            // Or if DataRaw is not empty but resulted in an empty list (e.g. TXT with only whitespace lines for Google \n split)
+            // In such cases, an empty array is appropriate. If DataRaw was "   " for TXT, it becomes "\"   \"" if currentSegment logic runs.
+            // If DataRaw was " " and it's TXT, Google \n split makes it empty. Standard logic makes it "\" \"".
+            // The original code `if (temp.Length > 0) data.Add(temp.ToString());` would add it.
+            // Current logic: if currentSegment has " ", it will be added.
+            // If DataRaw was empty string, currentSegment.Length is 0, resultList is empty. Correct.
+
+            return resultList.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
Google's DNS-over-HTTPS (DoH) JSON API returns TXT records as a single string, with multiple TXT values concatenated directly, sometimes using a newline character ('\n') as a delimiter between actual records. This differs from the standard DNS wire format where multiple TXT strings are individually length-prefixed and then concatenated, or from other DoH providers that might use JSON arrays or properly quoted strings.

This commit updates the `DnsAnswer.ConvertToMultiString()` method to:
1. Detect if a TXT record's `DataRaw` content appears to be from Google's DoH JSON (i.e., it's unquoted and contains newlines).
2. If so, it splits the string by newline characters and treats each part as an individual TXT record, wrapping it in quotes for consistency with other parsed TXT records.
3. If the Google DoH heuristic doesn't apply, the method falls back to its existing logic, which correctly handles standard wire-format TXT records (e.g., "string1""string2" or "string1" "string2") and single TXT record strings.

Comprehensive unit tests have been added in
`DnsClientX.Tests/TxtRecordParsingTests.cs` to cover:
- Google's newline-delimited TXT format.
- Single unquoted TXT strings (common for Google).
- Standard wire-format TXT strings (concatenated with and without spaces).
- Edge cases like null, empty, or whitespace-only `DataRaw`.

The DnsClientX.Tests project has also been updated to use MSTest as its testing framework.