### PR TITLE
Remove Console.WriteLine usage

### DIFF
--- a/DnsClientX.Examples/DemoDnsAnswer.cs
+++ b/DnsClientX.Examples/DemoDnsAnswer.cs
@@ -14,6 +14,6 @@ internal class DemoDnsAnswer {
             DataRaw = dkimRecord,
             Type = DnsRecordType.TXT
         };
-        Console.WriteLine(answer.Data);
+        Settings.Logger.WriteInformation(answer.Data);
     }
 }

--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -114,7 +114,7 @@ namespace DnsClientX.Examples {
                 HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, endpoint);
                 var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, endpoint);
                 foreach (var d in data[0].Answers) {
-                    Console.WriteLine(d.Data);
+                    Settings.Logger.WriteInformation(d.Data);
                 }
             }
         }
@@ -124,14 +124,14 @@ namespace DnsClientX.Examples {
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, "1.1.1.1");
             var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, "1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
             foreach (var d in data[0].Answers) {
-                Console.WriteLine(d.Data);
+                Settings.Logger.WriteInformation(d.Data);
             }
 
 
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, DnsEndpoint.GoogleWireFormat);
             var dataGoogle = await ClientX.QueryDns(domains, DnsRecordType.TXT, DnsEndpoint.GoogleWireFormat);
             foreach (var d in dataGoogle[0].Answers) {
-                Console.WriteLine(d.Data);
+                Settings.Logger.WriteInformation(d.Data);
             }
         }
 
@@ -140,14 +140,14 @@ namespace DnsClientX.Examples {
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, "1.1.1.1");
             var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, "1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
             foreach (var d in data[0].Answers) {
-                Console.WriteLine(d.Data);
+                Settings.Logger.WriteInformation(d.Data);
             }
 
 
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, DnsEndpoint.Quad9);
             var dataGoogle = await ClientX.QueryDns(domains, DnsRecordType.TXT, DnsEndpoint.Quad9);
             foreach (var d in dataGoogle[0].Answers) {
-                Console.WriteLine(d.Data);
+                Settings.Logger.WriteInformation(d.Data);
             }
         }
 
@@ -158,14 +158,14 @@ namespace DnsClientX.Examples {
                 Debug = false
             };
             var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
-            Console.WriteLine(data.Answers[0].Data);
+            Settings.Logger.WriteInformation(data.Answers[0].Data);
 
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, DnsEndpoint.Google);
             using var client1 = new ClientX(DnsEndpoint.GoogleWireFormat, DnsSelectionStrategy.First) {
                 Debug = false
             };
             var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
-            Console.WriteLine(data1.Answers[0].Data);
+            Settings.Logger.WriteInformation(data1.Answers[0].Data);
         }
 
         public static async Task ExampleSPFQuad() {
@@ -175,7 +175,7 @@ namespace DnsClientX.Examples {
                 Debug = false
             };
             var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
-            Console.WriteLine(data.Answers[0].Data);
+            Settings.Logger.WriteInformation(data.Answers[0].Data);
 
             foreach (DnsEndpoint endpoint in Enum.GetValues(typeof(DnsEndpoint))) {
                 HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, endpoint);
@@ -183,9 +183,9 @@ namespace DnsClientX.Examples {
                     Debug = false
                 };
                 var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
-                Console.WriteLine(data1.Answers[0].Data);
-                Console.WriteLine(data1.Answers[0].DataStrings.Length);
-                Console.WriteLine(data1.Answers[0].DataStrings[0]);
+                Settings.Logger.WriteInformation(data1.Answers[0].Data);
+                Settings.Logger.WriteInformation(data1.Answers[0].DataStrings.Length.ToString());
+                Settings.Logger.WriteInformation(data1.Answers[0].DataStrings[0]);
             }
         }
     }

