### PR TITLE
Add server port and protocol to minimal DNS answers

### DIFF
--- a/DnsClientX/Definitions/DnsAnswerMinimal.cs
+++ b/DnsClientX/Definitions/DnsAnswerMinimal.cs
@@ -39,6 +39,16 @@ namespace DnsClientX {
         public string Data { get; internal set; }
 
         /// <summary>
+        /// Gets the port of the DNS server that provided the answer.
+        /// </summary>
+        public int Port { get; internal set; }
+
+        /// <summary>
+        /// Gets the protocol used to obtain the DNS answer.
+        /// </summary>
+        public DnsRequestFormat RequestFormat { get; internal set; }
+
+        /// <summary>
         /// Performs an explicit conversion from <see cref="DnsAnswer"/> to <see cref="DnsAnswerMinimal"/>.
         /// </summary>
         /// <param name="dnsAnswer">The DNS answer.</param>

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -61,10 +61,16 @@ namespace DnsClientX {
         public DnsAnswer[] Answers { get; set; }
 
         /// <summary>
-        /// Gets the answers in their minimal form
+        /// Gets the answers in their minimal form.
         /// </summary>
         [JsonIgnore]
-        public DnsAnswerMinimal[] AnswersMinimal => Answers.Select(answer => (DnsAnswerMinimal)answer).ToArray();
+        private DnsAnswerMinimal[] _answersMinimal;
+
+        /// <summary>
+        /// Gets the answers in their minimal form.
+        /// </summary>
+        [JsonIgnore]
+        public DnsAnswerMinimal[] AnswersMinimal => _answersMinimal ?? Answers.Select(answer => (DnsAnswerMinimal)answer).ToArray();
 
         /// <summary>
         /// The authority records provided by the DNS server.
@@ -117,6 +123,17 @@ namespace DnsClientX {
                 Questions[i].BaseUri = configuration.BaseUri;
                 Questions[i].RequestFormat = configuration.RequestFormat;
                 Questions[i].Port = configuration.Port;
+            }
+
+            if (Answers != null) {
+                _answersMinimal = Answers.Select(answer => new DnsAnswerMinimal {
+                    Name = answer.Name,
+                    TTL = answer.TTL,
+                    Type = answer.Type,
+                    Data = answer.Data,
+                    Port = configuration.Port,
+                    RequestFormat = configuration.RequestFormat
+                }).ToArray();
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend `DnsAnswerMinimal` with `Port` and `RequestFormat`
- keep cached minimal answers in `DnsResponse`
- populate minimal answers with server details in `AddServerDetails`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: The SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_68627ea4ca8c832eac94e5913717eacd