### PR TITLE
Add null checks for answer data

### DIFF
--- a/DnsClientX.Tests/ResolveFilterNullDataTests.cs
+++ b/DnsClientX.Tests/ResolveFilterNullDataTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveFilterNullDataTests {
+        private static DnsAnswer CreateAnswer(string dataRaw, DnsRecordType type) {
+            return new DnsAnswer {
+                Name = "example.com",
+                Type = type,
+                TTL = 300,
+                DataRaw = dataRaw
+            };
+        }
+
+        [Fact]
+        public void FilterAnswers_ShouldIgnoreEmptyData() {
+            var client = new ClientX();
+            MethodInfo method = typeof(ClientX).GetMethod("FilterAnswers", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] { CreateAnswer(string.Empty, DnsRecordType.A) };
+            var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, "test", DnsRecordType.A })!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void FilterAnswersRegex_ShouldIgnoreEmptyData() {
+            var client = new ClientX();
+            MethodInfo method = typeof(ClientX).GetMethod("FilterAnswersRegex", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] { CreateAnswer(string.Empty, DnsRecordType.A) };
+            var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, new Regex("test"), DnsRecordType.A })!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void HasMatchingAnswers_ShouldReturnFalseForEmptyData() {
+            var client = new ClientX();
+            MethodInfo method = typeof(ClientX).GetMethod("HasMatchingAnswers", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] { CreateAnswer(string.Empty, DnsRecordType.A) };
+            var result = (bool)method.Invoke(client, new object[] { answers, "test", DnsRecordType.A })!;
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void HasMatchingAnswersRegex_ShouldReturnFalseForEmptyData() {
+            var client = new ClientX();
+            MethodInfo method = typeof(ClientX).GetMethod("HasMatchingAnswersRegex", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] { CreateAnswer(string.Empty, DnsRecordType.A) };
+            var result = (bool)method.Invoke(client, new object[] { answers, new Regex("test"), DnsRecordType.A })!;
+            Assert.False(result);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -126,6 +126,10 @@ namespace DnsClientX {
             var filteredAnswers = new List<DnsAnswer>();
 
             foreach (var answer in answers) {
+                if (string.IsNullOrEmpty(answer.Data)) {
+                    continue;
+                }
+
                 if (type == DnsRecordType.TXT && answer.Type == DnsRecordType.TXT) {
                     // For TXT records, check if any line contains the filter
                     var lines = answer.Data.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
@@ -165,6 +169,10 @@ namespace DnsClientX {
             var filteredAnswers = new List<DnsAnswer>();
 
             foreach (var answer in answers) {
+                if (string.IsNullOrEmpty(answer.Data)) {
+                    continue;
+                }
+
                 if (type == DnsRecordType.TXT && answer.Type == DnsRecordType.TXT) {
                     // For TXT records, check if any line matches the regex
                     var lines = answer.Data.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
@@ -206,6 +214,10 @@ namespace DnsClientX {
             }
 
             foreach (var answer in answers) {
+                if (string.IsNullOrEmpty(answer.Data)) {
+                    continue;
+                }
+
                 if (type == DnsRecordType.TXT && answer.Type == DnsRecordType.TXT) {
                     var lines = answer.Data.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
                     var matchingLines = lines.Where(line => line.ToLower().Contains(filter.ToLower())).ToArray();
@@ -234,6 +246,10 @@ namespace DnsClientX {
             }
 
             foreach (var answer in answers) {
+                if (string.IsNullOrEmpty(answer.Data)) {
+                    continue;
+                }
+
                 if (type == DnsRecordType.TXT && answer.Type == DnsRecordType.TXT) {
                     var lines = answer.Data.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
                     var matchingLines = lines.Where(line => regexFilter.IsMatch(line)).ToArray();


### PR DESCRIPTION
## Summary
- guard `answer.Data` usage with `string.IsNullOrEmpty`
- add tests to verify filtering handles empty data

## Testing
- `dotnet test --no-build` *(fails: QueryDns over network)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0e1a66c832e8839832156f7727d