### PR TITLE
Enable manual CI runs

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -12,6 +12,7 @@ on:
     pull_request:
         branches:
             - master
+    workflow_dispatch:
 
 env:
     DOTNET_VERSION: '8.x'

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -12,6 +12,7 @@ on:
     pull_request:
         branches:
             - master
+    workflow_dispatch:
 
 env:
     DOTNET_VERSION: '8.x'


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` so GitHub Actions can run on demand

## Testing
- `dotnet build DnsClientX.sln --configuration Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration Release --framework net8.0 --no-build --verbosity minimal` *(fails: Invalid URI: The hostname could not be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_6861abc58b28832ebfa733a354e61187