### PR TITLE
Fix null check in IsValidDnsAddress

### DIFF
--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -205,7 +205,9 @@ namespace DnsClientX {
         /// <param name="address">The IP address to validate</param>
         /// <returns>True if the address is valid for DNS use</returns>
         private static bool IsValidDnsAddress(IPAddress address) {
-            if (address == null) return false;
+            if (address is null) {
+                return false;
+            }
 
             // Convert to string for pattern matching
             string ipString = address.ToString();


### PR DESCRIPTION
## Summary
- handle null IPAddress before validation logic

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: SslStream authentication errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862c125b3d4832e9f4d8a97b5aed72e