### PR TITLE
Add DNSSEC integration tests

### DIFF
--- a/DnsClientX.Tests/DnssecTests.cs
+++ b/DnsClientX.Tests/DnssecTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnssecTests {
+        [Theory]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.Google)]
+        public async Task QueryDnskey_WithDnssec(DnsEndpoint endpoint) {
+            using var client = new ClientX(endpoint);
+            DnsResponse response = await client.Resolve("evotec.pl", DnsRecordType.DNSKEY, requestDnsSec: true);
+            Assert.NotEmpty(response.Answers);
+            Assert.Contains(response.Answers, a => a.Type == DnsRecordType.DNSKEY);
+            Assert.True(response.AuthenticData || response.Answers.Any(a => a.Type == DnsRecordType.RRSIG));
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.Cloudflare)]
+        [InlineData(DnsEndpoint.Google)]
+        public async Task QueryDs_WithDnssec(DnsEndpoint endpoint) {
+            using var client = new ClientX(endpoint);
+            DnsResponse response = await client.Resolve("evotec.pl", DnsRecordType.DS, requestDnsSec: true);
+            Assert.NotEmpty(response.Answers);
+            Assert.Contains(response.Answers, a => a.Type == DnsRecordType.DS);
+            Assert.True(response.AuthenticData || response.Answers.Any(a => a.Type == DnsRecordType.RRSIG));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DnssecTests` covering DNSKEY and DS queries with DNSSEC enabled

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `dotnet test DnsClientX.sln -c Debug --no-build` *(fails: The SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_6862c35d3b50832e907a5a0675848c14