### PR TITLE
Add DS record support

### DIFF
--- a/DnsClientX.Tests/DsRecordTests.cs
+++ b/DnsClientX.Tests/DsRecordTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DsRecordTests {
+        private const string DsString = "20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D";
+
+        [Fact]
+        public void ConvertData_ParsesDsRecord() {
+            var answer = new DnsAnswer {
+                Name = "example.com",
+                Type = DnsRecordType.DS,
+                TTL = 3600,
+                DataRaw = DsString
+            };
+
+            Assert.Equal("20326 RSASHA256 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D", answer.Data);
+        }
+
+        [Fact]
+        public void ProcessRecordData_DecodesDsWireFormat() {
+            byte[] digest = Convert.FromHexString("E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D");
+            byte[] rdata = new byte[4 + digest.Length];
+            rdata[0] = 0x4F; // key tag high byte 20326
+            rdata[1] = 0x66; // key tag low byte
+            rdata[2] = 0x08; // algorithm
+            rdata[3] = 0x02; // digest type
+            Array.Copy(digest, 0, rdata, 4, digest.Length);
+
+            Type wireType = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWire")!;
+            MethodInfo method = wireType.GetMethod("ProcessRecordData", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (string)method.Invoke(null, new object?[] { Array.Empty<byte>(), 0, DnsRecordType.DS, rdata, (ushort)rdata.Length, 0L })!;
+
+            Assert.Equal("20326 RSASHA256 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d", result);
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -213,6 +213,20 @@ namespace DnsClientX {
                 } else {
                     return DataRaw;
                 }
+            } else if (Type == DnsRecordType.DS) {
+                // For DS records, decode the key tag, algorithm, digest type and digest
+                var parts = DataRaw.Split(' ');
+                if (parts.Length >= 4 &&
+                    ushort.TryParse(parts[0], out var keyTag) &&
+                    byte.TryParse(parts[1], out var algVal) &&
+                    byte.TryParse(parts[2], out var digestType)) {
+                    string algorithmName = Enum.IsDefined(typeof(DnsKeyAlgorithm), (int)algVal)
+                        ? ((DnsKeyAlgorithm)algVal).ToString()
+                        : parts[1];
+                    return $"{keyTag} {algorithmName} {digestType} {parts[3]}";
+                } else {
+                    return DataRaw;
+                }
             } else if (Type == DnsRecordType.NSEC) {
                 // This is a NSEC record. Some providers may return non-standard (google) types.
                 // Check if the type is a non-standard type

--- a/DnsClientX/ProtocolDnsWire/DnsWire.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWire.cs
@@ -412,6 +412,17 @@ namespace DnsClientX {
                         return reader.DecodeCAARecord(rdLength);
                     } else if (type == DnsRecordType.DNSKEY) {
                         return reader.DecodeDNSKEYRecord(rdLength);
+                    } else if (type == DnsRecordType.DS) {
+                        if (rdLength < 4) throw new DnsClientException("The record data for DS is not long enough");
+                        ushort keyTag = BinaryPrimitives.ReadUInt16BigEndian(reader.ReadBytes(2));
+                        byte algorithmVal = reader.ReadByte();
+                        byte digestType = reader.ReadByte();
+                        byte[] digestBytes = reader.ReadBytes(rdLength - 4);
+                        string algorithmName = Enum.IsDefined(typeof(DnsKeyAlgorithm), (int)algorithmVal)
+                            ? ((DnsKeyAlgorithm)algorithmVal).ToString()
+                            : algorithmVal.ToString();
+                        string digest = BitConverter.ToString(digestBytes).Replace("-", "").ToLower();
+                        return $"{keyTag} {algorithmName} {digestType} {digest}";
                     } else if (type == DnsRecordType.NSEC) {
                         return reader.DecodeNSECRecord(dnsMessage, rdLength, messageStart);
                     } else {


### PR DESCRIPTION
## Summary
- implement DS record decoding in `DnsAnswer.ConvertData`
- handle DS in DNS wire decoding
- add unit tests for DS JSON and wire decoding

## Testing
- `dotnet test` *(fails: Failed: 126, Passed: 167, Skipped: 14)*

------
https://chatgpt.com/codex/tasks/task_e_6862b587f0d4832e941609e5f650202a