### PR TITLE
Add SVCB/HTTPS record types

### DIFF
--- a/DnsClientX.Tests/DnsRecordTypeSerializationTests.cs
+++ b/DnsClientX.Tests/DnsRecordTypeSerializationTests.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsRecordTypeSerializationTests {
+        [Theory]
+        [InlineData(DnsRecordType.SVCB, 64)]
+        [InlineData(DnsRecordType.HTTPS, 65)]
+        public void SerializeDeserialize_RoundTrips(DnsRecordType type, int expected) {
+            var answer = new DnsAnswer {
+                Name = "example.com",
+                Type = type,
+                TTL = 60,
+                DataRaw = "value"
+            };
+
+            string json = JsonSerializer.Serialize(answer);
+            Assert.Contains($"\"type\":{expected}", json);
+
+            var deserialized = JsonSerializer.Deserialize<DnsAnswer>(json)!;
+            Assert.Equal(type, deserialized.Type);
+        }
+
+        [Theory]
+        [InlineData(DnsRecordType.SVCB)]
+        [InlineData(DnsRecordType.HTTPS)]
+        public void ConvertData_ReturnsRaw(DnsRecordType type) {
+            var answer = new DnsAnswer {
+                Name = "example.com",
+                Type = type,
+                TTL = 60,
+                DataRaw = "1 . alpn=\"h2\""
+            };
+
+            Assert.Equal(answer.DataRaw, answer.Data);
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -379,6 +379,9 @@ namespace DnsClientX {
                 // If all parsing attempts fail or if it's an unrecognized format for NAPTR that didn't cleanly parse
                 Console.WriteLine($"NAPTR DataRaw '{DataRaw}' did not match known Hex, Base64, or plain text patterns, or failed parsing.");
                 return DataRaw; // Fallback
+            } else if (Type == DnsRecordType.SVCB || Type == DnsRecordType.HTTPS) {
+                // SVCB and HTTPS records use key=value pairs. Preserve the original formatting.
+                return DataRaw;
             } else {
                 // Some records return the data in a higher case (microsoft.com/NS/Quad9ECS) which needs to be fixed
                 return DataRaw.ToLower();

--- a/DnsClientX/Definitions/DnsRecordType.cs
+++ b/DnsClientX/Definitions/DnsRecordType.cs
@@ -237,7 +237,7 @@ public enum DnsRecordType : ushort {
     /// </summary>
     SVCB = 64,
     /// <summary>
-    /// Service Binding compatible type for us with HTTP
+    /// Service Binding compatible type for use with HTTP
     /// </summary>
     HTTPS = 65,
     /// <summary>


### PR DESCRIPTION
## Summary
- handle SVCB and HTTPS in ConvertData
- fix comment for HTTPS enum entry
- test enum serialization for SVCB and HTTPS

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: HTTP requests blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862c7f4794c832e94804e7514d8bb04