### PR TITLE
Add System.Net.Http package reference for netstandard

### DIFF
--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -54,6 +54,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- reference `System.Net.Http` when targeting `netstandard2.0`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: authentication/connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68541b4ff568832e825a6f2a46d5a4cc