### PR TITLE
Fix retry delay and add test

### DIFF
--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Diagnostics;
 using Xunit;
 
 namespace DnsClientX.Tests {
@@ -21,6 +22,28 @@ namespace DnsClientX.Tests {
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
             Assert.Equal(3, attempts);
+        }
+
+        [Fact]
+        public async Task ShouldDelayBetweenRetries() {
+            int attempts = 0;
+            Func<Task<int>> action = () => {
+                attempts++;
+                throw new TimeoutException();
+            };
+
+            MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
+            Task<int> Invoke() {
+                var generic = method.MakeGenericMethod(typeof(int));
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50 })!;
+            }
+
+            var sw = Stopwatch.StartNew();
+            await Assert.ThrowsAsync<TimeoutException>(Invoke);
+            sw.Stop();
+
+            Assert.Equal(3, attempts);
+            Assert.True(sw.ElapsedMilliseconds >= 100);
         }
     }
 }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -115,8 +115,10 @@ namespace DnsClientX {
                         // This was the last attempt, rethrow the exception
                         throw;
                     }
+
                     // Not the last attempt, wait and retry with normal delay
                     await Task.Delay(delayMs);
+                    continue;
                 }
             }
 


### PR DESCRIPTION
## Summary
- add `continue` after delaying in `RetryAsync`
- add Stopwatch-based unit test to ensure delay occurs

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: network-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0c3fa50832e8c4515e3bbff6f9d