### PR TITLE
Add missing XML documentation

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -19,6 +19,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
@@ -131,6 +132,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of DNS responses.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
@@ -180,6 +182,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of DNS responses.</returns>
         public async Task<DnsResponse[]> Resolve(string[] names, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             var tasks = new List<Task<DnsResponse>>();
@@ -222,7 +225,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The array of DNS responses from all queries.</returns>
         public async Task<DnsResponse[]> Resolve(string[] names, DnsRecordType type, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             var tasks = new List<Task<DnsResponse>>();
 

--- a/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
@@ -17,6 +17,7 @@ namespace DnsClientX {
         /// <param name="validateDnsSec">If set to <c>true</c>, the method will validate DNSSEC data.</param>
         /// <param name="debug">If set to <c>true</c>, the method will include debugging information in the response.</param>
         /// <param name="configuration">Provide configuration so it can be added to Question for display purposes</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         /// <exception cref="DnsClientException">Thrown when the HTTP request fails or the server returns an error.</exception>
         internal static async Task<DnsResponse> ResolveJsonFormat(this HttpClient client, string name,

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -15,7 +15,8 @@ namespace DnsClientX {
         /// <param name="requestDnsSec">If set to <c>true</c>, the query will request DNSSEC records.</param>
         /// <param name="validateDnsSec">If set to <c>true</c>, the response will be validated using DNSSEC.</param>
         /// <param name="debug">If set to <c>true</c>, debug information will be printed to the console.</param>
-        /// <param name="endpointConfiguration"></param>
+        /// <param name="endpointConfiguration">Configuration used for server details.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A Task that represents the asynchronous operation. The Task's result is a DnsResponse that contains the DNS response.</returns>
         /// <exception cref="DnsClientException">Thrown when the HTTP request fails or the server returns an error.</exception>
         internal static async Task<DnsResponse> ResolveWireFormatGet(this HttpClient client, string name,

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -19,8 +19,9 @@ namespace DnsClientX {
         /// <param name="requestDnsSec">if set to <c>true</c> [request DNS sec].</param>
         /// <param name="validateDnsSec">if set to <c>true</c> [validate DNS sec].</param>
         /// <param name="debug">if set to <c>true</c> [debug].</param>
-        /// <param name="endpointConfiguration"></param>
-        /// <returns></returns>
+        /// <param name="endpointConfiguration">Configuration used for server details.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The DNS response.</returns>
         /// <exception cref="System.ArgumentNullException">name - Name is null or empty.</exception>
         /// <exception cref="System.Exception">
         /// Failed to read the length prefix of the response.
@@ -109,6 +110,13 @@ namespace DnsClientX {
             return response;
         }
 
+        /// <summary>
+        /// Connects asynchronously to the specified host using a <see cref="TcpClient"/>.
+        /// </summary>
+        /// <param name="client">TCP client used for the connection.</param>
+        /// <param name="host">Target host.</param>
+        /// <param name="port">Target port.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         private static async Task ConnectAsync(TcpClient client, string host, int port, CancellationToken cancellationToken) {
             var connectTask = client.ConnectAsync(host, port);
             var delayTask = Task.Delay(Timeout.Infinite, cancellationToken);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -16,6 +16,7 @@ namespace DnsClientX {
         /// <param name="validateDnsSec">If set to <c>true</c>, the method will validate DNSSEC data.</param>
         /// <param name="debug">If set to <c>true</c>, the method will include debugging information in the response.</param>
         /// <param name="endpointConfiguration">Provide configuration so it can be added to Question for display purposes</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when the 'name' parameter is null or empty.</exception>
         /// <exception cref="DnsClientException">Thrown when the HTTP request fails or the server returns an error.</exception>

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -17,7 +17,8 @@ namespace DnsClientX {
         /// <param name="validateDnsSec"></param>
         /// <param name="debug"></param>
         /// <param name="endpointConfiguration">Provide configuration so it can be added to Question for display purposes</param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The DNS response.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         internal static async Task<DnsResponse> ResolveWireFormatTcp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
@@ -80,8 +81,9 @@ namespace DnsClientX {
         /// <param name="query"></param>
         /// <param name="dnsServer"></param>
         /// <param name="port"></param>
-        /// <param name="timeoutMilliseconds"></param>
-        /// <returns></returns>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             using (var tcpClient = new TcpClient()) {
                 try {
@@ -157,6 +159,11 @@ namespace DnsClientX {
         /// <summary>
         /// Connects the provided <see cref="TcpClient"/> with support for timeout and cancellation on older frameworks.
         /// </summary>
+        /// <param name="tcpClient">Client used for the connection.</param>
+        /// <param name="host">Target host.</param>
+        /// <param name="port">Target port.</param>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         private static async Task ConnectAsync(TcpClient tcpClient, string host, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             linkedCts.CancelAfter(timeoutMilliseconds);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -17,7 +17,8 @@ namespace DnsClientX {
         /// <param name="validateDnsSec"></param>
         /// <param name="debug"></param>
         /// <param name="endpointConfiguration">Provide configuration so it can be added to Question for display purposes</param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The DNS response.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         internal static async Task<DnsResponse> ResolveWireFormatUdp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
@@ -88,8 +89,9 @@ namespace DnsClientX {
         /// <param name="query"></param>
         /// <param name="dnsServer"></param>
         /// <param name="port"></param>
-        /// <param name="timeoutMilliseconds"></param>
-        /// <returns></returns>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverUdp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             using (var udpClient = new UdpClient()) {
                 // Set the server IP address and port number


### PR DESCRIPTION
## Summary
- improve cancellation token documentation across DNS helpers
- generate XML docs to verify build

## Testing
- `dotnet build DnsClientX/DnsClientX.csproj /property:GenerateDocumentationFile=true`
- `dotnet build DnsClientX.sln /property:GenerateDocumentationFile=true`

------
https://chatgpt.com/codex/tasks/task_e_6857b757f798832eb4b2e1fe5e9870c5