### PR TITLE
Refactor DNS endpoint configurations to use simplified hostnames and …

### DIFF
--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -209,18 +209,18 @@ namespace DnsClientX {
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.Quad9:
-                    hostnames = new List<string> { "9.9.9.9:5053", "149.112.112.112:5053" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+                    hostnames = new List<string> { "9.9.9.9", "149.112.112.112" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.Quad9ECS:
-                    hostnames = new List<string> { "9.9.9.11:5053", "149.112.112.11:5053" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+                    hostnames = new List<string> { "9.9.9.11", "149.112.112.11" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.Quad9Unsecure:
-                    hostnames = new List<string> { "9.9.9.10:5053", "149.112.112.10:5053" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+                    hostnames = new List<string> { "9.9.9.10", "149.112.112.10" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.OpenDNS:


### PR DESCRIPTION
…update request format. Changed hostnames for Quad9 and Quad9ECS endpoints to remove port numbers and switched request format to DnsOverHttps for improved compatibility.