### PR TITLE
Fix ConvertToPtrFormat trimming

### DIFF
--- a/DnsClientX.Tests/ConvertToPtrFormatTests.cs
+++ b/DnsClientX.Tests/ConvertToPtrFormatTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ConvertToPtrFormatTests {
+        private static string Invoke(string ip) {
+            var client = new ClientX();
+            MethodInfo method = typeof(ClientX).GetMethod("ConvertToPtrFormat", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            return (string)method.Invoke(client, new object[] { ip })!;
+        }
+
+        [Fact]
+        public void TrimsAndConvertsIpv4() {
+            var result = Invoke(" 1.2.3.4 ");
+            Assert.Equal("4.3.2.1.in-addr.arpa", result);
+        }
+
+        [Fact]
+        public void TrimsAndConvertsIpv6() {
+            var result = Invoke(" 2001:db8::1 ");
+            Assert.Equal("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", result);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -269,6 +269,7 @@ namespace DnsClientX {
         /// <param name="ipAddress"></param>
         /// <returns></returns>
         private string ConvertToPtrFormat(string ipAddress) {
+            ipAddress = ipAddress.Trim();
             if (IPAddress.TryParse(ipAddress, out IPAddress? ip)) {
                 if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork) {
                     // IPv4


### PR DESCRIPTION
## Summary
- trim PTR input to allow leading/trailing spaces
- add regression tests for ConvertToPtrFormat

## Testing
- `dotnet test --verbosity minimal` *(fails: SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0c94d3c832e98d14273a6b6887e