### PR TITLE
Implement configurable timeout and add tests

### DIFF
--- a/DnsClientX.Tests/TimeoutTests.cs
+++ b/DnsClientX.Tests/TimeoutTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Net.Http;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class TimeoutTests {
+        private class DelayingHandler : HttpMessageHandler {
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                await Task.Delay(500, cancellationToken);
+                return new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new ByteArrayContent(Array.Empty<byte>()) };
+            }
+        }
+
+        [Fact]
+        public async Task Resolve_ShouldFailWithTimeout() {
+            var handler = new DelayingHandler();
+            var clientX = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps, timeOutMilliseconds: 100);
+
+            var customClient = new HttpClient(handler) {
+                BaseAddress = clientX.EndpointConfiguration.BaseUri,
+                Timeout = TimeSpan.FromMilliseconds(clientX.EndpointConfiguration.TimeOut)
+            };
+
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(clientX)!;
+            clients[clientX.EndpointConfiguration.SelectionStrategy] = customClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(clientX, customClient);
+
+            var response = await clientX.Resolve("example.com", DnsRecordType.A, retryOnTransient: false);
+            Assert.Equal(DnsResponseCode.ServerFailure, response.Status);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -20,8 +20,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
-            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
+            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds);
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -40,8 +39,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
-            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
+            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds);
             var data = client.ResolveSync(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -60,11 +58,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds);
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -83,11 +77,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds);
             var data = client.ResolveSync(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -106,11 +96,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(dnsUri, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(dnsUri, requestFormat, timeOutMilliseconds);
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -129,11 +115,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(dnsUri, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(dnsUri, requestFormat, timeOutMilliseconds);
             var data = client.ResolveSync(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -151,11 +133,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(dnsUri, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(dnsUri, requestFormat, timeOutMilliseconds);
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -173,11 +151,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(dnsUri, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(dnsUri, requestFormat, timeOutMilliseconds);
             var data = client.ResolveSync(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -196,11 +170,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(hostName, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(hostName, requestFormat, timeOutMilliseconds);
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -219,11 +189,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(hostName, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(hostName, requestFormat, timeOutMilliseconds);
             var data = client.ResolveSync(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -241,11 +207,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(hostName, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(hostName, requestFormat, timeOutMilliseconds);
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -263,11 +225,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(hostName, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(hostName, requestFormat, timeOutMilliseconds);
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -285,11 +243,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(hostName, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(hostName, requestFormat, timeOutMilliseconds);
             var data = client.ResolveSync(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -306,11 +260,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(endpoint: dnsEndpoint) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(endpoint: dnsEndpoint, timeOutMilliseconds: timeOutMilliseconds);
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }
@@ -328,11 +278,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
-            ClientX client = new ClientX(endpoint: dnsEndpoint) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            ClientX client = new ClientX(endpoint: dnsEndpoint, timeOutMilliseconds: timeOutMilliseconds);
             var data = client.ResolveSync(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
             return data;
         }

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -143,6 +143,7 @@ namespace DnsClientX {
 
                 Client = new HttpClient(handler) {
                     BaseAddress = EndpointConfiguration.BaseUri,
+                    Timeout = TimeSpan.FromMilliseconds(EndpointConfiguration.TimeOut)
                 };
 
 #if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER


### PR DESCRIPTION
## Summary
- add customizable timeout for `HttpClient` usage
- update wire resolver to respect timeout token
- set timeout in all `ClientX` factory calls
- add unit test covering timeout handling

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --verbosity minimal` *(fails: The argument /workspace/DnsClientX/DnsClientX.Tests/bin/Debug/net8.0/DnsClientX.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6857e536f7c0832e9af42d83affd2547