### PR TITLE
Cache DNS server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,10 @@ var response = await ClientX.QueryDns("google.com", DnsRecordType.A, DnsEndpoint
 // Use system DNS with TCP only
 var response = await ClientX.QueryDns("google.com", DnsRecordType.A, DnsEndpoint.SystemTcp);
 
-// Get system DNS servers programmatically
+// Get system DNS servers programmatically (cached)
 var systemDnsServers = SystemInformation.GetDnsFromActiveNetworkCard();
+// Refresh the cache when network configuration changes
+var refreshedDnsServers = SystemInformation.GetDnsFromActiveNetworkCard(refresh: true);
 ```
 
 ### Advantages of System DNS


### PR DESCRIPTION
## Summary
- cache DNS server list in `SystemInformation`
- mention cache behaviour in README

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: tests cannot reach network)*

------
https://chatgpt.com/codex/tasks/task_e_68627e810474832ea81efa47aebf3366