### PR TITLE
Validate hostname input

### DIFF
--- a/DnsClientX.Tests/ConfigurationTests.cs
+++ b/DnsClientX.Tests/ConfigurationTests.cs
@@ -9,5 +9,13 @@ namespace DnsClientX.Tests {
             Assert.Equal(new Uri("https://1.1.1.1/dns-query"), config.BaseUri);
             Assert.Equal(443, config.Port);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Constructor_ShouldThrowOnNullOrWhitespaceHostname(string hostname) {
+            Assert.Throws<ArgumentException>(() => new Configuration(hostname!, DnsRequestFormat.DnsOverHttpsJSON));
+        }
     }
 }

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -77,6 +77,7 @@ namespace DnsClientX {
         /// <param name="hostname">The hostname of the DNS-over-HTTPS resolver.</param>
         /// <param name="requestFormat">The format of the DNS requests.</param>
         public Configuration(string hostname, DnsRequestFormat requestFormat) {
+            if (string.IsNullOrWhiteSpace(hostname)) throw new ArgumentException("Hostname is null or whitespace.", nameof(hostname));
             hostnames = new List<string> { hostname };
             RequestFormat = requestFormat;
             baseUriFormat = "https://{0}/dns-query";


### PR DESCRIPTION
## Summary
- validate hostname in configuration constructor
- cover new exception with tests

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln --no-build -c Release` *(fails: Failed:   126, Passed:   170, Skipped:    14)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0ba0a08832ebbc84f477e578c6d