### PR TITLE
Fix Assert.Fail usage in tests

### DIFF
--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -99,7 +99,7 @@ namespace DnsClientX.Tests {
 
             if (failureRate > 0.2) { // More than 20% of providers failing
                 var allIssues = failedProviders.Concat(inconsistentProviders);
-                Assert.Fail($"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
+                Assert.True(false, $"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
             } else if (problematicProviders > 0) {
                 output.WriteLine($"✅ Acceptable failure rate: {problematicProviders}/{totalProviders} providers ({failureRate:P0}) have issues - likely transient");
             }

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -94,7 +94,7 @@ namespace DnsClientX.Tests {
 
             if (failureRate > 0.2) { // More than 20% of providers failing
                 var allIssues = failedProviders.Concat(inconsistentProviders);
-                Assert.Fail($"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
+                Assert.True(false, $"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
             } else if (problematicProviders > 0) {
                 output.WriteLine($"✅ Acceptable failure rate: {problematicProviders}/{totalProviders} providers ({failureRate:P0}) have issues - likely transient");
             }

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -76,7 +76,7 @@ namespace DnsClientX.Tests {
 
             if (failureRate > 0.2) { // More than 20% of providers failing
                 var allIssues = failedProviders.Concat(inconsistentProviders);
-                Assert.Fail($"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
+                Assert.True(false, $"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
             } else if (problematicProviders > 0) {
                 output.WriteLine($"✅ Acceptable failure rate: {problematicProviders}/{totalProviders} providers ({failureRate:P0}) have issues - likely transient");
             }

--- a/DnsClientX.Tests/Quad9ReliabilityFix.cs
+++ b/DnsClientX.Tests/Quad9ReliabilityFix.cs
@@ -87,7 +87,7 @@ namespace DnsClientX.Tests {
 
                 } catch (Exception ex) {
                     output.WriteLine($"{provider}: ❌ Exception - {ex.GetType().Name}: {ex.Message}");
-                    Assert.Fail($"{provider} threw exception: {ex.Message}");
+                    Assert.True(false, $"{provider} threw exception: {ex.Message}");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace deprecated `Assert.Fail` calls with `Assert.True(false, ...)` across tests

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686284b80850832e85b23b5128b3e29a