### PR TITLE
Enable HTTP configuration overrides

### DIFF
--- a/DnsClientX.Tests/ConfigurationOverrideTests.cs
+++ b/DnsClientX.Tests/ConfigurationOverrideTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net.Http;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ConfigurationOverrideTests {
+        [Fact]
+        public void ShouldOverrideUserAgent() {
+            const string customUa = "MyApp/1.0";
+            using var client = new ClientX(DnsEndpoint.Cloudflare, userAgent: customUa);
+            Assert.Equal(customUa, client.EndpointConfiguration.UserAgent);
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var httpClient = (HttpClient)clientField.GetValue(client)!;
+            Assert.Contains(customUa, httpClient.DefaultRequestHeaders.UserAgent.ToString());
+        }
+
+        [Fact]
+        public void ShouldOverrideHttpVersion() {
+            var version = new Version(1, 1);
+            using var client = new ClientX(DnsEndpoint.Cloudflare, httpVersion: version);
+            Assert.Equal(version, client.EndpointConfiguration.HttpVersion);
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var httpClient = (HttpClient)clientField.GetValue(client)!;
+#if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER
+            Assert.Equal(version, httpClient.DefaultRequestVersion);
+#endif
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -37,14 +37,19 @@ namespace DnsClientX {
         public Uri BaseUri { get; private set; }
 
         /// <summary>
-        /// The preferred HTTP request version to use.
+        /// The preferred HTTP request version to use by default.
         /// </summary>
-        public static readonly Version HttpVersion = new(2, 0);
+        public static readonly Version DefaultHttpVersion = new(2, 0);
 
         /// <summary>
-        /// The User-Agent header value to send along with DNS requests.
+        /// Gets or sets the HTTP version used when communicating with the DNS provider.
         /// </summary>
-        public string UserAgent = "DnsClientX";
+        public Version HttpVersion { get; set; } = DefaultHttpVersion;
+
+        /// <summary>
+        /// Gets or sets the User-Agent header value to send along with DNS requests.
+        /// </summary>
+        public string UserAgent { get; set; } = "DnsClientX";
 
         /// <summary>
         /// Time-out for DNS Query in milliseconds. Valid only for UDP (for now).

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -93,10 +93,21 @@ namespace DnsClientX {
         /// <param name="endpoint">The endpoint.</param>
         /// <param name="dnsSelectionStrategy">Dns selection strategy</param>
         /// <param name="timeOutMilliseconds"></param>
-        public ClientX(DnsEndpoint endpoint = DnsEndpoint.Cloudflare, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000) {
+        public ClientX(
+            DnsEndpoint endpoint = DnsEndpoint.Cloudflare,
+            DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First,
+            int timeOutMilliseconds = 1000,
+            string? userAgent = null,
+            Version? httpVersion = null) {
             EndpointConfiguration = new Configuration(endpoint, dnsSelectionStrategy) {
                 TimeOut = timeOutMilliseconds
             };
+            if (userAgent != null) {
+                EndpointConfiguration.UserAgent = userAgent;
+            }
+            if (httpVersion != null) {
+                EndpointConfiguration.HttpVersion = httpVersion;
+            }
             ConfigureClient();
         }
 
@@ -106,10 +117,21 @@ namespace DnsClientX {
         /// <param name="hostname">The hostname.</param>
         /// <param name="requestFormat">The request format.</param>
         /// <param name="timeOutMilliseconds"></param>
-        public ClientX(string hostname, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000) {
+        public ClientX(
+            string hostname,
+            DnsRequestFormat requestFormat,
+            int timeOutMilliseconds = 1000,
+            string? userAgent = null,
+            Version? httpVersion = null) {
             EndpointConfiguration = new Configuration(hostname, requestFormat) {
                 TimeOut = timeOutMilliseconds
             };
+            if (userAgent != null) {
+                EndpointConfiguration.UserAgent = userAgent;
+            }
+            if (httpVersion != null) {
+                EndpointConfiguration.HttpVersion = httpVersion;
+            }
             ConfigureClient();
         }
 
@@ -119,10 +141,21 @@ namespace DnsClientX {
         /// <param name="baseUri">The base URI.</param>
         /// <param name="requestFormat">The request format.</param>
         /// <param name="timeOutMilliseconds"></param>
-        public ClientX(Uri baseUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000) {
+        public ClientX(
+            Uri baseUri,
+            DnsRequestFormat requestFormat,
+            int timeOutMilliseconds = 1000,
+            string? userAgent = null,
+            Version? httpVersion = null) {
             EndpointConfiguration = new Configuration(baseUri, requestFormat) {
                 TimeOut = timeOutMilliseconds
             };
+            if (userAgent != null) {
+                EndpointConfiguration.UserAgent = userAgent;
+            }
+            if (httpVersion != null) {
+                EndpointConfiguration.HttpVersion = httpVersion;
+            }
             ConfigureClient();
         }
 
@@ -160,7 +193,7 @@ namespace DnsClientX {
             };
 
 #if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER
-            client.DefaultRequestVersion = Configuration.HttpVersion;
+            client.DefaultRequestVersion = EndpointConfiguration.HttpVersion;
 #endif
             // Set the user agent to the default value
             client.DefaultRequestHeaders.UserAgent.ParseAdd(EndpointConfiguration.UserAgent);

--- a/README.md
+++ b/README.md
@@ -341,6 +341,13 @@ var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, new Uri("https:/
 data.Answers
 ```
 
+### Customizing HTTP settings
+
+```csharp
+using var client = new ClientX(DnsEndpoint.Cloudflare, userAgent: "MyApp/1.0", httpVersion: new Version(1, 1));
+```
+You can also modify `client.EndpointConfiguration.UserAgent` and `client.EndpointConfiguration.HttpVersion` after construction.
+
 ### Querying DNS over HTTPS via defined endpoint using ResolveAll
 
 ```csharp


### PR DESCRIPTION
## Summary
- expose `UserAgent` and `HttpVersion` on `Configuration`
- allow overriding them via `ClientX` constructors
- document customizing in README
- add tests for user agent and HTTP version overrides

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: remote certificate invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68627e72c4bc832e86bc7316c6b48789