### PR TITLE
Improve debug info for provider comparisons

### DIFF
--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -50,7 +50,7 @@ namespace DnsClientX.Tests {
                     continue;
                 }
 
-                output.WriteLine("Provider: " + endpointCompare.ToString());
+                output.WriteLine($"Comparing {primaryEndpoint} -> {endpointCompare}");
 
                 var ClientToCompare = new ClientX(endpointCompare);
                 DnsResponse aAnswersToCompare = await ClientToCompare.Resolve(name, resourceRecordType);
@@ -81,7 +81,7 @@ namespace DnsClientX.Tests {
                 Assert.Equal(sortedQuestions.Length, sortedQuestionsCompared.Length);
 
                 for (int i = 0; i < sortedQuestions.Length; i++) {
-                    output.WriteLine("Provider: " + endpointCompare.ToString());
+                    output.WriteLine($"Comparing {primaryEndpoint} -> {endpointCompare}");
                     output.WriteLine($"Question {i} should equal: {sortedQuestions[i].Name} == {sortedQuestionsCompared[i].Name}");
                     Assert.True(sortedQuestions[i].Name == sortedQuestionsCompared[i].Name, $"Provider {endpointCompare}. There is a name mismatch for " + sortedQuestions[i].Name);
                     Assert.True((bool)(sortedQuestions[i].Type == sortedQuestionsCompared[i].Type), $"Provider {endpointCompare}. There is a type mismatch for " + sortedQuestions[i].Type);

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -46,7 +46,7 @@ namespace DnsClientX.Tests {
                 if (excludedEndpoints != null && excludedEndpoints.Contains(endpointCompare)) {
                     continue;
                 }
-                output.WriteLine("Provider: " + endpointCompare.ToString());
+                output.WriteLine($"Comparing {primaryEndpoint} -> {endpointCompare}");
                 var clientToCompare = new ClientX(endpointCompare);
                 DnsAnswer[] aAnswersToCompare = await clientToCompare.ResolveAll(name, resourceRecordType);
 

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -2,6 +2,7 @@ using Xunit.Abstractions;
 
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace DnsClientX.Tests {
     public class CompareProvidersResolveFilter(ITestOutputHelper output) {
@@ -29,7 +30,7 @@ namespace DnsClientX.Tests {
                     continue;
                 }
 
-                output.WriteLine("Provider: " + endpointCompare.ToString());
+                output.WriteLine($"Comparing {primaryEndpoint} -> {endpointCompare}");
 
                 var ClientToCompare = new ClientX(endpointCompare);
                 DnsResponse aAnswersToCompare = await ClientToCompare.ResolveFilter(name, resourceRecordType, filter);
@@ -75,6 +76,9 @@ namespace DnsClientX.Tests {
                     var onlyInB = setB.Except(setA).ToList();
                     if (onlyInA.Any()) output.WriteLine("Only in primary: " + string.Join(" | ", onlyInA));
                     if (onlyInB.Any()) output.WriteLine("Only in compared: " + string.Join(" | ", onlyInB));
+#if DEBUG
+                    if (Debugger.IsAttached) Debugger.Break();
+#endif
                     throw;
                 }
 
@@ -87,7 +91,7 @@ namespace DnsClientX.Tests {
                 Assert.Equal(sortedQuestions.Length, sortedQuestionsCompared.Length);
 
                 for (int i = 0; i < sortedQuestions.Length; i++) {
-                    output.WriteLine("Provider: " + endpointCompare.ToString());
+                    output.WriteLine($"Comparing {primaryEndpoint} -> {endpointCompare}");
                     output.WriteLine(
                         $"Question {i} should equal: {sortedQuestions[i].Name} == {sortedQuestionsCompared[i].Name}");
                     Assert.True(sortedQuestions[i].Name == sortedQuestionsCompared[i].Name,
@@ -160,6 +164,9 @@ namespace DnsClientX.Tests {
                         var onlyInB = setB.Except(setA).ToList();
                         if (onlyInA.Any()) output.WriteLine("Only in primary: " + string.Join(" | ", onlyInA));
                         if (onlyInB.Any()) output.WriteLine("Only in compared: " + string.Join(" | ", onlyInB));
+#if DEBUG
+                        if (Debugger.IsAttached) Debugger.Break();
+#endif
                         throw;
                     }
                 }


### PR DESCRIPTION
## Summary
- add endpoint pair info when comparing DNS providers
- break into the debugger during failures when running under a debugger

## Testing
- `dotnet test --no-build` *(fails: SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_685474226b60832ea6cdbbfde247cb49