### PR TITLE
Fix HasMatchingAnswers null handling

### DIFF
--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             var responses = tasks.Select(task => task.Result).ToList();
 
             var filteredResponses = responses
-                .Where(response => HasMatchingAnswers(response.Answers, filter, type))
+                .Where(response => HasMatchingAnswers(response.Answers ?? Array.Empty<DnsAnswer>(), filter, type))
                 .Select(response => {
                     response.Answers = FilterAnswers(response.Answers, filter, type);
                     return response;
@@ -58,7 +58,7 @@ namespace DnsClientX {
             var responses = tasks.Select(task => task.Result).ToList();
 
             var filteredResponses = responses
-                .Where(response => HasMatchingAnswersRegex(response.Answers, regexFilter, type))
+                .Where(response => HasMatchingAnswersRegex(response.Answers ?? Array.Empty<DnsAnswer>(), regexFilter, type))
                 .Select(response => {
                     response.Answers = FilterAnswersRegex(response.Answers, regexFilter, type);
                     return response;
@@ -201,6 +201,10 @@ namespace DnsClientX {
         /// <param name="type">The DNS record type being filtered.</param>
         /// <returns>True if any answer contains a match.</returns>
         private bool HasMatchingAnswers(DnsAnswer[] answers, string filter, DnsRecordType type) {
+            if (answers == null) {
+                return false;
+            }
+
             foreach (var answer in answers) {
                 if (type == DnsRecordType.TXT && answer.Type == DnsRecordType.TXT) {
                     var lines = answer.Data.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
## Summary
- avoid null reference in HasMatchingAnswers
- pass empty array when answers are missing in ResolveFilter

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release --no-build --framework net472` *(fails: invalid argument)*
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release --no-build --framework net8.0` *(fails: 126 tests failed)*
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release --no-build --framework net9.0` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_686284c9c280832e9acec85b271273bf