### PR TITLE
Ensure UDP client disposed on error

### DIFF
--- a/DnsClientX.Tests/UdpClientDisposeTests.cs
+++ b/DnsClientX.Tests/UdpClientDisposeTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class UdpClientDisposeTests {
+        private class DisposableUdpClient : UdpClient {
+            private readonly Action _onDispose;
+            public DisposableUdpClient(Action onDispose) {
+                _onDispose = onDispose;
+            }
+            protected override void Dispose(bool disposing) {
+                base.Dispose(disposing);
+                _onDispose();
+            }
+        }
+
+        [Fact]
+        public async Task SendQueryOverUdp_ShouldDisposeClientOnException() {
+            bool disposed = false;
+            var originalFactory = DnsWireResolveUdp.UdpClientFactory;
+            DnsWireResolveUdp.UdpClientFactory = () => new DisposableUdpClient(() => disposed = true);
+            var method = typeof(DnsWireResolveUdp).GetMethod("SendQueryOverUdp", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var parameters = new object[] { Array.Empty<byte>(), "bad ip", 53, 100, CancellationToken.None };
+            Task Invoke() => (Task)method.Invoke(null, parameters)!;
+            await Assert.ThrowsAsync<FormatException>(Invoke);
+            Assert.True(disposed);
+            DnsWireResolveUdp.UdpClientFactory = originalFactory;
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -49,9 +49,12 @@
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 
-    <ItemGroup>
-        <Content Include="DnsClientX.ico" />
-    </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DnsClientX.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <Content Include="DnsClientX.ico" />
+  </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
         <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -6,6 +6,7 @@ using System.Threading;
 
 namespace DnsClientX {
     internal class DnsWireResolveUdp {
+        internal static Func<UdpClient> UdpClientFactory { get; set; } = () => new UdpClient();
         /// <summary>
         /// Sends a DNS query in wire format using DNS over UDP (53) and returns the response.
         /// </summary>
@@ -93,7 +94,8 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverUdp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
-            using (var udpClient = new UdpClient()) {
+            var udpClient = UdpClientFactory();
+            try {
                 // Set the server IP address and port number
                 var serverEndpoint = new IPEndPoint(IPAddress.Parse(dnsServer), port);
 
@@ -119,6 +121,8 @@ namespace DnsClientX {
                         throw new TimeoutException("The UDP query timed out.");
                     }
                 }
+            } finally {
+                udpClient.Dispose();
             }
         }
     }


### PR DESCRIPTION
## Summary
- dispose `UdpClient` with try/finally
- expose factory for testing
- test disposal when an exception is thrown

## Testing
- `dotnet test --no-build --filter "FullyQualifiedName~UdpClientDisposeTests"`

------
https://chatgpt.com/codex/tasks/task_e_685805995b1c832eaf19a1256e6b7c0d