### PR TITLE
Fix Base64 decode when DataRaw empty

### DIFF
--- a/DnsClientX.Tests/DnsAnswerBase64Tests.cs
+++ b/DnsClientX.Tests/DnsAnswerBase64Tests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsAnswerBase64Tests {
+        [Fact]
+        public void ConvertData_TlsaEmptyDataRaw_ReturnsEmpty() {
+            var answer = new DnsAnswer {
+                Name = "example.com",
+                Type = DnsRecordType.TLSA,
+                TTL = 3600,
+                DataRaw = string.Empty
+            };
+
+            Assert.Equal(string.Empty, answer.Data);
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -261,6 +261,9 @@ namespace DnsClientX {
                     return DataRaw;
                 } else {
                     // Handle Base64 format
+                    if (string.IsNullOrEmpty(DataRaw)) {
+                        return DataRaw;
+                    }
                     parts = Convert.FromBase64String(DataRaw);
                 }
 
@@ -279,12 +282,15 @@ namespace DnsClientX {
                 // For PTR records, decode the domain name from the record data
                 try {
                     // First try to decode as Base64
-                    var output = Encoding.UTF8.GetString(Convert.FromBase64String(DataRaw));
-                    return ConvertSpecialFormatToDotted(output);
+                    if (!string.IsNullOrEmpty(DataRaw)) {
+                        var output = Encoding.UTF8.GetString(Convert.FromBase64String(DataRaw));
+                        return ConvertSpecialFormatToDotted(output);
+                    }
                 } catch (FormatException) {
-                    // If it's not Base64, try to handle it as a special format directly
-                    return ConvertSpecialFormatToDotted(DataRaw);
+                    // Ignore and try special format directly
                 }
+
+                return ConvertSpecialFormatToDotted(DataRaw);
             } else if (Type == DnsRecordType.NAPTR) {
                 // NAPTR record (RFC 3403)
                 // Handles Base64, Hex, or Plain Text DataRaw
@@ -309,8 +315,10 @@ namespace DnsClientX {
 
                 try {
                     // Attempt Base64 Decoding
-                    byte[] rdataBase64 = Convert.FromBase64String(DataRaw);
-                    return ParseNaptrRDataAndFormat(rdataBase64);
+                    if (!string.IsNullOrEmpty(DataRaw)) {
+                        byte[] rdataBase64 = Convert.FromBase64String(DataRaw);
+                        return ParseNaptrRDataAndFormat(rdataBase64);
+                    }
                 } catch (FormatException) {
                     // Not Base64, try parsing as plain text
                 } catch (Exception ex) {


### PR DESCRIPTION
## Summary
- handle empty `DataRaw` when decoding Base64 in `DnsAnswer`
- add regression test covering empty TLSA `DataRaw`

## Testing
- `dotnet test --no-build` *(fails: Error parsing NAPTR record from Hex ...)*

------
https://chatgpt.com/codex/tasks/task_e_6862c11d9e2c832eb0a94ca55fae5fdd