### PR TITLE
Implement IDisposable in ClientX

### DIFF
--- a/DnsClientX.Examples/DemoDispose.cs
+++ b/DnsClientX.Examples/DemoDispose.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    internal static class DemoDispose {
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var response = await client.ResolveFirst("evotec.pl");
+            response?.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DisposeTests {
+        private class DummyHandler : HttpMessageHandler {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            }
+        }
+
+        private class TestHttpClient : HttpClient {
+            public bool Disposed { get; private set; }
+            public TestHttpClient(HttpMessageHandler handler) : base(handler) {
+            }
+            protected override void Dispose(bool disposing) {
+                base.Dispose(disposing);
+                Disposed = true;
+            }
+        }
+
+        [Fact]
+        public void DisposeShouldCleanupResources() {
+            var handler = new DummyHandler();
+            var clientX = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps);
+
+            var testClient = new TestHttpClient(handler) { BaseAddress = clientX.EndpointConfiguration.BaseUri };
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(clientX)!;
+            clients[clientX.EndpointConfiguration.SelectionStrategy] = testClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(clientX, testClient);
+            var handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            handlerField.SetValue(clientX, handler);
+
+            clientX.Dispose();
+
+            Assert.True(testClient.Disposed);
+            Assert.Empty(clients);
+            Assert.Null(clientField.GetValue(clientX));
+            Assert.Null(handlerField.GetValue(clientX));
+        }
+
+        [Fact]
+        public void DisposeCanBeCalledMultipleTimes() {
+            var clientX = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            clientX.Dispose();
+            clientX.Dispose();
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net.Http;
+
+namespace DnsClientX {
+    public partial class ClientX : IDisposable {
+        private bool _disposed;
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the client and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing">True to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing) {
+            if (_disposed) return;
+
+            if (disposing) {
+                lock (_lock) {
+                    foreach (var client in _clients.Values) {
+                        client.Dispose();
+                    }
+                    _clients.Clear();
+
+                    Client?.Dispose();
+                    Client = null;
+                    handler?.Dispose();
+                    handler = null;
+                }
+            }
+
+            _disposed = true;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -11,7 +11,7 @@ namespace DnsClientX {
     /// <summary>
     /// The primary class for sending DNS over HTTPS queries.
     /// </summary>
-    public partial class ClientX {
+    public partial class ClientX : IDisposable {
         /// <summary>
         /// The client
         /// </summary>

--- a/DnsClientX/README.MD
+++ b/DnsClientX/README.MD
@@ -100,6 +100,14 @@ var data = await Client.ResolveAll(domainName, type);
 data
 ```
 
+### Disposing the client
+
+```csharp
+using var client = new ClientX(DnsEndpoint.Cloudflare);
+var result = await client.ResolveFirst("evotec.pl");
+result.Answers
+```
+
 ### Querying DNS over HTTPS with multiple endpoints using Resolve
 
 ```csharp


### PR DESCRIPTION
## Summary
- implement IDisposable pattern on ClientX
- add dispose example
- document disposal in README
- test disposal behaviour

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858060fe318832ea35d8425f6c7c290