### PR TITLE
Implement disposal logic for ClientX

### DIFF
--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -154,14 +154,14 @@ namespace DnsClientX.Examples {
         public static async Task ExampleSPF() {
             var domains = new[] { "disneyplus.com" };
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, "1.1.1.1");
-            var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
+            using var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
                 Debug = false
             };
             var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
             Console.WriteLine(data.Answers[0].Data);
 
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, DnsEndpoint.Google);
-            var client1 = new ClientX(DnsEndpoint.GoogleWireFormat, DnsSelectionStrategy.First) {
+            using var client1 = new ClientX(DnsEndpoint.GoogleWireFormat, DnsSelectionStrategy.First) {
                 Debug = false
             };
             var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
@@ -171,7 +171,7 @@ namespace DnsClientX.Examples {
         public static async Task ExampleSPFQuad() {
             var domains = new[] { "disneyplus.com" };
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, "1.1.1.1");
-            var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
+            using var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
                 Debug = false
             };
             var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
@@ -179,7 +179,7 @@ namespace DnsClientX.Examples {
 
             foreach (DnsEndpoint endpoint in Enum.GetValues(typeof(DnsEndpoint))) {
                 HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, endpoint);
-                var client1 = new ClientX(endpoint, DnsSelectionStrategy.First) {
+                using var client1 = new ClientX(endpoint, DnsSelectionStrategy.First) {
                     Debug = false
                 };
                 var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");

--- a/DnsClientX.Examples/DemoRecords.cs
+++ b/DnsClientX.Examples/DemoRecords.cs
@@ -9,7 +9,7 @@ namespace DnsClientX.Examples {
         /// <param name="recordType">The type.</param>
         /// <param name="endpoint">The endpoint.</param>
         public static async Task Demo(string domain, DnsRecordType recordType, DnsEndpoint endpoint) {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
             var caaAnswer = await client.ResolveAll(domain, recordType);
             caaAnswer.DisplayTable();

--- a/DnsClientX.Examples/DemoResolve.cs
+++ b/DnsClientX.Examples/DemoResolve.cs
@@ -48,7 +48,7 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
+                using var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
                     Debug = false
                 };
 

--- a/DnsClientX.Examples/DemoResolveAll.cs
+++ b/DnsClientX.Examples/DemoResolveAll.cs
@@ -48,7 +48,7 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                var client = new ClientX(endpoint) {
+                using var client = new ClientX(endpoint) {
                     Debug = false
                 };
 
@@ -94,7 +94,7 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                var client = new ClientX(endpoint) {
+                using var client = new ClientX(endpoint) {
                     Debug = false
                 };
 

--- a/DnsClientX.Examples/DemoResolveFirst.cs
+++ b/DnsClientX.Examples/DemoResolveFirst.cs
@@ -47,7 +47,7 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                var client = new ClientX(endpoint) {
+                using var client = new ClientX(endpoint) {
                     Debug = false
                 };
 

--- a/DnsClientX.Examples/DemoResolveParallel.cs
+++ b/DnsClientX.Examples/DemoResolveParallel.cs
@@ -49,7 +49,7 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                var client = new ClientX(endpoint) {
+                using var client = new ClientX(endpoint) {
                     Debug = false
                 };
 

--- a/DnsClientX.Examples/DemoResolveParallelDNSBL.cs
+++ b/DnsClientX.Examples/DemoResolveParallelDNSBL.cs
@@ -142,7 +142,7 @@ namespace DnsClientX.Examples {
             // Start the stopwatch before the operation
             stopwatch.Start();
 
-            var client = new ClientX(endpoint) {
+            using var client = new ClientX(endpoint) {
                 Debug = false
             };
 

--- a/DnsClientX.Examples/DemoResolveReturn.cs
+++ b/DnsClientX.Examples/DemoResolveReturn.cs
@@ -57,7 +57,7 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                var client = new ClientX(endpoint) {
+                using var client = new ClientX(endpoint) {
                     Debug = false
                 };
 

--- a/DnsClientX.Examples/DemoResolveWithFilter.cs
+++ b/DnsClientX.Examples/DemoResolveWithFilter.cs
@@ -45,7 +45,7 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
+                using var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
                     Debug = false
                 };
 
@@ -97,7 +97,7 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
+                using var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
                     Debug = false
                 };
 

--- a/DnsClientX.Tests/CancellationTests.cs
+++ b/DnsClientX.Tests/CancellationTests.cs
@@ -20,7 +20,7 @@ namespace DnsClientX.Tests {
         [Fact]
         public async Task ResolveShouldCancelEarly() {
             var handler = new DelayingHandler();
-            var clientX = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            using var clientX = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps);
 
             var customClient = new HttpClient(handler) { BaseAddress = clientX.EndpointConfiguration.BaseUri };
             var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/DnsClientX.Tests/CompareJsonWithDnsWire.cs
+++ b/DnsClientX.Tests/CompareJsonWithDnsWire.cs
@@ -8,10 +8,10 @@ namespace DnsClientX.Tests {
         [InlineData("evotec.pl", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.AAAA)]
         [InlineData("www.microsoft.com", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.CNAME)]
         public async Task CompareAnswersRecord(string name, DnsEndpoint endpoint, DnsEndpoint endpointCompare, DnsRecordType resourceRecordType) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll(name, resourceRecordType);
 
-            var ClientWire = new ClientX(endpointCompare);
+            using var ClientWire = new ClientX(endpointCompare);
             DnsAnswer[] aAnswersWire = await ClientWire.ResolveAll(name, resourceRecordType);
 
             // Sort the arrays by Name, Type, and Data

--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -46,7 +46,7 @@ namespace DnsClientX.Tests {
             var results = new Dictionary<DnsEndpoint, (DnsResponse response, string? error)>();
 
             // Get primary endpoint result
-            var primaryClient = new ClientX(primaryEndpoint);
+            using var primaryClient = new ClientX(primaryEndpoint);
             var primaryResult = await GetResponseWithRetry(primaryClient, name, resourceRecordType, primaryEndpoint, output);
             results[primaryEndpoint] = primaryResult;
 
@@ -57,7 +57,7 @@ namespace DnsClientX.Tests {
 
             // Get all other endpoint results
             foreach (var endpoint in allEndpoints) {
-                var client = new ClientX(endpoint);
+                using var client = new ClientX(endpoint);
                 var result = await GetResponseWithRetry(client, name, resourceRecordType, endpoint, output);
                 results[endpoint] = result;
 
@@ -199,7 +199,7 @@ namespace DnsClientX.Tests {
 
             var primaryEndpoint = DnsEndpoint.Cloudflare;
 
-            var Client = new ClientX(primaryEndpoint);
+            using var Client = new ClientX(primaryEndpoint);
             DnsResponse aAnswersPrimary = await Client.Resolve(name, resourceRecordType);
 
             foreach (var endpointCompare in Enum.GetValues(typeof(DnsEndpoint)).Cast<DnsEndpoint>()) {
@@ -212,7 +212,7 @@ namespace DnsClientX.Tests {
 
                 output.WriteLine("Provider: " + endpointCompare.ToString());
 
-                var ClientToCompare = new ClientX(endpointCompare);
+                using var ClientToCompare = new ClientX(endpointCompare);
                 DnsResponse aAnswersToCompare = await ClientToCompare.Resolve(name, resourceRecordType);
 
                 var sortedAAnswers = aAnswersPrimary.Answers.OrderBy(a => a.Name).ThenBy(a => a.Type).ThenBy(a => a.Data).ToArray();

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -43,7 +43,7 @@ namespace DnsClientX.Tests {
             var results = new Dictionary<DnsEndpoint, (DnsAnswer[] answers, string? error, DnsResponseCode status)>();
 
             // Get primary endpoint result
-            var primaryClient = new ClientX(primaryEndpoint);
+            using var primaryClient = new ClientX(primaryEndpoint);
             var primaryAnswers = await GetAnswersWithRetry(primaryClient, name, resourceRecordType, primaryEndpoint, output);
             results[primaryEndpoint] = primaryAnswers;
 
@@ -54,7 +54,7 @@ namespace DnsClientX.Tests {
 
             // Get all other endpoint results
             foreach (var endpoint in allEndpoints) {
-                var client = new ClientX(endpoint);
+                using var client = new ClientX(endpoint);
                 var result = await GetAnswersWithRetry(client, name, resourceRecordType, endpoint, output);
                 results[endpoint] = result;
 
@@ -180,7 +180,7 @@ namespace DnsClientX.Tests {
 
             var primaryEndpoint = DnsEndpoint.Cloudflare;
 
-            var Client = new ClientX(primaryEndpoint);
+            using var Client = new ClientX(primaryEndpoint);
             DnsAnswer[] aAnswersPrimary = await Client.ResolveAll(name, resourceRecordType);
 
             foreach (var endpointCompare in Enum.GetValues(typeof(DnsEndpoint)).Cast<DnsEndpoint>()) {
@@ -191,7 +191,7 @@ namespace DnsClientX.Tests {
                     continue;
                 }
                 output.WriteLine("Provider: " + endpointCompare.ToString());
-                var clientToCompare = new ClientX(endpointCompare);
+                using var clientToCompare = new ClientX(endpointCompare);
                 DnsAnswer[] aAnswersToCompare = await clientToCompare.ResolveAll(name, resourceRecordType);
 
                 var sortedAAnswers = aAnswersPrimary.OrderBy(a => a.Name).ThenBy(a => a.Type).ThenBy(a => a.Data).ToArray();
@@ -225,9 +225,9 @@ namespace DnsClientX.Tests {
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNSFamily)]
         public async Task CompareRecordTextMultiline(string name, DnsRecordType resourceRecordType, DnsEndpoint primaryEndpoint, DnsEndpoint endpointCompare) {
-            var Client = new ClientX(primaryEndpoint);
+            using var Client = new ClientX(primaryEndpoint);
             DnsAnswer[] aAnswersPrimary = await Client.ResolveAll(name, resourceRecordType);
-            var ClientToCompare = new ClientX(endpointCompare);
+            using var ClientToCompare = new ClientX(endpointCompare);
             DnsAnswer[] aAnswersToCompare = await ClientToCompare.ResolveAll(name, resourceRecordType);
 
             // we focus only on SPF1 TXT records

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -23,7 +23,7 @@ namespace DnsClientX.Tests {
             var results = new Dictionary<DnsEndpoint, (DnsResponse response, string? error)>();
 
             // Get primary endpoint result
-            var primaryClient = new ClientX(primaryEndpoint);
+            using var primaryClient = new ClientX(primaryEndpoint);
             var primaryResult = await GetResponseWithRetry(primaryClient, name, resourceRecordType, filter, primaryEndpoint, output);
             results[primaryEndpoint] = primaryResult;
 
@@ -34,7 +34,7 @@ namespace DnsClientX.Tests {
 
             // Get all other endpoint results
             foreach (var endpoint in allEndpoints) {
-                var client = new ClientX(endpoint);
+                using var client = new ClientX(endpoint);
                 var result = await GetResponseWithRetry(client, name, resourceRecordType, filter, endpoint, output);
                 results[endpoint] = result;
 
@@ -151,7 +151,7 @@ namespace DnsClientX.Tests {
 
             var primaryEndpoint = DnsEndpoint.Cloudflare;
 
-            var Client = new ClientX(primaryEndpoint);
+            using var Client = new ClientX(primaryEndpoint);
             DnsResponse aAnswersPrimary = await Client.ResolveFilter(name, resourceRecordType, filter);
 
             foreach (var endpointCompare in Enum.GetValues(typeof(DnsEndpoint)).Cast<DnsEndpoint>()) {
@@ -165,7 +165,7 @@ namespace DnsClientX.Tests {
 
                 output.WriteLine("Provider: " + endpointCompare.ToString());
 
-                var ClientToCompare = new ClientX(endpointCompare);
+                using var ClientToCompare = new ClientX(endpointCompare);
                 DnsResponse aAnswersToCompare = await ClientToCompare.ResolveFilter(name, resourceRecordType, filter);
 
                 var sortedAAnswers = aAnswersPrimary.Answers.OrderBy(a => a.Name).ThenBy(a => a.Type)
@@ -243,7 +243,7 @@ namespace DnsClientX.Tests {
         public async Task CompareRecordsMulti(string[] names, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             string filter = "v=spf1";
             var primaryEndpoint = DnsEndpoint.Cloudflare;
-            var Client = new ClientX(primaryEndpoint);
+            using var Client = new ClientX(primaryEndpoint);
 
             DnsResponse[] aAnswersPrimary = await Client.ResolveFilter(names, resourceRecordType, filter);
 
@@ -256,7 +256,7 @@ namespace DnsClientX.Tests {
                     continue;
                 }
 
-                var ClientToCompare = new ClientX(endpointCompare);
+                using var ClientToCompare = new ClientX(endpointCompare);
                 DnsResponse[] aAnswersToCompare = await ClientToCompare.ResolveFilter(names, resourceRecordType, filter);
 
                 for (int j = 0; j < aAnswersPrimary.Length; j++) {

--- a/DnsClientX.Tests/Quad9ReliabilityFix.cs
+++ b/DnsClientX.Tests/Quad9ReliabilityFix.cs
@@ -28,7 +28,7 @@ namespace DnsClientX.Tests {
                 attempt++;
                 try {
                     // Create a fresh client for each attempt to avoid connection reuse issues
-                    var client = new ClientX(endpoint) {
+                    using var client = new ClientX(endpoint) {
                         Debug = false
                     };
 
@@ -73,7 +73,7 @@ namespace DnsClientX.Tests {
             output.WriteLine(new string('=', 50));
 
             foreach (var provider in reliableProviders) {
-                var client = new ClientX(provider) { Debug = false };
+                using var client = new ClientX(provider) { Debug = false };
 
                 try {
                     var response = await client.Resolve(domain, DnsRecordType.A);

--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -17,7 +17,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll("github.com", DnsRecordType.TXT);
             foreach (DnsAnswer answer in aAnswers) {
                 Assert.True(answer.Name == "github.com");
@@ -43,7 +43,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll("evotec.pl", DnsRecordType.A);
             foreach (DnsAnswer answer in aAnswers) {
                 Assert.True(answer.Name == "evotec.pl");
@@ -68,7 +68,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForTXT_Sync(DnsEndpoint endpoint) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = Client.ResolveAllSync("github.com", DnsRecordType.TXT);
             foreach (DnsAnswer answer in aAnswers) {
                 Assert.True(answer.Name == "github.com");
@@ -94,7 +94,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForA_Sync(DnsEndpoint endpoint) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = Client.ResolveAllSync("evotec.pl", DnsRecordType.A);
             foreach (DnsAnswer answer in aAnswers) {
                 Assert.True(answer.Name == "evotec.pl");

--- a/DnsClientX.Tests/ResolveFirst.cs
+++ b/DnsClientX.Tests/ResolveFirst.cs
@@ -17,7 +17,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             var answer = await Client.ResolveFirst("github.com", DnsRecordType.TXT);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "github.com");
@@ -42,7 +42,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             var answer = await Client.ResolveFirst("evotec.pl", DnsRecordType.A);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "evotec.pl");
@@ -66,7 +66,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForTXT_Sync(DnsEndpoint endpoint) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             var answer = Client.ResolveFirstSync("github.com", DnsRecordType.TXT);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "github.com");
@@ -91,7 +91,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForA_Sync(DnsEndpoint endpoint) {
-            var Client = new ClientX(endpoint);
+            using var Client = new ClientX(endpoint);
             var answer = Client.ResolveFirstSync("evotec.pl", DnsRecordType.A);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "evotec.pl");

--- a/DnsClientX.Tests/ResolveHttpRequestException.cs
+++ b/DnsClientX.Tests/ResolveHttpRequestException.cs
@@ -39,7 +39,7 @@ namespace DnsClientX.Tests {
         /// </summary>
         public async Task ShouldHandleHttpRequestExceptionWithoutInner() {
             var handler = new ThrowingHandler();
-            var clientX = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            using var clientX = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps);
 
             var customClient = new HttpClient(handler) { BaseAddress = clientX.EndpointConfiguration.BaseUri };
             var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/DnsClientX.Tests/ResolveSync.cs
+++ b/DnsClientX.Tests/ResolveSync.cs
@@ -87,7 +87,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXTSync(DnsEndpoint endpoint)
         {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT);
 
             Assert.True(response.Answers.Length > 0, "Expected at least one answer");
@@ -114,7 +114,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForFirstSyncTXT(DnsEndpoint endpoint)
         {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT);
 
             Assert.True(response.Answers.Length > 0, "Expected at least one answer");
@@ -139,7 +139,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForAllSyncTXT(DnsEndpoint endpoint)
         {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT);
 
             Assert.True(response.Answers.Length > 0, "Expected at least one answer");
@@ -166,7 +166,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForASync(DnsEndpoint endpoint)
         {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var response = await TryResolveWithDiagnostics(client, "evotec.pl", DnsRecordType.A);
 
             Assert.True(response.Answers.Length > 0, "Expected at least one answer");
@@ -192,7 +192,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForPTRSync(DnsEndpoint endpoint) {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var response = client.ResolveSync("1.1.1.1", DnsRecordType.PTR);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Data == "one.one.one.one");
@@ -205,7 +205,7 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData(DnsEndpoint.Cloudflare)]
         public void ShouldWorkForMultipleDomainsSync(DnsEndpoint endpoint) {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var domains = new[] { "evotec.pl", "google.com" };
             var responses = client.ResolveSync(domains, DnsRecordType.A);
             foreach (var domain in domains) {
@@ -221,7 +221,7 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData(DnsEndpoint.Cloudflare)]
         public void ShouldWorkForMultipleTypesSync(DnsEndpoint endpoint) {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var types = new[] { DnsRecordType.A, DnsRecordType.TXT };
             var responses = client.ResolveSync("evotec.pl", types);
             foreach (var type in types) {
@@ -248,7 +248,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForFirstSyncA(DnsEndpoint endpoint) {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var answer = client.ResolveFirstSync("evotec.pl", DnsRecordType.A);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "evotec.pl");
@@ -270,7 +270,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForAllSyncA(DnsEndpoint endpoint) {
-            var client = new ClientX(endpoint);
+            using var client = new ClientX(endpoint);
             var answers = client.ResolveAllSync("evotec.pl", DnsRecordType.A);
             foreach (DnsAnswer answer in answers) {
                 Assert.True(answer.Name == "evotec.pl");

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Http;
+
+namespace DnsClientX {
+    public partial class ClientX : IDisposable {
+        private bool _disposed;
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes managed resources.
+        /// </summary>
+        /// <param name="disposing">Whether managed resources should be disposed.</param>
+        protected virtual void Dispose(bool disposing) {
+            if (!_disposed) {
+                if (disposing) {
+                    lock (_lock) {
+                        foreach (HttpClient client in _clients.Values) {
+                            client.Dispose();
+                        }
+                        _clients.Clear();
+                        Client?.Dispose();
+                        handler?.Dispose();
+                    }
+                }
+
+                _disposed = true;
+            }
+        }
+
+        ~ClientX() {
+            Dispose(disposing: false);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This library supports multiple NET versions:
 - [x] Supports parallel queries
 - [x] No external dependencies on .NET 6, .NET 7 and .NET 8
 - [x] Minimal dependencies on .NET Standard 2.0 and .NET 4.7.2
+- [x] Implements IDisposable to release cached HttpClient resources
 
 ## Understanding DNS Query Behavior
 
@@ -343,16 +344,16 @@ data.Answers
 ### Querying DNS over HTTPS via defined endpoint using ResolveAll
 
 ```csharp
-var Client = new ClientX(DnsEndpoint.OpenDNS);
-var data = await Client.ResolveAll(domainName, type);
-data
+using var client = new ClientX(DnsEndpoint.OpenDNS);
+var data = await client.ResolveAll(domainName, type);
 ```
+Because `ClientX` implements `IDisposable`, wrapping it in a `using` statement ensures internal `HttpClient` instances are released.
 
 ### Querying DNS over HTTPS with single endpoint using ResolveAll
 
 ```csharp
-var Client = new ClientX(DnsEndpoint.OpenDNS);
-var data = await Client.ResolveAll(domainName, type);
+using var client = new ClientX(DnsEndpoint.OpenDNS);
+var data = await client.ResolveAll(domainName, type);
 data
 ```
 
@@ -401,7 +402,7 @@ foreach (var endpoint in dnsEndpoints) {
     }
 
     // Create a new client for each endpoint
-    var client = new ClientX(endpoint) {
+    using var client = new ClientX(endpoint) {
         Debug = false
     };
 


### PR DESCRIPTION
## Summary
- implement `IDisposable` for `ClientX` and dispose cached `HttpClient`
- use `using var` where `ClientX` instances are created
- document disposing requirement in README

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_686273cf5398832eb0d71c0e9854fca9