### PR TITLE
Fix Random initialization

### DIFF
--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -11,7 +11,7 @@ namespace DnsClientX {
         /// <summary>
         /// The random number generator.
         /// </summary>
-        private static readonly Random random = new Random();
+        private static readonly Random random = Random.Shared;
 
 
         private List<string> hostnames = new List<string>();


### PR DESCRIPTION
## Summary
- use `Random.Shared` in configuration

## Testing
- `dotnet build DnsClientX.sln --configuration Release`
- `dotnet test --configuration Release` *(fails: Failed: 129, Passed: 177)*

------
https://chatgpt.com/codex/tasks/task_e_6862c80d1370832ea5cdf77ad5f8a90a