### PR TITLE
Fix user agent header initialization

### DIFF
--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -196,6 +196,7 @@ namespace DnsClientX {
             client.DefaultRequestVersion = EndpointConfiguration.HttpVersion;
 #endif
             // Set the user agent to the default value
+            client.DefaultRequestHeaders.UserAgent.Clear();
             client.DefaultRequestHeaders.UserAgent.ParseAdd(EndpointConfiguration.UserAgent);
             client.DefaultRequestHeaders.Accept.Clear();
 


### PR DESCRIPTION
## Summary
- clear any existing `UserAgent` headers before setting ours

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal` *(fails: The SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0d1b3f8832e96ae46d277232004