### PR TITLE
Fix progress logger event args

### DIFF
--- a/DnsClientX.Tests/InternalLoggerTests.cs
+++ b/DnsClientX.Tests/InternalLoggerTests.cs
@@ -1,0 +1,33 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class InternalLoggerTests {
+        [Fact]
+        public void WriteProgress_SetsPercentage() {
+            var logger = new InternalLogger();
+            LogEventArgs? args = null;
+            logger.OnProgressMessage += (_, e) => args = e;
+
+            logger.WriteProgress("activity", "operation", 42);
+
+            Assert.NotNull(args);
+            Assert.Equal(42, args!.ProgressPercentage);
+            Assert.Null(args.ProgressCurrentSteps);
+            Assert.Null(args.ProgressTotalSteps);
+        }
+
+        [Fact]
+        public void WriteProgress_WithSteps_SetsPercentage() {
+            var logger = new InternalLogger();
+            LogEventArgs? args = null;
+            logger.OnProgressMessage += (_, e) => args = e;
+
+            logger.WriteProgress("activity", "operation", 75, 1, 4);
+
+            Assert.NotNull(args);
+            Assert.Equal(75, args!.ProgressPercentage);
+            Assert.Equal(1, args.ProgressCurrentSteps);
+            Assert.Equal(4, args.ProgressTotalSteps);
+        }
+    }
+}

--- a/DnsClientX/Logging/InternalLogger.cs
+++ b/DnsClientX/Logging/InternalLogger.cs
@@ -77,7 +77,9 @@ public class InternalLogger {
     }
 
     /// <summary>
-    /// Writes a progress message to the console and invokes the OnProgressMessage event.
+    /// Writes a progress message to the console and invokes the OnProgressMessage event. The
+    /// <see cref="LogEventArgs.ProgressPercentage"/> property of the event is set to
+    /// <paramref name="percentCompleted"/>.
     /// </summary>
     /// <param name="activity">The activity being logged.</param>
     /// <param name="currentOperation">The current operation being logged.</param>
@@ -86,7 +88,7 @@ public class InternalLogger {
     /// <param name="totalSteps">The total steps of the operation (optional).</param>
     public void WriteProgress(string activity, string currentOperation, int percentCompleted, int? currentSteps = null, int? totalSteps = null) {
         lock (_lock) {
-            OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, totalSteps));
+            OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, percentCompleted));
             if (IsProgress) {
                 if (currentSteps.HasValue && totalSteps.HasValue) {
                     Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}% ({3} out of {4})", activity, currentOperation, percentCompleted, currentSteps, totalSteps);
@@ -282,7 +284,7 @@ public class LogEventArgs : EventArgs {
     /// <param name="currentOperation">The current operation.</param>
     /// <param name="currentSteps">The current steps.</param>
     /// <param name="totalSteps">The total steps.</param>
-    /// <param name="percentage">The percentage.</param>
+    /// <param name="percentage">The progress percentage.</param>
     public LogEventArgs(string activity, string currentOperation, int? currentSteps, int? totalSteps, int? percentage) {
         ProgressActivity = activity;
         ProgressCurrentOperation = currentOperation;


### PR DESCRIPTION
## Summary
- fix `WriteProgress` to pass `percentCompleted`
- document progress percentage in `WriteProgress`
- clarify LogEventArgs constructor summary
- add `InternalLoggerTests`

## Testing
- `dotnet build DnsClientX.sln --no-restore`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --verbosity minimal` *(fails: The tests attempt network calls and fail)*

------
https://chatgpt.com/codex/tasks/task_e_68580559b45c832eb861c34f2a40f564