### PR TITLE
Fix double semicolon and add configuration unit test

### DIFF
--- a/DnsClientX.Tests/ConfigurationTests.cs
+++ b/DnsClientX.Tests/ConfigurationTests.cs
@@ -1,0 +1,13 @@
+using System;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ConfigurationTests {
+        [Fact]
+        public void ShouldCreateConfigurationFromHostname() {
+            var config = new Configuration("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
+            Assert.Equal(new Uri("https://1.1.1.1/dns-query"), config.BaseUri);
+            Assert.Equal(443, config.Port);
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -74,7 +74,7 @@ namespace DnsClientX {
         public Configuration(string hostname, DnsRequestFormat requestFormat) {
             hostnames = new List<string> { hostname };
             RequestFormat = requestFormat;
-            baseUriFormat = "https://{0}/dns-query"; ;
+            baseUriFormat = "https://{0}/dns-query";
             BaseUri = new Uri(string.Format(baseUriFormat, hostname));
 
             if (requestFormat == DnsRequestFormat.DnsOverTLS) {


### PR DESCRIPTION
## Summary
- fix extra semicolon in `Configuration` constructor
- add `ConfigurationTests` verifying a configuration can be built

## Testing
- `dotnet test` *(fails: Invalid URI & network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685805608168832eb94d9cb53fae645e