### PR TITLE
Fix RetryAsync loop and test invocation count

### DIFF
--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class RetryAsyncTests {
+        [Fact]
+        public async Task ShouldRetrySpecifiedNumberOfTimes() {
+            int attempts = 0;
+            Func<Task<int>> action = () => {
+                attempts++;
+                throw new TimeoutException();
+            };
+
+            MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
+            Task<int> Invoke() {
+                var generic = method.MakeGenericMethod(typeof(int));
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1 })!;
+            }
+
+            await Assert.ThrowsAsync<TimeoutException>(Invoke);
+            Assert.Equal(3, attempts);
+        }
+    }
+}
+

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -83,15 +83,13 @@ namespace DnsClientX {
         }
 
         private static async Task<T> RetryAsync<T>(Func<Task<T>> action, int maxRetries = 3, int delayMs = 200) {
-            for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            for (int attempt = 1; ; attempt++) {
                 try {
                     return await action();
                 } catch (Exception ex) when (IsTransient(ex) && attempt < maxRetries) {
                     await Task.Delay(delayMs);
                 }
             }
-            // Last attempt, let exception bubble up
-            return await action();
         }
 
         private static bool IsTransient(Exception ex) {


### PR DESCRIPTION
## Summary
- fix `RetryAsync` to execute at most the specified number of attempts
- add unit test covering retry attempts via reflection

## Testing
- `dotnet test` *(fails: Invalid URI and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854052ec4dc832eb53ff248a17b5702