### PR TITLE
Fix IPv6 format

### DIFF
--- a/DnsClientX.Tests/FormatDnsAddressTests.cs
+++ b/DnsClientX.Tests/FormatDnsAddressTests.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class FormatDnsAddressTests {
+        private static string InvokeFormatDnsAddress(string ip) {
+            MethodInfo method = typeof(SystemInformation).GetMethod("FormatDnsAddress", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var address = IPAddress.Parse(ip);
+            return (string)method.Invoke(null, new object[] { address })!;
+        }
+
+        [Fact]
+        public void FormatIpv4_ReturnsSameString() {
+            var result = InvokeFormatDnsAddress("1.1.1.1");
+            Assert.Equal("1.1.1.1", result);
+        }
+
+        [Theory]
+        [InlineData("2001:db8::1", "[2001:db8::1]")]
+        [InlineData("fe80::1%12", "[fe80::1]")]
+        public void FormatIpv6_RemovesZoneAndAddsBrackets(string input, string expected) {
+            var result = InvokeFormatDnsAddress(input);
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -161,7 +161,11 @@ namespace DnsClientX {
 
             if (address.AddressFamily == AddressFamily.InterNetworkV6) {
                 // Remove zone identifier (e.g., %15) for IPv6 addresses
-                addressString = addressString.Split('%')[0];
+                int zoneIndex = addressString.IndexOf('%');
+                if (zoneIndex > -1) {
+                    addressString = addressString.Substring(0, zoneIndex);
+                }
+
                 // Wrap IPv6 addresses in brackets for proper DNS formatting
                 addressString = $"[{addressString}]";
             }


### PR DESCRIPTION
## Summary
- handle IPv6 zone indices properly in `FormatDnsAddress`
- wrap IPv6 output in brackets
- add tests for `FormatDnsAddress`

## Testing
- `dotnet build DnsClientX.sln -c Release -v minimal`
- `dotnet test DnsClientX.sln -c Release --filter "FullyQualifiedName~FormatDnsAddressTests" -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68627ead9c98832ea170c4fefacdc5d8