### PR TITLE
Improve resolv.conf handling

### DIFF
--- a/DnsClientX.Tests/ParseResolvConfTests.cs
+++ b/DnsClientX.Tests/ParseResolvConfTests.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ParseResolvConfTests {
+        [Fact]
+        public void MissingFile_ReturnsEmptyList() {
+            string tempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
+            MethodInfo method = typeof(SystemInformation).GetMethod("ParseResolvConf", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (List<string>)method.Invoke(null, new object[] { tempPath, null })!;
+            Assert.Empty(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- handle missing `/etc/resolv.conf` gracefully
- expose helper `ParseResolvConf` for tests
- add unit test for missing file scenario

## Testing
- `dotnet build DnsClientX.Tests/DnsClientX.Tests.csproj -c Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release --no-build --filter FullyQualifiedName~ParseResolvConfTests`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: SSL connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_686284d95b7c832ebf5a25959025fc22