### PR TITLE
Fix AddServerDetails when Questions is null

### DIFF
--- a/DnsClientX.Examples/HelpersSpectre.cs
+++ b/DnsClientX.Examples/HelpersSpectre.cs
@@ -43,7 +43,7 @@ namespace DnsClientX.Examples {
             table.AddColumn("Questions");
             table.AddColumn("Answers");
 
-            var questions = response.Questions == null
+            var questions = response.Questions.Length == 0
                 ? string.Empty
                 : string.Join(", ", response.Questions.Select(q => $"{q.Name} => {q.Type}"));
 
@@ -72,10 +72,10 @@ namespace DnsClientX.Examples {
             table.AddColumn("Server");
             table.AddColumn("Answers");
 
-            var questions = response.Questions == null
+            var questions = response.Questions.Length == 0
                 ? string.Empty
                 : string.Join(", ", response.Questions.Select(q => $"{q.Name} => {q.Type}"));
-            var server = response.Questions == null
+            var server = response.Questions.Length == 0
                 ? string.Empty
                 : string.Join(Environment.NewLine, response.Questions.Select(q => $"HostName: {q.HostName}{Environment.NewLine}Port: {q.Port}{Environment.NewLine}RequestFormat: {q.RequestFormat}{Environment.NewLine}BaseUri: {q.BaseUri}"));
 

--- a/DnsClientX.Tests/QueryDnsSpecialCases.cs
+++ b/DnsClientX.Tests/QueryDnsSpecialCases.cs
@@ -24,7 +24,8 @@ namespace DnsClientX.Tests {
             var response = await ClientX.QueryDns("spf-a.anotherexample.com", DnsRecordType.A, endpoint);
             Assert.True(response.Answers.Length == 0);
             Assert.True(response.Status != DnsResponseCode.NoError);
-            if (response.Questions != null) {
+            Assert.NotNull(response.Questions);
+            if (response.Questions.Length > 0) {
                 Assert.True(response.Questions.Length == 1);
                 foreach (DnsQuestion question in response.Questions) {
                     Assert.True(question.Name == "spf-a.anotherexample.com");

--- a/DnsClientX.Tests/TcpTimeoutTests.cs
+++ b/DnsClientX.Tests/TcpTimeoutTests.cs
@@ -19,7 +19,7 @@ namespace DnsClientX.Tests {
             // With such a short timeout, it should either timeout or complete very quickly
             Assert.True(response.Status != DnsResponseCode.NoError || response.Status == DnsResponseCode.NoError);
             // This test mainly ensures no exception is thrown and the timeout mechanism is in place
-            Assert.True(response.Questions == null || response.Questions.Length > 0);
+            Assert.NotNull(response.Questions);
         }
 
         [Fact(Skip = "Skipped on macOS due to platform-specific issues")]
@@ -34,7 +34,7 @@ namespace DnsClientX.Tests {
 
             // This should work normally - though it might still fail if DNS resolution fails
             // We just check that it doesn't throw an exception and returns a response
-            Assert.True(response.Questions == null || response.Questions.Length > 0);
+            Assert.NotNull(response.Questions);
         }
     }
 }

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -110,9 +110,7 @@ namespace DnsClientX {
         /// <param name="configuration"></param>
         internal void AddServerDetails(Configuration configuration) {
             if (Questions == null) {
-                // TODO: This is unexpected. Wrong query? Better handle?
-                return;
-                throw new InvalidOperationException("Questions is not set. This is unexpected. Wrong query?");
+                Questions = Array.Empty<DnsQuestion>();
             }
             for (int i = 0; i < Questions.Length; i++) {
                 Questions[i].HostName = configuration.Hostname;


### PR DESCRIPTION
## Summary
- ensure `AddServerDetails` always sets `Questions` even if provider omits them
- update display helper to handle empty questions list
- update related unit tests

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_686273ba5968832eb122c5fd4ae51e75