### PR TITLE
Update docs and tests for nullable Questions

### DIFF
--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -85,7 +85,7 @@ namespace DnsClientX.Examples {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.Cloudflare);
             var data = await ClientX.QueryDns(["evotec.pl", "google.com", "onet.pl"], DnsRecordType.A, DnsEndpoint.Cloudflare, DnsSelectionStrategy.Random);
             foreach (var dnsResponse in data) {
-                dnsResponse.Questions.DisplayTable();
+                dnsResponse.Questions?.DisplayTable();
                 dnsResponse.Answers.DisplayTable();
             }
         }
@@ -93,7 +93,7 @@ namespace DnsClientX.Examples {
         public static async Task ExampleSystemDns() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.System);
             var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.System, DnsSelectionStrategy.Random);
-            data.Questions.DisplayTable();
+            data.Questions?.DisplayTable();
             data.Answers.DisplayTable();
         }
 

--- a/DnsClientX.Examples/Helpers.cs
+++ b/DnsClientX.Examples/Helpers.cs
@@ -35,8 +35,10 @@ namespace DnsClientX.Examples {
                 Console.WriteLine("\tAnswers: No answers");
                 return;
             }
-            foreach (DnsQuestion question in response.Value.Questions) {
-                Console.WriteLine($"\tQuestion: {question.Name} => {question.Type}");
+            if (response.Value.Questions != null) {
+                foreach (DnsQuestion question in response.Value.Questions) {
+                    Console.WriteLine($"\tQuestion: {question.Name} => {question.Type}");
+                }
             }
             Console.WriteLine($"\tAnswers: ");
             foreach (DnsAnswer answer in response.Value.Answers) {

--- a/DnsClientX.Examples/HelpersSpectre.cs
+++ b/DnsClientX.Examples/HelpersSpectre.cs
@@ -43,7 +43,9 @@ namespace DnsClientX.Examples {
             table.AddColumn("Questions");
             table.AddColumn("Answers");
 
-            var questions = string.Join(", ", response.Questions.Select(q => $"{q.Name} => {q.Type}"));
+            var questions = response.Questions == null
+                ? string.Empty
+                : string.Join(", ", response.Questions.Select(q => $"{q.Name} => {q.Type}"));
 
             foreach (var answer in response.Answers) {
                 var answerTable = new Table().Border(TableBorder.Rounded);
@@ -70,8 +72,12 @@ namespace DnsClientX.Examples {
             table.AddColumn("Server");
             table.AddColumn("Answers");
 
-            var questions = string.Join(", ", response.Questions.Select(q => $"{q.Name} => {q.Type}"));
-            var server = string.Join(Environment.NewLine, response.Questions.Select(q => $"HostName: {q.HostName}{Environment.NewLine}Port: {q.Port}{Environment.NewLine}RequestFormat: {q.RequestFormat}{Environment.NewLine}BaseUri: {q.BaseUri}"));
+            var questions = response.Questions == null
+                ? string.Empty
+                : string.Join(", ", response.Questions.Select(q => $"{q.Name} => {q.Type}"));
+            var server = response.Questions == null
+                ? string.Empty
+                : string.Join(Environment.NewLine, response.Questions.Select(q => $"HostName: {q.HostName}{Environment.NewLine}Port: {q.Port}{Environment.NewLine}RequestFormat: {q.RequestFormat}{Environment.NewLine}BaseUri: {q.BaseUri}"));
 
             var answerTable = new Table().Border(TableBorder.Rounded);
             answerTable.AddColumn("Type");

--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -73,8 +73,16 @@ namespace DnsClientX.Tests {
                     Assert.Equal(sortedAAnswers[i].DataStrings.Length, sortedAAnswersCompared[i].DataStrings.Length);
                 }
 
-                var sortedQuestions = aAnswersPrimary.Questions.OrderBy(a => a.Name).ThenBy(a => a.Type).ThenBy(a => a.Type).ToArray();
-                var sortedQuestionsCompared = aAnswersToCompare.Questions.OrderBy(a => a.Name).ThenBy(a => a.Type).ThenBy(a => a.Type).ToArray();
+                var sortedQuestions = (aAnswersPrimary.Questions ?? Array.Empty<DnsQuestion>())
+                    .OrderBy(a => a.Name)
+                    .ThenBy(a => a.Type)
+                    .ThenBy(a => a.Type)
+                    .ToArray();
+                var sortedQuestionsCompared = (aAnswersToCompare.Questions ?? Array.Empty<DnsQuestion>())
+                    .OrderBy(a => a.Name)
+                    .ThenBy(a => a.Type)
+                    .ThenBy(a => a.Type)
+                    .ToArray();
 
                 // Check that the arrays have the same length
                 output.WriteLine($"Question count expected {sortedQuestions.Length} vs {sortedQuestionsCompared.Length}");

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -78,10 +78,16 @@ namespace DnsClientX.Tests {
                     throw;
                 }
 
-                var sortedQuestions = aAnswersPrimary.Questions.OrderBy(a => a.Name).ThenBy(a => a.Type)
-                    .ThenBy(a => a.Type).ToArray();
-                var sortedQuestionsCompared = aAnswersToCompare.Questions.OrderBy(a => a.Name).ThenBy(a => a.Type)
-                    .ThenBy(a => a.Type).ToArray();
+                var sortedQuestions = (aAnswersPrimary.Questions ?? Array.Empty<DnsQuestion>())
+                    .OrderBy(a => a.Name)
+                    .ThenBy(a => a.Type)
+                    .ThenBy(a => a.Type)
+                    .ToArray();
+                var sortedQuestionsCompared = (aAnswersToCompare.Questions ?? Array.Empty<DnsQuestion>())
+                    .OrderBy(a => a.Name)
+                    .ThenBy(a => a.Type)
+                    .ThenBy(a => a.Type)
+                    .ToArray();
 
                 // Check that the arrays have the same length
                 Assert.Equal(sortedQuestions.Length, sortedQuestionsCompared.Length);

--- a/DnsClientX.Tests/QueryDnsByHostName.cs
+++ b/DnsClientX.Tests/QueryDnsByHostName.cs
@@ -44,7 +44,7 @@ namespace DnsClientX.Tests {
             var domains = new[] { "evotec.pl", "google.com" };
             var responses = await ClientX.QueryDns(domains, DnsRecordType.A, hostName, requestFormat);
             foreach (var domain in domains) {
-                var response = responses.First(r => r.Questions.Any(q => q.Name == domain));
+                var response = responses.First(r => r.Questions?.Any(q => q.Name == domain) == true);
                 foreach (DnsAnswer answer in response.Answers) {
                     Assert.True(answer.Name == domain);
                     Assert.True(answer.Type == DnsRecordType.A);

--- a/DnsClientX.Tests/QueryDnsSpecialCases.cs
+++ b/DnsClientX.Tests/QueryDnsSpecialCases.cs
@@ -22,12 +22,14 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldDeliverResponseOnFailedQueries(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("spf-a.anotherexample.com", DnsRecordType.A, endpoint);
-            Assert.True(response.Questions.Length == 1);
             Assert.True(response.Answers.Length == 0);
             Assert.True(response.Status != DnsResponseCode.NoError);
-            foreach (DnsQuestion question in response.Questions) {
-                Assert.True(question.Name == "spf-a.anotherexample.com");
-                Assert.True(question.Type == DnsRecordType.A);
+            if (response.Questions != null) {
+                Assert.True(response.Questions.Length == 1);
+                foreach (DnsQuestion question in response.Questions) {
+                    Assert.True(question.Name == "spf-a.anotherexample.com");
+                    Assert.True(question.Type == DnsRecordType.A);
+                }
             }
         }
     }

--- a/DnsClientX.Tests/ResolveSync.cs
+++ b/DnsClientX.Tests/ResolveSync.cs
@@ -89,7 +89,7 @@ namespace DnsClientX.Tests {
             var domains = new[] { "evotec.pl", "google.com" };
             var responses = client.ResolveSync(domains, DnsRecordType.A);
             foreach (var domain in domains) {
-                var response = responses.First(r => r.Questions.Any(q => q.Name == domain));
+                var response = responses.First(r => r.Questions?.Any(q => q.Name == domain) == true);
                 foreach (DnsAnswer answer in response.Answers) {
                     Assert.True(answer.Name == domain);
                     Assert.True(answer.Type == DnsRecordType.A);
@@ -105,7 +105,7 @@ namespace DnsClientX.Tests {
             var types = new[] { DnsRecordType.A, DnsRecordType.TXT };
             var responses = client.ResolveSync("evotec.pl", types);
             foreach (var type in types) {
-                var response = responses.First(r => r.Questions.Any(q => q.Type == type));
+                var response = responses.First(r => r.Questions?.Any(q => q.Type == type) == true);
                 foreach (DnsAnswer answer in response.Answers) {
                     Assert.True(answer.Name == "evotec.pl");
                     Assert.True(answer.Type == type);

--- a/DnsClientX.Tests/TcpTimeoutTests.cs
+++ b/DnsClientX.Tests/TcpTimeoutTests.cs
@@ -13,7 +13,7 @@ namespace DnsClientX.Tests {
             // With such a short timeout, it should either timeout or complete very quickly
             Assert.True(response.Status != DnsResponseCode.NoError || response.Status == DnsResponseCode.NoError);
             // This test mainly ensures no exception is thrown and the timeout mechanism is in place
-            Assert.True(response.Questions.Length > 0);
+            Assert.True(response.Questions == null || response.Questions.Length > 0);
         }
           [Fact]
         public async Task SystemTcp_ShouldWorkWithNormalTimeout() {
@@ -23,7 +23,7 @@ namespace DnsClientX.Tests {
 
             // This should work normally - though it might still fail if DNS resolution fails
             // We just check that it doesn't throw an exception and returns a response
-            Assert.True(response.Questions.Length > 0);
+            Assert.True(response.Questions == null || response.Questions.Length > 0);
         }
     }
 }

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -47,7 +47,9 @@ namespace DnsClientX {
         public bool CheckingDisabled { get; set; }
 
         /// <summary>
-        /// The questions that were asked in the DNS query.
+        /// The questions that were asked in the DNS query. Some providers do
+        /// not return the question section in their response. In those cases
+        /// this property will be <c>null</c>.
         /// </summary>
         [JsonPropertyName("Question")]
         public DnsQuestion[] Questions { get; set; }


### PR DESCRIPTION
## Summary
- document that `DnsResponse.Questions` may be null
- guard against null questions in examples
- update tests to allow `Questions` to be null

## Testing
- `dotnet test` *(fails: Could not reach DNS servers)*

------
https://chatgpt.com/codex/tasks/task_e_6857e5181590832ea84a8d227f921cb8