### PR TITLE
Avoid double-dispose of HttpClient instances

### DIFF
--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DisposeTests {
+        private class TrackingHandler : HttpMessageHandler {
+            public int DisposeCount { get; private set; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            protected override void Dispose(bool disposing) {
+                base.Dispose(disposing);
+                DisposeCount++;
+            }
+        }
+
+        [Fact]
+        public void Client_Dispose_ShouldNotDisposeHttpClientTwice() {
+            var handler = new TrackingHandler();
+            var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
+            using var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(clientX)!;
+            clients[clientX.EndpointConfiguration.SelectionStrategy] = customClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(clientX, customClient);
+
+            clientX.Dispose();
+
+            Assert.Equal(1, handler.DisposeCount);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 
 namespace DnsClientX {
     public partial class ClientX : IDisposable {
         private bool _disposed;
+        private readonly HashSet<HttpClient> _disposedClients = new();
 
         /// <inheritdoc/>
         public void Dispose() {
@@ -20,10 +22,16 @@ namespace DnsClientX {
                 if (disposing) {
                     lock (_lock) {
                         foreach (HttpClient client in _clients.Values) {
-                            client.Dispose();
+                            if (_disposedClients.Add(client)) {
+                                client.Dispose();
+                            }
                         }
                         _clients.Clear();
-                        Client?.Dispose();
+
+                        if (Client != null && _disposedClients.Add(Client)) {
+                            Client.Dispose();
+                        }
+
                         handler?.Dispose();
                     }
                 }


### PR DESCRIPTION
## Summary
- prevent double disposal of HttpClient instances
- add a unit test verifying a client is disposed only once

## Testing
- `dotnet build DnsClientX.sln`
- `dotnet test` *(fails: Failed: 126, Passed: 168, Skipped: 14)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0d82360832e8ac4292616d407fe