--- a/DnsClientX.Examples/Helpers.cs
+++ b/DnsClientX.Examples/Helpers.cs
@@ -10,9 +10,9 @@ namespace DnsClientX.Examples {
         /// </summary>
         /// <param name="responses">The array of DNS responses to display.</param>
         public static void DisplayToConsole(this DnsResponse[] responses) {
-            Console.WriteLine($"Result:");
+            Settings.Logger.WriteInformation($"Result:");
             if (responses.Length == 0) {
-                Console.WriteLine("\tResponses: No responses");
+                Settings.Logger.WriteInformation("\tResponses: No responses");
                 return;
             }
             foreach (DnsResponse response in responses) {
@@ -25,22 +25,22 @@ namespace DnsClientX.Examples {
         /// </summary>
         /// <param name="response">The DNS response to display.</param>
         public static void DisplayToConsole(this DnsResponse? response) {
-            Console.WriteLine($"Result:");
+            Settings.Logger.WriteInformation($"Result:");
             if (response is null) {
-                Console.WriteLine("\tResponse: Null");
+                Settings.Logger.WriteInformation("\tResponse: Null");
                 return;
             }
-            Console.WriteLine($"\tResponse: {response.Value.Status}");
+            Settings.Logger.WriteInformation($"\tResponse: {response.Value.Status}");
             if (response.Value.Answers is null) {
-                Console.WriteLine("\tAnswers: No answers");
+                Settings.Logger.WriteInformation("\tAnswers: No answers");
                 return;
             }
             if (response.Value.Questions != null) {
                 foreach (DnsQuestion question in response.Value.Questions) {
-                    Console.WriteLine($"\tQuestion: {question.Name} => {question.Type}");
+                    Settings.Logger.WriteInformation($"\tQuestion: {question.Name} => {question.Type}");
                 }
             }
-            Console.WriteLine($"\tAnswers: ");
+            Settings.Logger.WriteInformation($"\tAnswers: ");
             foreach (DnsAnswer answer in response.Value.Answers) {
                 DisplayToConsole(answer);
             }
@@ -51,9 +51,9 @@ namespace DnsClientX.Examples {
         /// </summary>
         /// <param name="answers">The array of DNS answers to display.</param>
         public static void DisplayToConsole(this DnsAnswer[] answers) {
-            Console.WriteLine($"Result:");
+            Settings.Logger.WriteInformation($"Result:");
             if (answers.Length == 0) {
-                Console.WriteLine("\tAnswers: No answers");
+                Settings.Logger.WriteInformation("\tAnswers: No answers");
                 return;
             }
             foreach (DnsAnswer answer in answers) {
@@ -68,18 +68,18 @@ namespace DnsClientX.Examples {
         /// <param name="announce">If set to true, an additional "Result:" line is printed before the answer.</param>
         public static void DisplayToConsole(this DnsAnswer? answer, bool announce = false) {
             if (announce) {
-                Console.WriteLine($"Result:");
+                Settings.Logger.WriteInformation($"Result:");
             }
 
             if (answer == null) {
-                Console.WriteLine("\tAnswer: Null");
+                Settings.Logger.WriteInformation("\tAnswer: Null");
                 return;
             }
-            Console.WriteLine($"\tType: {answer.Value.Type}; TTL: '{answer.Value.TTL}'; Name: '{answer.Value.Name}' => '{answer.Value.Data}'");
+            Settings.Logger.WriteInformation($"\tType: {answer.Value.Type}; TTL: '{answer.Value.TTL}'; Name: '{answer.Value.Name}' => '{answer.Value.Data}'");
             if (answer.Value.DataStrings.Length > 1) {
-                Console.WriteLine($"\t\tDataStrings: ");
+                Settings.Logger.WriteInformation($"\t\tDataStrings: ");
                 foreach (string dataString in answer.Value.DataStrings) {
-                    Console.WriteLine($"\t\t{dataString}");
+                    Settings.Logger.WriteInformation($"\t\t{dataString}");
                 }
             }
         }

--- a/DnsClientX.PowerShell/OnImportAndRemove.cs
+++ b/DnsClientX.PowerShell/OnImportAndRemove.cs
@@ -51,7 +51,7 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
                 try {
                     return Assembly.LoadFrom(assemblyPath);
                 } catch (Exception ex) {
-                    Console.WriteLine($"Failed to load assembly from {assemblyPath}: {ex.Message}");
+                    DnsClientX.Settings.Logger.WriteError($"Failed to load assembly from {assemblyPath}: {ex.Message}");
                 }
             }
         }

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -310,7 +310,7 @@ namespace DnsClientX {
                         }
                     }
                 } catch (Exception ex) {
-                    Console.WriteLine($"Error parsing NAPTR record from Hex: {ex.Message} for DataRaw: {DataRaw}");
+                    Settings.Logger.WriteDebug($"Error parsing NAPTR record from Hex: {ex.Message} for DataRaw: {DataRaw}");
                     // Fall through to try other formats or return DataRaw at the end
                 }
 
@@ -323,7 +323,7 @@ namespace DnsClientX {
                 } catch (FormatException) {
                     // Not Base64, try parsing as plain text
                 } catch (Exception ex) {
-                    Console.WriteLine($"Error parsing NAPTR record from Base64: {ex.Message} for DataRaw: {DataRaw}");
+                    Settings.Logger.WriteDebug($"Error parsing NAPTR record from Base64: {ex.Message} for DataRaw: {DataRaw}");
                     // Fall through or return DataRaw at the end
                 }
 
@@ -373,11 +373,11 @@ namespace DnsClientX {
                         }
                     }
                 } catch (Exception ex) {
-                    Console.WriteLine($"Error parsing NAPTR record from plain text: {ex.Message} for DataRaw: {DataRaw}");
+                    Settings.Logger.WriteDebug($"Error parsing NAPTR record from plain text: {ex.Message} for DataRaw: {DataRaw}");
                 }
 
                 // If all parsing attempts fail or if it's an unrecognized format for NAPTR that didn't cleanly parse
-                Console.WriteLine($"NAPTR DataRaw '{DataRaw}' did not match known Hex, Base64, or plain text patterns, or failed parsing.");
+                Settings.Logger.WriteDebug($"NAPTR DataRaw '{DataRaw}' did not match known Hex, Base64, or plain text patterns, or failed parsing.");
                 return DataRaw; // Fallback
             } else {
                 // Some records return the data in a higher case (microsoft.com/NS/Quad9ECS) which needs to be fixed

--- a/DnsClientX/Logging/DebuggingHelpers.cs
+++ b/DnsClientX/Logging/DebuggingHelpers.cs
@@ -13,7 +13,9 @@ namespace DnsClientX {
         /// <returns></returns>
         internal static ushort TroubleshootingDnsWire2(BinaryReader reader, string description, bool display = true) {
             byte[] bytes = reader.ReadBytes(2);
-            Console.WriteLine(description + ": " + BitConverter.ToString(bytes));
+            if (display) {
+                Settings.Logger.WriteDebug(description + ": " + BitConverter.ToString(bytes));
+            }
             return BinaryPrimitives.ReadUInt16BigEndian(bytes);
         }
 
@@ -26,7 +28,9 @@ namespace DnsClientX {
         /// <returns></returns>
         internal static uint TroubleshootingDnsWire4(BinaryReader reader, string description, bool display = true) {
             byte[] bytes = reader.ReadBytes(4);
-            Console.WriteLine(description + ": " + BitConverter.ToString(bytes));
+            if (display) {
+                Settings.Logger.WriteDebug(description + ": " + BitConverter.ToString(bytes));
+            }
             return BinaryPrimitives.ReadUInt32BigEndian(bytes);
         }
     }

--- a/DnsClientX/Logging/Settings.cs
+++ b/DnsClientX/Logging/Settings.cs
@@ -10,6 +10,11 @@ namespace DnsClientX {
         protected static InternalLogger _logger = new InternalLogger();
 
         /// <summary>
+        /// Gets the internal logger instance.
+        /// </summary>
+        public static InternalLogger Logger => _logger;
+
+        /// <summary>
         /// Gets or sets a value indicating whether error logging is enabled.
         /// </summary>
         public bool Error {

--- a/DnsClientX/ProtocolDnsJson/DnsJson.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJson.cs
@@ -28,8 +28,8 @@ namespace DnsClientX {
                     // Read the stream as a string
                     StreamReader reader = new StreamReader(stream);
                     string json = await reader.ReadToEndAsync();
-                    // Print the JSON data to the console
-                    Console.WriteLine(json);
+                    // Write the JSON data using logger
+                    Settings.Logger.WriteDebug(json);
                     // Deserialize the JSON data
                     return JsonSerializer.Deserialize<T>(json);
                 }

--- a/DnsClientX/ProtocolDnsWire/DnsWire.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWire.cs
@@ -46,11 +46,11 @@ namespace DnsClientX {
 
                 if (debug) {
                     if (res != null) {
-                        // Print the DNS wire format bytes to the console
-                        Console.WriteLine("Response Uri: " + res.RequestMessage.RequestUri);
+                        // Print the DNS wire format bytes to the logger
+                        Settings.Logger.WriteDebug("Response Uri: " + res.RequestMessage.RequestUri);
                     }
 
-                    Console.WriteLine("Response DnsWireFormatBytes: " + BitConverter.ToString(dnsWireFormatBytes));
+                    Settings.Logger.WriteDebug("Response DnsWireFormatBytes: " + BitConverter.ToString(dnsWireFormatBytes));
                 }
 
                 // Extract the RCODE from the DNS message header

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -30,9 +30,9 @@ namespace DnsClientX {
             using HttpRequestMessage req = new(HttpMethod.Get, url);
 
             if (debug) {
-                // Print the DNS wire format bytes to the console
-                Console.WriteLine("Query Name: " + name + " type: " + type + " url: " + req.RequestUri);
-                Console.WriteLine("Query DnsWireFormatBytes: " + (base64UrlDnsMessage));
+                // Print the DNS wire format bytes to the logger
+                Settings.Logger.WriteDebug("Query Name: " + name + " type: " + type + " url: " + req.RequestUri);
+                Settings.Logger.WriteDebug("Query DnsWireFormatBytes: " + (base64UrlDnsMessage));
             }
 
             try {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -46,20 +46,20 @@ namespace DnsClientX {
             Buffer.BlockCopy(queryBytes, 0, combinedQueryBytes, lengthPrefix.Length, queryBytes.Length);
 
             if (debug) {
-                // Print the combined DNS query bytes to the console
-                Console.WriteLine($"Query Name: " + name + " type: " + type);
-                Console.WriteLine($"Query before combination: {BitConverter.ToString(queryBytes)}");
-                Console.WriteLine($"Sending combined query: {BitConverter.ToString(combinedQueryBytes)}");
+                // Print the combined DNS query bytes to the logger
+                Settings.Logger.WriteDebug($"Query Name: " + name + " type: " + type);
+                Settings.Logger.WriteDebug($"Query before combination: {BitConverter.ToString(queryBytes)}");
+                Settings.Logger.WriteDebug($"Sending combined query: {BitConverter.ToString(combinedQueryBytes)}");
 
-                Console.WriteLine($"Transaction ID: {BitConverter.ToString(queryBytes, 0, 2)}");
-                Console.WriteLine($"Flags: {BitConverter.ToString(queryBytes, 2, 2)}");
-                Console.WriteLine($"Question count: {BitConverter.ToString(queryBytes, 4, 2)}");
-                Console.WriteLine($"Answer count: {BitConverter.ToString(queryBytes, 6, 2)}");
-                Console.WriteLine($"Authority records count: {BitConverter.ToString(queryBytes, 8, 2)}");
-                Console.WriteLine($"Additional records count: {BitConverter.ToString(queryBytes, 10, 2)}");
-                Console.WriteLine($"Question name: {BitConverter.ToString(queryBytes, 12, queryBytes.Length - 12 - 4)}");
-                Console.WriteLine($"Question type: {BitConverter.ToString(queryBytes, queryBytes.Length - 4, 2)}");
-                Console.WriteLine($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
+                Settings.Logger.WriteDebug($"Transaction ID: {BitConverter.ToString(queryBytes, 0, 2)}");
+                Settings.Logger.WriteDebug($"Flags: {BitConverter.ToString(queryBytes, 2, 2)}");
+                Settings.Logger.WriteDebug($"Question count: {BitConverter.ToString(queryBytes, 4, 2)}");
+                Settings.Logger.WriteDebug($"Answer count: {BitConverter.ToString(queryBytes, 6, 2)}");
+                Settings.Logger.WriteDebug($"Authority records count: {BitConverter.ToString(queryBytes, 8, 2)}");
+                Settings.Logger.WriteDebug($"Additional records count: {BitConverter.ToString(queryBytes, 10, 2)}");
+                Settings.Logger.WriteDebug($"Question name: {BitConverter.ToString(queryBytes, 12, queryBytes.Length - 12 - 4)}");
+                Settings.Logger.WriteDebug($"Question type: {BitConverter.ToString(queryBytes, queryBytes.Length - 4, 2)}");
+                Settings.Logger.WriteDebug($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
             }
 
             // Create a new TCP client and connect to the DNS server

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -27,9 +27,9 @@ namespace DnsClientX {
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {
-                // Print the DNS wire format bytes to the console
-                Console.WriteLine("Query    Name: " + name + " type: " + type);
-                Console.WriteLine($"Sending query: {BitConverter.ToString(queryBytes)}");
+                // Print the DNS wire format bytes to the logger
+                Settings.Logger.WriteDebug("Query    Name: " + name + " type: " + type);
+                Settings.Logger.WriteDebug($"Sending query: {BitConverter.ToString(queryBytes)}");
             }
 
             var content = new ByteArrayContent(queryBytes);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -27,19 +27,19 @@ namespace DnsClientX {
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {
-                // Print the DNS query bytes to the console
-                Console.WriteLine($"Query Name: " + name + " type: " + type);
-                Console.WriteLine($"Sending query: {BitConverter.ToString(queryBytes)}");
+                // Print the DNS query bytes to the logger
+                Settings.Logger.WriteDebug($"Query Name: " + name + " type: " + type);
+                Settings.Logger.WriteDebug($"Sending query: {BitConverter.ToString(queryBytes)}");
 
-                Console.WriteLine($"Transaction ID: {BitConverter.ToString(queryBytes, 0, 2)}");
-                Console.WriteLine($"Flags: {BitConverter.ToString(queryBytes, 2, 2)}");
-                Console.WriteLine($"Question count: {BitConverter.ToString(queryBytes, 4, 2)}");
-                Console.WriteLine($"Answer count: {BitConverter.ToString(queryBytes, 6, 2)}");
-                Console.WriteLine($"Authority records count: {BitConverter.ToString(queryBytes, 8, 2)}");
-                Console.WriteLine($"Additional records count: {BitConverter.ToString(queryBytes, 10, 2)}");
-                Console.WriteLine($"Question name: {BitConverter.ToString(queryBytes, 12, queryBytes.Length - 12 - 4)}");
-                Console.WriteLine($"Question type: {BitConverter.ToString(queryBytes, queryBytes.Length - 4, 2)}");
-                Console.WriteLine($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
+                Settings.Logger.WriteDebug($"Transaction ID: {BitConverter.ToString(queryBytes, 0, 2)}");
+                Settings.Logger.WriteDebug($"Flags: {BitConverter.ToString(queryBytes, 2, 2)}");
+                Settings.Logger.WriteDebug($"Question count: {BitConverter.ToString(queryBytes, 4, 2)}");
+                Settings.Logger.WriteDebug($"Answer count: {BitConverter.ToString(queryBytes, 6, 2)}");
+                Settings.Logger.WriteDebug($"Authority records count: {BitConverter.ToString(queryBytes, 8, 2)}");
+                Settings.Logger.WriteDebug($"Additional records count: {BitConverter.ToString(queryBytes, 10, 2)}");
+                Settings.Logger.WriteDebug($"Question name: {BitConverter.ToString(queryBytes, 12, queryBytes.Length - 12 - 4)}");
+                Settings.Logger.WriteDebug($"Question type: {BitConverter.ToString(queryBytes, queryBytes.Length - 4, 2)}");
+                Settings.Logger.WriteDebug($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
             }
             try {
                 // Send the DNS query over TCP and receive the response

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -27,19 +27,19 @@ namespace DnsClientX {
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {
-                // Print the DNS query bytes to the console
-                Console.WriteLine($"Query Name: " + name + " type: " + type);
-                Console.WriteLine($"Sending query: {BitConverter.ToString(queryBytes)}");
+                // Print the DNS query bytes to the logger
+                Settings.Logger.WriteDebug($"Query Name: " + name + " type: " + type);
+                Settings.Logger.WriteDebug($"Sending query: {BitConverter.ToString(queryBytes)}");
 
-                Console.WriteLine($"Transaction ID: {BitConverter.ToString(queryBytes, 0, 2)}");
-                Console.WriteLine($"Flags: {BitConverter.ToString(queryBytes, 2, 2)}");
-                Console.WriteLine($"Question count: {BitConverter.ToString(queryBytes, 4, 2)}");
-                Console.WriteLine($"Answer count: {BitConverter.ToString(queryBytes, 6, 2)}");
-                Console.WriteLine($"Authority records count: {BitConverter.ToString(queryBytes, 8, 2)}");
-                Console.WriteLine($"Additional records count: {BitConverter.ToString(queryBytes, 10, 2)}");
-                Console.WriteLine($"Question name: {BitConverter.ToString(queryBytes, 12, queryBytes.Length - 12 - 4)}");
-                Console.WriteLine($"Question type: {BitConverter.ToString(queryBytes, queryBytes.Length - 4, 2)}");
-                Console.WriteLine($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
+                Settings.Logger.WriteDebug($"Transaction ID: {BitConverter.ToString(queryBytes, 0, 2)}");
+                Settings.Logger.WriteDebug($"Flags: {BitConverter.ToString(queryBytes, 2, 2)}");
+                Settings.Logger.WriteDebug($"Question count: {BitConverter.ToString(queryBytes, 4, 2)}");
+                Settings.Logger.WriteDebug($"Answer count: {BitConverter.ToString(queryBytes, 6, 2)}");
+                Settings.Logger.WriteDebug($"Authority records count: {BitConverter.ToString(queryBytes, 8, 2)}");
+                Settings.Logger.WriteDebug($"Additional records count: {BitConverter.ToString(queryBytes, 10, 2)}");
+                Settings.Logger.WriteDebug($"Question name: {BitConverter.ToString(queryBytes, 12, queryBytes.Length - 12 - 4)}");
+                Settings.Logger.WriteDebug($"Question type: {BitConverter.ToString(queryBytes, queryBytes.Length - 4, 2)}");
+                Settings.Logger.WriteDebug($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
             }
 
             try {

--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -31,7 +31,7 @@ namespace DnsClientX {
             var dnsServers = new List<string>();
             bool debug = Environment.GetEnvironmentVariable("DNSCLIENTX_DEBUG_SYSTEMDNS") == "1";
 
-            void DebugPrint(string msg) { if (debug) Console.WriteLine($"[DnsClientX:SystemDNS] {msg}"); }
+            void DebugPrint(string msg) { if (debug) Settings.Logger.WriteDebug($"[DnsClientX:SystemDNS] {msg}"); }
 
             try {
                 DebugPrint("Starting DNS server discovery...");
@@ -225,7 +225,7 @@ namespace DnsClientX {
                 // Filter out macOS virtual network interface addresses (192.168.64.x)
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && ipString.StartsWith("192.168.64.")) {
                     bool debug = Environment.GetEnvironmentVariable("DNSCLIENTX_DEBUG_SYSTEMDNS") == "1";
-                    if (debug) Console.WriteLine($"[DnsClientX:SystemDNS] Filtering out macOS virtual network DNS: {ipString}");
+                    if (debug) Settings.Logger.WriteDebug($"[DnsClientX:SystemDNS] Filtering out macOS virtual network DNS: {ipString}");
                     return false;
                 }
 

--- a/RetryTest/Program.cs
+++ b/RetryTest/Program.cs
@@ -5,7 +5,8 @@ using DnsClientX;
 namespace RetryTest {
     class Program {
         static async Task Main(string[] args) {
-            Console.WriteLine("Testing Quad9 DNS servers for empty response patterns...");
+            var logger = new InternalLogger(true) { IsInformation = true };
+            logger.WriteInformation("Testing Quad9 DNS servers for empty response patterns...");
 
             var endpoints = new[] {
                 ("Cloudflare", DnsEndpoint.Cloudflare),
@@ -21,7 +22,7 @@ namespace RetryTest {
             };
 
             foreach (var (domain, recordType) in testCases) {
-                Console.WriteLine($"\n=== Testing {domain} / {recordType} ===");
+                logger.WriteInformation($"\n=== Testing {domain} / {recordType} ===");
 
                 foreach (var (name, endpoint) in endpoints) {
                     try {
@@ -30,25 +31,25 @@ namespace RetryTest {
                         // Test ResolveAll which is what the failing test uses
                         var answers = await client.ResolveAll(domain, recordType);
 
-                        Console.WriteLine($"{name}: {answers.Length} records");
+                        logger.WriteInformation($"{name}: {answers.Length} records");
                         if (answers.Length == 0) {
                             // Get the full response to see status code
                             var fullResponse = await client.Resolve(domain, recordType);
-                            Console.WriteLine($"  Status: {fullResponse.Status}");
-                            Console.WriteLine($"  Error: {fullResponse.Error ?? "None"}");
+                            logger.WriteInformation($"  Status: {fullResponse.Status}");
+                            logger.WriteInformation($"  Error: {fullResponse.Error ?? "None"}");
                         } else {
                             foreach (var answer in answers) {
-                                Console.WriteLine($"  - {answer.Data}");
+                                logger.WriteInformation($"  - {answer.Data}");
                             }
                         }
 
                     } catch (Exception ex) {
-                        Console.WriteLine($"{name}: EXCEPTION - {ex.Message}");
+                        logger.WriteError($"{name}: EXCEPTION - {ex.Message}");
                     }
                 }
             }
 
-            Console.WriteLine("\nDone testing empty response patterns.");
+            logger.WriteInformation("\nDone testing empty response patterns.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- route runtime messages through the internal logger
- expose logger via Settings

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln --no-build -c Release` *(fails: Could not connect)*

------
https://chatgpt.com/codex/tasks/task_e_6862c801df4c832e9fba3dd24d46e9fb