### PR TITLE
Fix inner exception message

### DIFF
--- a/DnsClientX.Tests/ResolveHttpRequestException.cs
+++ b/DnsClientX.Tests/ResolveHttpRequestException.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net.Http;
+using DnsClientX;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveHttpRequestException {
+        private class ThrowingHandler : HttpMessageHandler {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                throw new HttpRequestException("network error");
+            }
+        }
+
+        [Fact]
+        public async Task ShouldHandleHttpRequestExceptionWithoutInner() {
+            var handler = new ThrowingHandler();
+            var clientX = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps);
+
+            var customClient = new HttpClient(handler) { BaseAddress = clientX.EndpointConfiguration.BaseUri };
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(clientX)!;
+            clients[clientX.EndpointConfiguration.SelectionStrategy] = customClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(clientX, customClient);
+
+            var response = await clientX.Resolve("example.com", DnsRecordType.A, retryOnTransient: false);
+            Assert.Equal(DnsResponseCode.ServerFailure, response.Status);
+            Assert.Contains("network error", response.Error);
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -70,7 +70,7 @@ namespace DnsClientX {
                 ];
                 response.Status = responseCode;
                 response.AddServerDetails(endpointConfiguration);
-                response.Error = $"Failed to query type {type} of \"{name}\" => {ex.Message + " " + ex.InnerException.Message}";
+                response.Error = $"Failed to query type {type} of \"{name}\" => {ex.Message + " " + ex.InnerException?.Message}";
                 return response;
             }
         }


### PR DESCRIPTION
## Summary
- avoid NullReferenceException when handling `HttpRequestException`
- test `ResolveWireFormatGet` handles missing inner exception

## Testing
- `dotnet test` *(fails: Failed:   202, Passed:   193, Skipped:     0, Total:   395)*

------
https://chatgpt.com/codex/tasks/task_e_6854053ea4e4832eaaee98cf1946da31