### PR TITLE
Fix Punycode conversion for invalid input

### DIFF
--- a/DnsClientX.Tests/ConvertToPunycodeTests.cs
+++ b/DnsClientX.Tests/ConvertToPunycodeTests.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ConvertToPunycodeTests {
+        private static string? Invoke(string? input) {
+            MethodInfo method = typeof(ClientX).GetMethod("ConvertToPunycode", BindingFlags.NonPublic | BindingFlags.Static)!;
+            return (string?)method.Invoke(null, new object?[] { input });
+        }
+
+        [Fact]
+        public void ReturnsOriginalForNullOrWhitespace() {
+            Assert.Null(Invoke(null));
+            Assert.Equal("   ", Invoke("   "));
+        }
+
+        [Fact]
+        public void ReturnsOriginalForInvalidDomain() {
+            const string invalid = "a^b.com";
+            Assert.Equal(invalid, Invoke(invalid));
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -251,8 +251,16 @@ namespace DnsClientX {
         /// <param name="domainName"></param>
         /// <returns></returns>
         private static string ConvertToPunycode(string domainName) {
-            IdnMapping idn = new IdnMapping();
-            return idn.GetAscii(domainName);
+            if (string.IsNullOrWhiteSpace(domainName)) {
+                return domainName;
+            }
+
+            try {
+                IdnMapping idn = new IdnMapping();
+                return idn.GetAscii(domainName);
+            } catch {
+                return domainName;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- guard `ConvertToPunycode` from null, whitespace, and invalid input
- add unit tests for the new behavior

## Testing
- `dotnet test` *(fails: The SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_686284c234e4832ea8598e01efd1d952