### PR TITLE
Fix null handling in ResolveFilter

### DIFF
--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             var responses = tasks.Select(task => task.Result).ToList();
 
             var filteredResponses = responses
-                .Where(response => HasMatchingAnswers(response.Answers, filter, type))
+                .Where(response => HasMatchingAnswers(response.Answers ?? Array.Empty<DnsAnswer>(), filter, type))
                 .Select(response => {
                     response.Answers = FilterAnswers(response.Answers, filter, type);
                     return response;
@@ -58,7 +58,7 @@ namespace DnsClientX {
             var responses = tasks.Select(task => task.Result).ToList();
 
             var filteredResponses = responses
-                .Where(response => HasMatchingAnswersRegex(response.Answers, regexFilter, type))
+                .Where(response => HasMatchingAnswersRegex(response.Answers ?? Array.Empty<DnsAnswer>(), regexFilter, type))
                 .Select(response => {
                     response.Answers = FilterAnswersRegex(response.Answers, regexFilter, type);
                     return response;
@@ -225,6 +225,10 @@ namespace DnsClientX {
         /// <param name="type">The DNS record type being filtered.</param>
         /// <returns>True if any answer contains a match.</returns>
         private bool HasMatchingAnswersRegex(DnsAnswer[] answers, Regex regexFilter, DnsRecordType type) {
+            if (answers == null) {
+                return false;
+            }
+
             foreach (var answer in answers) {
                 if (type == DnsRecordType.TXT && answer.Type == DnsRecordType.TXT) {
                     var lines = answer.Data.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
## Summary
- avoid null answers when filtering responses
- guard against null in `HasMatchingAnswersRegex`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: Unable to resolve DNS queries)*

------
https://chatgpt.com/codex/tasks/task_e_686284d09334832e923e7f106c0032a0