### PR TITLE
Implement disposal example updates

### DIFF
--- a/DnsClientX.Examples/DemoByManualUrl.cs
+++ b/DnsClientX.Examples/DemoByManualUrl.cs
@@ -5,21 +5,21 @@ namespace DnsClientX.Examples {
     public class DemoByManualUrl {
         public static async Task Example() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, "1.1.1.1", dnsRequestFormat: DnsRequestFormat.DnsOverHttpsJSON);
-            ClientX client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
+            using var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
             var data = await client.Resolve("evotec.pl", DnsRecordType.A);
             data.DisplayTable();
         }
 
         public static async Task Example2() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
-            ClientX client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
+            using var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
             var data = await client.Resolve("evotec.pl", DnsRecordType.A);
             data.DisplayTable();
         }
 
         public static async Task ExampleGoogle() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, new Uri("https://8.8.8.8/resolve"), DnsRequestFormat.DnsOverHttpsJSON);
-            ClientX client = new ClientX(new Uri("https://8.8.8.8/resolve"), DnsRequestFormat.DnsOverHttpsJSON);
+            using var client = new ClientX(new Uri("https://8.8.8.8/resolve"), DnsRequestFormat.DnsOverHttpsJSON);
             var data = await client.Resolve("evotec.pl", DnsRecordType.A);
             data.DisplayTable();
         }
@@ -27,7 +27,7 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleTesting() {
             HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverTLS);
-            ClientX client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverTLS) {
+            using var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverTLS) {
                 Debug = false
             };
             var data = await client.Resolve("www.example.com", DnsRecordType.A);
@@ -36,7 +36,7 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleTestingHttpOverPost() {
             HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST);
-            ClientX client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST) {
+            using var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST) {
                 Debug = false
             };
             var data = await client.Resolve("www.example.com", DnsRecordType.A);
@@ -45,7 +45,7 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleTestingUdp() {
             HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, "192.168.241.6", DnsRequestFormat.DnsOverUDP);
-            ClientX client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
+            using var client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
                 Debug = false
             };
             var data = await client.Resolve("www.example.com", DnsRecordType.A);
@@ -55,7 +55,7 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleTestingTcp() {
             HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, "192.168.241.5", DnsRequestFormat.DnsOverTCP);
-            ClientX client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
+            using var client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
                 Debug = false
             };
             var data = await client.Resolve("www.example.com", DnsRecordType.A);

--- a/DnsClientX.Examples/DemoResolveUdpTcp.cs
+++ b/DnsClientX.Examples/DemoResolveUdpTcp.cs
@@ -4,7 +4,7 @@ namespace DnsClientX.Examples {
     internal class DemoResolveUdpTcp {
         public static async Task ExampleTestingUdp() {
             HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.TXT, "192.168.241.6", DnsRequestFormat.DnsOverUDP);
-            ClientX client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
+            using var client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
                 Debug = true
             };
             var data = await client.Resolve("github.com", DnsRecordType.TXT);
@@ -13,7 +13,7 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleTestingTcp() {
             HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.TXT, "192.168.241.5", DnsRequestFormat.DnsOverTCP);
-            ClientX client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
+            using var client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
                 Debug = true
             };
             var data = await client.Resolve("github.com", DnsRecordType.TXT);
@@ -22,7 +22,7 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleTestingUdpWrongServer() {
             HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.TXT, "8.8.1.1", DnsRequestFormat.DnsOverUDP);
-            ClientX client = new ClientX("8.8.1.1", DnsRequestFormat.DnsOverUDP) {
+            using var client = new ClientX("8.8.1.1", DnsRequestFormat.DnsOverUDP) {
                 Debug = true
             };
             var data = await client.Resolve("github.com", DnsRecordType.TXT);
@@ -31,7 +31,7 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleTestingUdpWrongServer1() {
             HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.TXT, "a1-226.akam.net", DnsRequestFormat.DnsOverUDP);
-            ClientX client = new ClientX("a1akam1.net", DnsRequestFormat.DnsOverUDP) {
+            using var client = new ClientX("a1akam1.net", DnsRequestFormat.DnsOverUDP) {
                 Debug = true
             };
             var data = await client.Resolve("github.com", DnsRecordType.TXT);


### PR DESCRIPTION
## Summary
- update examples to show disposing `ClientX`
- ensure client disposal in usage scenarios

## Testing
- `dotnet test DnsClientX.sln --verbosity minimal` *(fails: The SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_68627e5bb780832e9bdda11d24a62305