### PR TITLE
Handle connection reset and unreachable sockets as transient

### DIFF
--- a/DnsClientX.Tests/TransientDetectionTests.cs
+++ b/DnsClientX.Tests/TransientDetectionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Reflection;
 using Xunit;
 
@@ -73,6 +74,15 @@ namespace DnsClientX.Tests {
             var response = new DnsResponse { Status = DnsResponseCode.NXDomain };
 
             Assert.False(InvokeIsTransientResponse(response));
+        }
+
+        [Theory]
+        [InlineData(SocketError.ConnectionReset)]
+        [InlineData(SocketError.NetworkUnreachable)]
+        public void IsTransient_SocketExceptionSpecificErrors_ShouldBeTrue(SocketError error) {
+            var ex = new SocketException((int)error);
+
+            Assert.True(InvokeIsTransient(ex));
         }
     }
 }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -174,12 +175,19 @@ namespace DnsClientX {
                 }
             }
 
+            if (ex is SocketException socketEx) {
+                if (socketEx.SocketErrorCode == SocketError.ConnectionReset ||
+                    socketEx.SocketErrorCode == SocketError.NetworkUnreachable) {
+                    return true;
+                }
+            }
+
             // Network and timeout-related exceptions
             return ex is DnsClientException ||
                    ex is TaskCanceledException ||
                    ex is TimeoutException ||
                    ex is HttpRequestException ||
-                   ex is System.Net.Sockets.SocketException ||
+                   ex is SocketException ||
                    ex is System.IO.IOException ||
                    (ex.InnerException != null && IsTransient(ex.InnerException));
         }


### PR DESCRIPTION
## Summary
- expand `IsTransient` to check specific `SocketError` values
- add unit tests covering connection reset and network unreachable cases

## Testing
- `dotnet test --filter "FullyQualifiedName~TransientDetectionTests"`

------
https://chatgpt.com/codex/tasks/task_e_68627eb6cfdc832e88941912ad6fe785