### PR TITLE
Add ConfigureAwait to async calls

### DIFF
--- a/DnsClientX.Examples/DemoByManualUrl.cs
+++ b/DnsClientX.Examples/DemoByManualUrl.cs
@@ -6,21 +6,21 @@ namespace DnsClientX.Examples {
         public static async Task Example() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, "1.1.1.1", dnsRequestFormat: DnsRequestFormat.DnsOverHttpsJSON);
             using var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
-            var data = await client.Resolve("evotec.pl", DnsRecordType.A);
+            var data = await client.Resolve("evotec.pl", DnsRecordType.A).ConfigureAwait(false);
             data.DisplayTable();
         }
 
         public static async Task Example2() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
             using var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
-            var data = await client.Resolve("evotec.pl", DnsRecordType.A);
+            var data = await client.Resolve("evotec.pl", DnsRecordType.A).ConfigureAwait(false);
             data.DisplayTable();
         }
 
         public static async Task ExampleGoogle() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, new Uri("https://8.8.8.8/resolve"), DnsRequestFormat.DnsOverHttpsJSON);
             using var client = new ClientX(new Uri("https://8.8.8.8/resolve"), DnsRequestFormat.DnsOverHttpsJSON);
-            var data = await client.Resolve("evotec.pl", DnsRecordType.A);
+            var data = await client.Resolve("evotec.pl", DnsRecordType.A).ConfigureAwait(false);
             data.DisplayTable();
         }
 
@@ -30,7 +30,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverTLS) {
                 Debug = false
             };
-            var data = await client.Resolve("www.example.com", DnsRecordType.A);
+            var data = await client.Resolve("www.example.com", DnsRecordType.A).ConfigureAwait(false);
             data.DisplayTable();
         }
 
@@ -39,7 +39,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST) {
                 Debug = false
             };
-            var data = await client.Resolve("www.example.com", DnsRecordType.A);
+            var data = await client.Resolve("www.example.com", DnsRecordType.A).ConfigureAwait(false);
             data.DisplayTable();
         }
 
@@ -48,7 +48,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
                 Debug = false
             };
-            var data = await client.Resolve("www.example.com", DnsRecordType.A);
+            var data = await client.Resolve("www.example.com", DnsRecordType.A).ConfigureAwait(false);
             //var data = await DnsWireResolveUdp.ResolveWireFormatUdp("www.example.com", DnsRecordType.A, false, false, true);
             data.DisplayTable();
         }
@@ -58,7 +58,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
                 Debug = false
             };
-            var data = await client.Resolve("www.example.com", DnsRecordType.A);
+            var data = await client.Resolve("www.example.com", DnsRecordType.A).ConfigureAwait(false);
             //var data = await DnsWireResolveUdp.ResolveWireFormatTcp("www.example.com", DnsRecordType.A, false, false, true);
             data.DisplayTable();
         }

--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -10,42 +10,42 @@ namespace DnsClientX.Examples {
         public static async Task Example0() {
             var domains = new[] { "evotec.pl", "google.com" };
             HelpersSpectre.AddLine("QueryDns", "evotec.pl / google.com", DnsRecordType.A, "1.1.1.1");
-            var data = await ClientX.QueryDns(domains, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
+            var data = await ClientX.QueryDns(domains, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON).ConfigureAwait(false);
             data.DisplayTable();
         }
 
         public static async Task ExamplePTR() {
             var domains = new[] { "1.1.1.1" };
             HelpersSpectre.AddLine("QueryDns", "1.1.1.1", DnsRecordType.A, "1.1.1.1");
-            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "1.1.1.1", DnsRequestFormat.DnsOverHttps).ConfigureAwait(false);
             data.DisplayTable();
         }
 
         public static async Task ExamplePTR1() {
             var domains = new[] { "1.1.1.1", "192.168.241.5", "192.168.241.108" };
             HelpersSpectre.AddLine("QueryDns", "1.1.1.1", DnsRecordType.A, "192.168.241.5");
-            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "192.168.241.5", DnsRequestFormat.DnsOverUDP);
+            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "192.168.241.5", DnsRequestFormat.DnsOverUDP).ConfigureAwait(false);
             data.DisplayTable();
         }
 
         public static async Task ExamplePTR2() {
             var domains = new[] { "1.1.1.1", "192.168.241.5", "192.168.241.108" };
             HelpersSpectre.AddLine("QueryDns", "1.1.1.1", DnsRecordType.A, "192.168.241.5");
-            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "192.168.241.5", DnsRequestFormat.DnsOverTCP);
+            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "192.168.241.5", DnsRequestFormat.DnsOverTCP).ConfigureAwait(false);
             data.DisplayTable();
         }
 
         public static async Task ExamplePTR3() {
             var domains = new[] { "1.1.1.1", "108.138.7.68" };
             HelpersSpectre.AddLine("QueryDns", "1.1.1.1", DnsRecordType.A, "1.1.1.1");
-            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            var data = await ClientX.QueryDns(domains, DnsRecordType.PTR, "1.1.1.1", DnsRequestFormat.DnsOverHttps).ConfigureAwait(false);
             data.DisplayTable();
         }
 
 
         public static async Task Example1() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.CloudflareWireFormat);
-            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.CloudflareWireFormat);
+            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.CloudflareWireFormat).ConfigureAwait(false);
             data.Answers.DisplayTable();
         }
 
@@ -53,13 +53,13 @@ namespace DnsClientX.Examples {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, "1.1.1.1",
                 DnsRequestFormat.DnsOverHttpsJSON);
             var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, "1.1.1.1",
-                DnsRequestFormat.DnsOverHttpsJSON);
+                DnsRequestFormat.DnsOverHttpsJSON).ConfigureAwait(false);
             data.Answers.DisplayTable();
         }
 
         public static async Task Example3() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
-            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
+            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON).ConfigureAwait(false);
             data.Answers.DisplayTable();
         }
 
@@ -67,25 +67,25 @@ namespace DnsClientX.Examples {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"),
                 DnsRequestFormat.DnsOverHttpsPOST);
             var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"),
-                DnsRequestFormat.DnsOverHttpsPOST);
+                DnsRequestFormat.DnsOverHttpsPOST).ConfigureAwait(false);
             data.Answers.DisplayTable();
         }
 
         public static async Task ExampleGoogleOverWire() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.GoogleWireFormat);
-            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.GoogleWireFormat);
+            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.GoogleWireFormat).ConfigureAwait(false);
             data.Answers.DisplayTable();
         }
 
         public static async Task ExampleGoogleOverWirePost() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.GoogleWireFormatPost);
-            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.GoogleWireFormatPost);
+            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.GoogleWireFormatPost).ConfigureAwait(false);
             data.Answers.DisplayTable();
         }
 
         public static async Task ExampleCloudflareSelection() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.Cloudflare);
-            var data = await ClientX.QueryDns(["evotec.pl", "google.com", "onet.pl"], DnsRecordType.A, DnsEndpoint.Cloudflare, DnsSelectionStrategy.Random);
+            var data = await ClientX.QueryDns(["evotec.pl", "google.com", "onet.pl"], DnsRecordType.A, DnsEndpoint.Cloudflare, DnsSelectionStrategy.Random).ConfigureAwait(false);
             foreach (var dnsResponse in data) {
                 dnsResponse.Questions?.DisplayTable();
                 dnsResponse.Answers.DisplayTable();
@@ -94,7 +94,7 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleSystemDns() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.System);
-            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.System, DnsSelectionStrategy.Random);
+            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.System, DnsSelectionStrategy.Random).ConfigureAwait(false);
             data.Questions?.DisplayTable();
             data.Answers.DisplayTable();
         }
@@ -103,7 +103,7 @@ namespace DnsClientX.Examples {
             var domains = "_25._tcp.mail.ietf.org";
             foreach (DnsEndpoint endpoint in Enum.GetValues(typeof(DnsEndpoint))) {
                 HelpersSpectre.AddLine("QueryDns", domains, DnsRecordType.TLSA, endpoint);
-                var data = await ClientX.QueryDns(domains, DnsRecordType.TLSA, endpoint);
+                var data = await ClientX.QueryDns(domains, DnsRecordType.TLSA, endpoint).ConfigureAwait(false);
                 data.DisplayTable();
             }
         }
@@ -112,7 +112,7 @@ namespace DnsClientX.Examples {
             var domains = new[] { "disneyplus.com" };
             foreach (DnsEndpoint endpoint in Enum.GetValues(typeof(DnsEndpoint))) {
                 HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, endpoint);
-                var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, endpoint);
+                var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, endpoint).ConfigureAwait(false);
                 foreach (var d in data[0].Answers) {
                     Console.WriteLine(d.Data);
                 }
@@ -122,14 +122,14 @@ namespace DnsClientX.Examples {
         public static async Task ExampleTXT() {
             var domains = new[] { "disneyplus.com" };
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, "1.1.1.1");
-            var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, "1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
+            var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, "1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON).ConfigureAwait(false);
             foreach (var d in data[0].Answers) {
                 Console.WriteLine(d.Data);
             }
 
 
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, DnsEndpoint.GoogleWireFormat);
-            var dataGoogle = await ClientX.QueryDns(domains, DnsRecordType.TXT, DnsEndpoint.GoogleWireFormat);
+            var dataGoogle = await ClientX.QueryDns(domains, DnsRecordType.TXT, DnsEndpoint.GoogleWireFormat).ConfigureAwait(false);
             foreach (var d in dataGoogle[0].Answers) {
                 Console.WriteLine(d.Data);
             }
@@ -138,14 +138,14 @@ namespace DnsClientX.Examples {
         public static async Task ExampleTXTQuad() {
             var domains = new[] { "disneyplus.com" };
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, "1.1.1.1");
-            var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, "1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
+            var data = await ClientX.QueryDns(domains, DnsRecordType.TXT, "1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON).ConfigureAwait(false);
             foreach (var d in data[0].Answers) {
                 Console.WriteLine(d.Data);
             }
 
 
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.TXT, DnsEndpoint.Quad9);
-            var dataGoogle = await ClientX.QueryDns(domains, DnsRecordType.TXT, DnsEndpoint.Quad9);
+            var dataGoogle = await ClientX.QueryDns(domains, DnsRecordType.TXT, DnsEndpoint.Quad9).ConfigureAwait(false);
             foreach (var d in dataGoogle[0].Answers) {
                 Console.WriteLine(d.Data);
             }
@@ -157,14 +157,14 @@ namespace DnsClientX.Examples {
             using var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
                 Debug = false
             };
-            var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
+            var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1").ConfigureAwait(false);
             Console.WriteLine(data.Answers[0].Data);
 
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, DnsEndpoint.Google);
             using var client1 = new ClientX(DnsEndpoint.GoogleWireFormat, DnsSelectionStrategy.First) {
                 Debug = false
             };
-            var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
+            var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1").ConfigureAwait(false);
             Console.WriteLine(data1.Answers[0].Data);
         }
 
@@ -174,7 +174,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
                 Debug = false
             };
-            var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
+            var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1").ConfigureAwait(false);
             Console.WriteLine(data.Answers[0].Data);
 
             foreach (DnsEndpoint endpoint in Enum.GetValues(typeof(DnsEndpoint))) {
@@ -182,7 +182,7 @@ namespace DnsClientX.Examples {
                 using var client1 = new ClientX(endpoint, DnsSelectionStrategy.First) {
                     Debug = false
                 };
-                var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
+                var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1").ConfigureAwait(false);
                 Console.WriteLine(data1.Answers[0].Data);
                 Console.WriteLine(data1.Answers[0].DataStrings.Length);
                 Console.WriteLine(data1.Answers[0].DataStrings[0]);

--- a/DnsClientX.Examples/DemoRecords.cs
+++ b/DnsClientX.Examples/DemoRecords.cs
@@ -11,7 +11,7 @@ namespace DnsClientX.Examples {
         public static async Task Demo(string domain, DnsRecordType recordType, DnsEndpoint endpoint) {
             using var client = new ClientX(endpoint);
             HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
-            var caaAnswer = await client.ResolveAll(domain, recordType);
+            var caaAnswer = await client.ResolveAll(domain, recordType).ConfigureAwait(false);
             caaAnswer.DisplayTable();
         }
     }

--- a/DnsClientX.Examples/DemoResolve.cs
+++ b/DnsClientX.Examples/DemoResolve.cs
@@ -55,7 +55,7 @@ namespace DnsClientX.Examples {
                 foreach (var domain in domains) {
                     foreach (var recordType in recordTypes) {
                         HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
-                        DnsResponse? response = await client.Resolve(domain, recordType);
+                        DnsResponse? response = await client.Resolve(domain, recordType).ConfigureAwait(false);
                         response?.DisplayTable();
                     }
                 }

--- a/DnsClientX.Examples/DemoResolveAll.cs
+++ b/DnsClientX.Examples/DemoResolveAll.cs
@@ -55,7 +55,7 @@ namespace DnsClientX.Examples {
                 foreach (var domain in domains) {
                     foreach (var recordType in recordTypes) {
                         HelpersSpectre.AddLine("ResolveAll", domain, recordType, endpoint);
-                        var response = await client.ResolveAll(domain, recordType);
+                        var response = await client.ResolveAll(domain, recordType).ConfigureAwait(false);
                         response.DisplayToConsole();
                     }
                 }
@@ -101,7 +101,7 @@ namespace DnsClientX.Examples {
                 foreach (var domain in domains) {
                     foreach (var recordType in recordTypes) {
                         HelpersSpectre.AddLine("ResolveAll", domain, recordType, endpoint);
-                        var response = await client.ResolveAll(domain, recordType);
+                        var response = await client.ResolveAll(domain, recordType).ConfigureAwait(false);
                         response.DisplayToConsole();
                     }
                 }

--- a/DnsClientX.Examples/DemoResolveFirst.cs
+++ b/DnsClientX.Examples/DemoResolveFirst.cs
@@ -54,7 +54,7 @@ namespace DnsClientX.Examples {
                 foreach (var domain in domains) {
                     foreach (var recordType in recordTypes) {
                         HelpersSpectre.AddLine("ResolveFirst", domain, recordType, endpoint);
-                        var response = await client.ResolveFirst(domain);
+                        var response = await client.ResolveFirst(domain).ConfigureAwait(false);
                         response?.DisplayTable();
                     }
                 }

--- a/DnsClientX.Examples/DemoResolveParallel.cs
+++ b/DnsClientX.Examples/DemoResolveParallel.cs
@@ -55,7 +55,7 @@ namespace DnsClientX.Examples {
 
                 foreach (var domain in domains) {
                     HelpersSpectre.AddLine("Resolve (Parallel)", domain, string.Join(",", recordTypes), endpoint);
-                    var responses = await client.Resolve(domain, recordTypes.ToArray());
+                    var responses = await client.Resolve(domain, recordTypes.ToArray()).ConfigureAwait(false);
                     responses?.DisplayTable();
                 }
             }

--- a/DnsClientX.Examples/DemoResolveParallelDNSBL.cs
+++ b/DnsClientX.Examples/DemoResolveParallelDNSBL.cs
@@ -147,7 +147,7 @@ namespace DnsClientX.Examples {
             };
 
             HelpersSpectre.AddLine("Resolve (Parallel)", $"{ipAddress} => {queries.Count} queries", DnsRecordType.A, endpoint);
-            var responses = await client.Resolve(queries.ToArray(), DnsRecordType.A);
+            var responses = await client.Resolve(queries.ToArray(), DnsRecordType.A).ConfigureAwait(false);
             stopwatch.Stop();
             HelpersSpectre.AddLine($"Time to resolve {stopwatch.ElapsedMilliseconds} ms", $"{ipAddress} => {queries.Count} queries", DnsRecordType.A, endpoint);
             responses.DisplayTable();

--- a/DnsClientX.Examples/DemoResolveReturn.cs
+++ b/DnsClientX.Examples/DemoResolveReturn.cs
@@ -64,7 +64,7 @@ namespace DnsClientX.Examples {
                 foreach (var domain in domains) {
                     foreach (var recordType in recordTypes) {
                         HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
-                        DnsResponse? response = await client.Resolve(domain, recordType, requestDnsSec: true, validateDnsSec: true, returnAllTypes: true);
+                        DnsResponse? response = await client.Resolve(domain, recordType, requestDnsSec: true, validateDnsSec: true, returnAllTypes: true).ConfigureAwait(false);
                         response?.DisplayTable();
                     }
                 }

--- a/DnsClientX.Examples/DemoResolveUdpTcp.cs
+++ b/DnsClientX.Examples/DemoResolveUdpTcp.cs
@@ -7,7 +7,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
                 Debug = true
             };
-            var data = await client.Resolve("github.com", DnsRecordType.TXT);
+            var data = await client.Resolve("github.com", DnsRecordType.TXT).ConfigureAwait(false);
             data.DisplayTable();
         }
 
@@ -16,7 +16,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
                 Debug = true
             };
-            var data = await client.Resolve("github.com", DnsRecordType.TXT);
+            var data = await client.Resolve("github.com", DnsRecordType.TXT).ConfigureAwait(false);
             data.DisplayTable();
         }
 
@@ -25,7 +25,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("8.8.1.1", DnsRequestFormat.DnsOverUDP) {
                 Debug = true
             };
-            var data = await client.Resolve("github.com", DnsRecordType.TXT);
+            var data = await client.Resolve("github.com", DnsRecordType.TXT).ConfigureAwait(false);
             data.DisplayTable();
         }
 
@@ -34,7 +34,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("a1akam1.net", DnsRequestFormat.DnsOverUDP) {
                 Debug = true
             };
-            var data = await client.Resolve("github.com", DnsRecordType.TXT);
+            var data = await client.Resolve("github.com", DnsRecordType.TXT).ConfigureAwait(false);
             data.DisplayTable();
         }
     }

--- a/DnsClientX.Examples/DemoResolveWithFilter.cs
+++ b/DnsClientX.Examples/DemoResolveWithFilter.cs
@@ -52,7 +52,7 @@ namespace DnsClientX.Examples {
                 foreach (var domain in domains) {
                     foreach (var recordType in recordTypes) {
                         HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
-                        DnsResponse? response = await client.ResolveFilter(domain, recordType, filter);
+                        DnsResponse? response = await client.ResolveFilter(domain, recordType, filter).ConfigureAwait(false);
                         response?.DisplayTable();
                     }
                 }
@@ -104,7 +104,7 @@ namespace DnsClientX.Examples {
 
 
                 HelpersSpectre.AddLine("Resolve", "Multiple Domains", recordType, endpoint);
-                var response = await client.ResolveFilter(domains, recordType, filter);
+                var response = await client.ResolveFilter(domains, recordType, filter).ConfigureAwait(false);
                 response?.DisplayTable();
             }
         }

--- a/DnsClientX.Examples/Program.cs
+++ b/DnsClientX.Examples/Program.cs
@@ -8,14 +8,14 @@ namespace DnsClientX.Examples {
             // await DemoQuery.ExamplePTR2();
             // await DemoQuery.ExamplePTR3();
 
-            await DemoDnsAnswer.ExampleDnsAnswerParsing();
+            await DemoDnsAnswer.ExampleDnsAnswerParsing().ConfigureAwait(false);
 
             //await DemoQuery.ExampleTXTAll();
             return;
-            await DemoQuery.ExampleTXT();
-            await DemoQuery.ExampleSPF();
-            await DemoQuery.ExampleTXTQuad();
-            await DemoQuery.ExampleSPFQuad();
+            await DemoQuery.ExampleTXT().ConfigureAwait(false);
+            await DemoQuery.ExampleSPF().ConfigureAwait(false);
+            await DemoQuery.ExampleTXTQuad().ConfigureAwait(false);
+            await DemoQuery.ExampleSPFQuad().ConfigureAwait(false);
             return;
 
             // await ConvertToDnsClient.ExampleConvertToDnsClientFromX();
@@ -31,14 +31,14 @@ namespace DnsClientX.Examples {
             //await DemoQuery.Example0();
             //await DemoQuery.ExampleTLSA();
 
-            await DemoResolveUdpTcp.ExampleTestingUdpWrongServer();
-            await DemoResolveUdpTcp.ExampleTestingUdpWrongServer1();
+            await DemoResolveUdpTcp.ExampleTestingUdpWrongServer().ConfigureAwait(false);
+            await DemoResolveUdpTcp.ExampleTestingUdpWrongServer1().ConfigureAwait(false);
 
             return;
-            await DemoQuery.Example1();
-            await DemoQuery.ExampleGoogleOverWire();
-            await DemoQuery.ExampleGoogleOverWirePost();
-            await DemoQuery.ExampleCloudflareSelection();
+            await DemoQuery.Example1().ConfigureAwait(false);
+            await DemoQuery.ExampleGoogleOverWire().ConfigureAwait(false);
+            await DemoQuery.ExampleGoogleOverWirePost().ConfigureAwait(false);
+            await DemoQuery.ExampleCloudflareSelection().ConfigureAwait(false);
             //await DemoQuery.ExampleSystemDns();
 
 

--- a/DnsClientX.PowerShell/Communication/AsyncPSCmdlet.cs
+++ b/DnsClientX.PowerShell/Communication/AsyncPSCmdlet.cs
@@ -94,7 +94,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             try {
                 _currentOutPipe = outPipe;
                 _currentReplyPipe = replyPipe;
-                await task();
+                await task().ConfigureAwait(false);
             } finally {
                 _currentOutPipe = null;
                 _currentReplyPipe = null;

--- a/DnsClientX.Tests/CancellationTests.cs
+++ b/DnsClientX.Tests/CancellationTests.cs
@@ -10,7 +10,7 @@ namespace DnsClientX.Tests {
     public class CancellationTests {
         private class DelayingHandler : HttpMessageHandler {
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
-                await Task.Delay(5000, cancellationToken);
+                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
                 return new HttpResponseMessage(System.Net.HttpStatusCode.OK) {
                     Content = new ByteArrayContent(Array.Empty<byte>())
                 };
@@ -30,7 +30,7 @@ namespace DnsClientX.Tests {
             clientField.SetValue(clientX, customClient);
 
             using var cts = new CancellationTokenSource(100);
-            await Assert.ThrowsAsync<TaskCanceledException>(() => clientX.Resolve("example.com", DnsRecordType.A, cancellationToken: cts.Token));
+            await Assert.ThrowsAsync<TaskCanceledException>(() => clientX.Resolve("example.com", DnsRecordType.A, cancellationToken: cts.Token)).ConfigureAwait(false);
         }
     }
 }

--- a/DnsClientX.Tests/CompareJsonWithDnsWire.cs
+++ b/DnsClientX.Tests/CompareJsonWithDnsWire.cs
@@ -9,10 +9,10 @@ namespace DnsClientX.Tests {
         [InlineData("www.microsoft.com", DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS, DnsRecordType.CNAME)]
         public async Task CompareAnswersRecord(string name, DnsEndpoint endpoint, DnsEndpoint endpointCompare, DnsRecordType resourceRecordType) {
             using var Client = new ClientX(endpoint);
-            DnsAnswer[] aAnswers = await Client.ResolveAll(name, resourceRecordType);
+            DnsAnswer[] aAnswers = await Client.ResolveAll(name, resourceRecordType).ConfigureAwait(false);
 
             using var ClientWire = new ClientX(endpointCompare);
-            DnsAnswer[] aAnswersWire = await ClientWire.ResolveAll(name, resourceRecordType);
+            DnsAnswer[] aAnswersWire = await ClientWire.ResolveAll(name, resourceRecordType).ConfigureAwait(false);
 
             // Sort the arrays by Name, Type, and Data
             var sortedAAnswers = aAnswers.OrderBy(a => a.Name).ThenBy(a => a.Type).ThenBy(a => a.Data).ToArray();

--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -47,7 +47,7 @@ namespace DnsClientX.Tests {
 
             // Get primary endpoint result
             using var primaryClient = new ClientX(primaryEndpoint);
-            var primaryResult = await GetResponseWithRetry(primaryClient, name, resourceRecordType, primaryEndpoint, output);
+            var primaryResult = await GetResponseWithRetry(primaryClient, name, resourceRecordType, primaryEndpoint, output).ConfigureAwait(false);
             results[primaryEndpoint] = primaryResult;
 
             output.WriteLine($"Primary ({primaryEndpoint}): {primaryResult.response.Answers?.Length ?? 0} records, Status: {primaryResult.response.Status}");
@@ -58,7 +58,7 @@ namespace DnsClientX.Tests {
             // Get all other endpoint results
             foreach (var endpoint in allEndpoints) {
                 using var client = new ClientX(endpoint);
-                var result = await GetResponseWithRetry(client, name, resourceRecordType, endpoint, output);
+                var result = await GetResponseWithRetry(client, name, resourceRecordType, endpoint, output).ConfigureAwait(false);
                 results[endpoint] = result;
 
                 output.WriteLine($"Provider {endpoint}: {result.response.Answers?.Length ?? 0} records, Status: {result.response.Status}");
@@ -129,11 +129,11 @@ namespace DnsClientX.Tests {
 
             for (int attempt = 1; attempt <= maxRetries; attempt++) {
                 try {
-                    var response = await client.Resolve(name, type);
+                    var response = await client.Resolve(name, type).ConfigureAwait(false);
 
                     if ((response.Answers?.Length ?? 0) == 0 && response.Status == DnsResponseCode.NoError && attempt < maxRetries) {
                         output.WriteLine($"  {endpoint}: Attempt {attempt} returned 0 records with NoError status, retrying...");
-                        await Task.Delay(delayMs);
+                        await Task.Delay(delayMs).ConfigureAwait(false);
                         continue;
                     }
 
@@ -149,7 +149,7 @@ namespace DnsClientX.Tests {
                         return (emptyResponse, $"Exception after {maxRetries} attempts: {ex.Message}");
                     }
                     output.WriteLine($"  {endpoint}: Attempt {attempt} failed: {ex.Message}, retrying...");
-                    await Task.Delay(delayMs);
+                    await Task.Delay(delayMs).ConfigureAwait(false);
                 }
             }
 
@@ -200,7 +200,7 @@ namespace DnsClientX.Tests {
             var primaryEndpoint = DnsEndpoint.Cloudflare;
 
             using var Client = new ClientX(primaryEndpoint);
-            DnsResponse aAnswersPrimary = await Client.Resolve(name, resourceRecordType);
+            DnsResponse aAnswersPrimary = await Client.Resolve(name, resourceRecordType).ConfigureAwait(false);
 
             foreach (var endpointCompare in Enum.GetValues(typeof(DnsEndpoint)).Cast<DnsEndpoint>()) {
                 if (endpointCompare == primaryEndpoint) {
@@ -213,7 +213,7 @@ namespace DnsClientX.Tests {
                 output.WriteLine("Provider: " + endpointCompare.ToString());
 
                 using var ClientToCompare = new ClientX(endpointCompare);
-                DnsResponse aAnswersToCompare = await ClientToCompare.Resolve(name, resourceRecordType);
+                DnsResponse aAnswersToCompare = await ClientToCompare.Resolve(name, resourceRecordType).ConfigureAwait(false);
 
                 var sortedAAnswers = aAnswersPrimary.Answers.OrderBy(a => a.Name).ThenBy(a => a.Type).ThenBy(a => a.Data).ToArray();
                 var sortedAAnswersCompared = aAnswersToCompare.Answers.OrderBy(a => a.Name).ThenBy(a => a.Type).ThenBy(a => a.Data).ToArray();

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -24,7 +24,7 @@ namespace DnsClientX.Tests {
 
             // Get primary endpoint result
             using var primaryClient = new ClientX(primaryEndpoint);
-            var primaryResult = await GetResponseWithRetry(primaryClient, name, resourceRecordType, filter, primaryEndpoint, output);
+            var primaryResult = await GetResponseWithRetry(primaryClient, name, resourceRecordType, filter, primaryEndpoint, output).ConfigureAwait(false);
             results[primaryEndpoint] = primaryResult;
 
             output.WriteLine($"Primary ({primaryEndpoint}): {primaryResult.response.Answers?.Length ?? 0} records, Status: {primaryResult.response.Status}");
@@ -35,7 +35,7 @@ namespace DnsClientX.Tests {
             // Get all other endpoint results
             foreach (var endpoint in allEndpoints) {
                 using var client = new ClientX(endpoint);
-                var result = await GetResponseWithRetry(client, name, resourceRecordType, filter, endpoint, output);
+                var result = await GetResponseWithRetry(client, name, resourceRecordType, filter, endpoint, output).ConfigureAwait(false);
                 results[endpoint] = result;
 
                 output.WriteLine($"Provider {endpoint}: {result.response.Answers?.Length ?? 0} records, Status: {result.response.Status}");
@@ -106,11 +106,11 @@ namespace DnsClientX.Tests {
 
             for (int attempt = 1; attempt <= maxRetries; attempt++) {
                 try {
-                    var response = await client.ResolveFilter(name, type, filter);
+                    var response = await client.ResolveFilter(name, type, filter).ConfigureAwait(false);
 
                     if ((response.Answers?.Length ?? 0) == 0 && response.Status == DnsResponseCode.NoError && attempt < maxRetries) {
                         output.WriteLine($"  {endpoint}: Attempt {attempt} returned 0 records with NoError status, retrying...");
-                        await Task.Delay(delayMs);
+                        await Task.Delay(delayMs).ConfigureAwait(false);
                         continue;
                     }
 
@@ -126,7 +126,7 @@ namespace DnsClientX.Tests {
                         return (emptyResponse, $"Exception after {maxRetries} attempts: {ex.Message}");
                     }
                     output.WriteLine($"  {endpoint}: Attempt {attempt} failed: {ex.Message}, retrying...");
-                    await Task.Delay(delayMs);
+                    await Task.Delay(delayMs).ConfigureAwait(false);
                 }
             }
 
@@ -152,7 +152,7 @@ namespace DnsClientX.Tests {
             var primaryEndpoint = DnsEndpoint.Cloudflare;
 
             using var Client = new ClientX(primaryEndpoint);
-            DnsResponse aAnswersPrimary = await Client.ResolveFilter(name, resourceRecordType, filter);
+            DnsResponse aAnswersPrimary = await Client.ResolveFilter(name, resourceRecordType, filter).ConfigureAwait(false);
 
             foreach (var endpointCompare in Enum.GetValues(typeof(DnsEndpoint)).Cast<DnsEndpoint>()) {
                 if (endpointCompare == primaryEndpoint) {
@@ -166,7 +166,7 @@ namespace DnsClientX.Tests {
                 output.WriteLine("Provider: " + endpointCompare.ToString());
 
                 using var ClientToCompare = new ClientX(endpointCompare);
-                DnsResponse aAnswersToCompare = await ClientToCompare.ResolveFilter(name, resourceRecordType, filter);
+                DnsResponse aAnswersToCompare = await ClientToCompare.ResolveFilter(name, resourceRecordType, filter).ConfigureAwait(false);
 
                 var sortedAAnswers = aAnswersPrimary.Answers.OrderBy(a => a.Name).ThenBy(a => a.Type)
                     .ThenBy(a => a.Data).ToArray();
@@ -245,7 +245,7 @@ namespace DnsClientX.Tests {
             var primaryEndpoint = DnsEndpoint.Cloudflare;
             using var Client = new ClientX(primaryEndpoint);
 
-            DnsResponse[] aAnswersPrimary = await Client.ResolveFilter(names, resourceRecordType, filter);
+            DnsResponse[] aAnswersPrimary = await Client.ResolveFilter(names, resourceRecordType, filter).ConfigureAwait(false);
 
             foreach (var endpointCompare in Enum.GetValues(typeof(DnsEndpoint)).Cast<DnsEndpoint>()) {
                 if (endpointCompare == primaryEndpoint) {
@@ -257,7 +257,7 @@ namespace DnsClientX.Tests {
                 }
 
                 using var ClientToCompare = new ClientX(endpointCompare);
-                DnsResponse[] aAnswersToCompare = await ClientToCompare.ResolveFilter(names, resourceRecordType, filter);
+                DnsResponse[] aAnswersToCompare = await ClientToCompare.ResolveFilter(names, resourceRecordType, filter).ConfigureAwait(false);
 
                 for (int j = 0; j < aAnswersPrimary.Length; j++) {
                     var sortedAAnswers = aAnswersPrimary[j].Answers.OrderBy(a => a.Name).ThenBy(a => a.Type)

--- a/DnsClientX.Tests/EdnsDoBitTests.cs
+++ b/DnsClientX.Tests/EdnsDoBitTests.cs
@@ -29,26 +29,26 @@ namespace DnsClientX.Tests {
 
         private static async Task<byte[]> RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
             using var udp = new UdpClient(port);
-            UdpReceiveResult result = await udp.ReceiveAsync();
-            await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
+            UdpReceiveResult result = await udp.ReceiveAsync().ConfigureAwait(false);
+            await udp.SendAsync(response, response.Length, result.RemoteEndPoint).ConfigureAwait(false);
             return result.Buffer;
         }
 
         private static async Task<byte[]> RunTcpServerAsync(int port, byte[] response, CancellationToken token) {
             TcpListener listener = new TcpListener(IPAddress.Loopback, port);
             listener.Start();
-            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using TcpClient client = await listener.AcceptTcpClientAsync().ConfigureAwait(false);
             NetworkStream stream = client.GetStream();
             byte[] lengthBuffer = new byte[2];
-            await stream.ReadAsync(lengthBuffer, 0, 2, token);
+            await stream.ReadAsync(lengthBuffer, 0, 2, token).ConfigureAwait(false);
             if (BitConverter.IsLittleEndian) Array.Reverse(lengthBuffer);
             int length = BitConverter.ToUInt16(lengthBuffer, 0);
             byte[] queryBuffer = new byte[length];
-            await stream.ReadAsync(queryBuffer, 0, length, token);
+            await stream.ReadAsync(queryBuffer, 0, length, token).ConfigureAwait(false);
             byte[] prefix = BitConverter.GetBytes((ushort)response.Length);
             if (BitConverter.IsLittleEndian) Array.Reverse(prefix);
-            await stream.WriteAsync(prefix, 0, prefix.Length, token);
-            await stream.WriteAsync(response, 0, response.Length, token);
+            await stream.WriteAsync(prefix, 0, prefix.Length, token).ConfigureAwait(false);
+            await stream.WriteAsync(response, 0, response.Length, token).ConfigureAwait(false);
             listener.Stop();
             return queryBuffer;
         }
@@ -83,8 +83,8 @@ namespace DnsClientX.Tests {
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
             var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, cts.Token })!;
-            await task;
-            byte[] query = await udpTask;
+            await task.ConfigureAwait(false);
+            byte[] query = await udpTask.ConfigureAwait(false);
 
             AssertDoBit(query, "example.com");
         }
@@ -100,8 +100,8 @@ namespace DnsClientX.Tests {
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
             var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, cts.Token })!;
-            await task;
-            byte[] query = await tcpTask;
+            await task.ConfigureAwait(false);
+            byte[] query = await tcpTask.ConfigureAwait(false);
 
             AssertDoBit(query, "example.com");
         }

--- a/DnsClientX.Tests/Quad9ReliabilityFix.cs
+++ b/DnsClientX.Tests/Quad9ReliabilityFix.cs
@@ -32,7 +32,7 @@ namespace DnsClientX.Tests {
                         Debug = false
                     };
 
-                    var response = await client.Resolve(domain, DnsRecordType.A);
+                    var response = await client.Resolve(domain, DnsRecordType.A).ConfigureAwait(false);
 
                     if (response.Status == DnsResponseCode.NoError && response.Answers?.Length > 0) {
                         success = true;
@@ -48,7 +48,7 @@ namespace DnsClientX.Tests {
                     // Exponential backoff: 500ms, 1s, 2s, 4s
                     var delay = (int)(500 * Math.Pow(2, attempt - 1));
                     output.WriteLine($"  ⏱️ Waiting {delay}ms before retry...");
-                    await Task.Delay(delay);
+                    await Task.Delay(delay).ConfigureAwait(false);
                 }
             }
 
@@ -76,7 +76,7 @@ namespace DnsClientX.Tests {
                 using var client = new ClientX(provider) { Debug = false };
 
                 try {
-                    var response = await client.Resolve(domain, DnsRecordType.A);
+                    var response = await client.Resolve(domain, DnsRecordType.A).ConfigureAwait(false);
                     var success = response.Status == DnsResponseCode.NoError && response.Answers?.Length > 0;
 
                     output.WriteLine($"{provider}: {(success ? "✅ Reliable" : "❌ Failed")} " +

--- a/DnsClientX.Tests/QueryDnsByEndpoint.cs
+++ b/DnsClientX.Tests/QueryDnsByEndpoint.cs
@@ -14,7 +14,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
-            var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, endpoint);
+            var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, endpoint).ConfigureAwait(false);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "github.com");
                 Assert.True(answer.Type == DnsRecordType.TXT);
@@ -36,7 +36,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
-            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint);
+            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint).ConfigureAwait(false);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "evotec.pl");
                 Assert.True(answer.Type == DnsRecordType.A);
@@ -58,7 +58,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForPTR(DnsEndpoint endpoint) {
-            var response = await ClientX.QueryDns("1.1.1.1", DnsRecordType.PTR, endpoint);
+            var response = await ClientX.QueryDns("1.1.1.1", DnsRecordType.PTR, endpoint).ConfigureAwait(false);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Data == "one.one.one.one");
                 Assert.True(answer.Name == "1.1.1.1.in-addr.arpa");

--- a/DnsClientX.Tests/QueryDnsByHostName.cs
+++ b/DnsClientX.Tests/QueryDnsByHostName.cs
@@ -7,7 +7,7 @@ namespace DnsClientX.Tests {
         // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
         [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
         public async Task ShouldWorkForTXT(string hostName, DnsRequestFormat requestFormat) {
-            var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, hostName, requestFormat);
+            var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, hostName, requestFormat).ConfigureAwait(false);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "github.com");
                 Assert.True(answer.Type == DnsRecordType.TXT);
@@ -24,7 +24,7 @@ namespace DnsClientX.Tests {
         // [InlineData("8.8.8.8", DnsRequestFormat.JSON)]
         [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
         public async Task ShouldWorkForA(string hostName, DnsRequestFormat requestFormat) {
-            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, hostName, requestFormat);
+            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, hostName, requestFormat).ConfigureAwait(false);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "evotec.pl");
                 Assert.True(answer.Type == DnsRecordType.A);
@@ -42,7 +42,7 @@ namespace DnsClientX.Tests {
         [InlineData("208.67.222.222", DnsRequestFormat.DnsOverHttps)]
         public async Task ShouldWorkForMultipleDomains(string hostName, DnsRequestFormat requestFormat) {
             var domains = new[] { "evotec.pl", "google.com" };
-            var responses = await ClientX.QueryDns(domains, DnsRecordType.A, hostName, requestFormat);
+            var responses = await ClientX.QueryDns(domains, DnsRecordType.A, hostName, requestFormat).ConfigureAwait(false);
             foreach (var domain in domains) {
                 var response = responses.First(r => r.Questions?.Any(q => q.Name == domain) == true);
                 foreach (DnsAnswer answer in response.Answers) {

--- a/DnsClientX.Tests/QueryDnsByUri.cs
+++ b/DnsClientX.Tests/QueryDnsByUri.cs
@@ -9,7 +9,7 @@ namespace DnsClientX.Tests {
         [InlineData("https://208.67.222.123/dns-query", DnsRequestFormat.DnsOverHttps)]
         public async Task ShouldWorkForTXT(string baseUri, DnsRequestFormat requestFormat) {
             Uri uri = new Uri(baseUri);
-            var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, uri, requestFormat);
+            var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, uri, requestFormat).ConfigureAwait(false);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "github.com");
                 Assert.True(answer.Type == DnsRecordType.TXT);
@@ -25,7 +25,7 @@ namespace DnsClientX.Tests {
         [InlineData("https://dns.adguard.com/dns-query", DnsRequestFormat.DnsOverHttps)]
         public async Task ShouldWorkForA(string baseUri, DnsRequestFormat requestFormat) {
             Uri uri = new Uri(baseUri);
-            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, uri, requestFormat);
+            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, uri, requestFormat).ConfigureAwait(false);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "evotec.pl");
                 Assert.True(answer.Type == DnsRecordType.A);

--- a/DnsClientX.Tests/QueryDnsFailing.cs
+++ b/DnsClientX.Tests/QueryDnsFailing.cs
@@ -4,7 +4,7 @@ namespace DnsClientX.Tests {
         [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]
         [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
         public async Task ShouldFailWithTimeout(string hostName, DnsRequestFormat requestFormat) {
-            var response = await ClientX.QueryDns("github.com", DnsRecordType.A, hostName, requestFormat, timeOutMilliseconds: 500);
+            var response = await ClientX.QueryDns("github.com", DnsRecordType.A, hostName, requestFormat, timeOutMilliseconds: 500).ConfigureAwait(false);
             Assert.True(response.Status != DnsResponseCode.NoError);
         }
 
@@ -16,7 +16,7 @@ namespace DnsClientX.Tests {
             ClientX client = new ClientX(hostName, requestFormat) {
                 Debug = true
             };
-            var response = await client.Resolve("github.com", DnsRecordType.A);
+            var response = await client.Resolve("github.com", DnsRecordType.A).ConfigureAwait(false);
             Assert.True(response.Status != DnsResponseCode.NoError);
         }
     }

--- a/DnsClientX.Tests/QueryDnsIDN.cs
+++ b/DnsClientX.Tests/QueryDnsIDN.cs
@@ -17,7 +17,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
-            var response = await ClientX.QueryDns("www.bücher.de", DnsRecordType.A, endpoint);
+            var response = await ClientX.QueryDns("www.bücher.de", DnsRecordType.A, endpoint).ConfigureAwait(false);
             foreach (DnsAnswer answer in response.Answers) {
                 Assert.True(answer.Name == "www.xn--bcher-kva.de");
                 Assert.True(answer.Type == DnsRecordType.A);

--- a/DnsClientX.Tests/QueryDnsSpecialCases.cs
+++ b/DnsClientX.Tests/QueryDnsSpecialCases.cs
@@ -21,7 +21,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldDeliverResponseOnFailedQueries(DnsEndpoint endpoint) {
-            var response = await ClientX.QueryDns("spf-a.anotherexample.com", DnsRecordType.A, endpoint);
+            var response = await ClientX.QueryDns("spf-a.anotherexample.com", DnsRecordType.A, endpoint).ConfigureAwait(false);
             Assert.True(response.Answers.Length == 0);
             Assert.True(response.Status != DnsResponseCode.NoError);
             Assert.NotNull(response.Questions);

--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -18,7 +18,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
-            DnsAnswer[] aAnswers = await Client.ResolveAll("github.com", DnsRecordType.TXT);
+            DnsAnswer[] aAnswers = await Client.ResolveAll("github.com", DnsRecordType.TXT).ConfigureAwait(false);
             foreach (DnsAnswer answer in aAnswers) {
                 Assert.True(answer.Name == "github.com");
                 Assert.True((bool)(answer.Type == DnsRecordType.TXT));
@@ -44,7 +44,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
-            DnsAnswer[] aAnswers = await Client.ResolveAll("evotec.pl", DnsRecordType.A);
+            DnsAnswer[] aAnswers = await Client.ResolveAll("evotec.pl", DnsRecordType.A).ConfigureAwait(false);
             foreach (DnsAnswer answer in aAnswers) {
                 Assert.True(answer.Name == "evotec.pl");
                 Assert.True((bool)(answer.Type == DnsRecordType.A));

--- a/DnsClientX.Tests/ResolveFirst.cs
+++ b/DnsClientX.Tests/ResolveFirst.cs
@@ -18,7 +18,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
-            var answer = await Client.ResolveFirst("github.com", DnsRecordType.TXT);
+            var answer = await Client.ResolveFirst("github.com", DnsRecordType.TXT).ConfigureAwait(false);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "github.com");
             Assert.True(answer.Value.Type == DnsRecordType.TXT);
@@ -43,7 +43,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
-            var answer = await Client.ResolveFirst("evotec.pl", DnsRecordType.A);
+            var answer = await Client.ResolveFirst("evotec.pl", DnsRecordType.A).ConfigureAwait(false);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "evotec.pl");
             Assert.True(answer.Value.Type == DnsRecordType.A);

--- a/DnsClientX.Tests/ResolveHttpRequestException.cs
+++ b/DnsClientX.Tests/ResolveHttpRequestException.cs
@@ -48,7 +48,7 @@ namespace DnsClientX.Tests {
             var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
             clientField.SetValue(clientX, customClient);
 
-            var response = await clientX.Resolve("example.com", DnsRecordType.A, retryOnTransient: false);
+            var response = await clientX.Resolve("example.com", DnsRecordType.A, retryOnTransient: false).ConfigureAwait(false);
             Assert.Equal(DnsResponseCode.ServerFailure, response.Status);
             Assert.Contains("network error", response.Error);
         }

--- a/DnsClientX.Tests/ResolveSync.cs
+++ b/DnsClientX.Tests/ResolveSync.cs
@@ -60,7 +60,7 @@ namespace DnsClientX.Tests {
 
                 if (attempt < maxRetries)
                 {
-                    await Task.Delay(1000 * attempt); // Exponential backoff
+                    await Task.Delay(1000 * attempt).ConfigureAwait(false); // Exponential backoff
                 }
             }
 
@@ -88,7 +88,7 @@ namespace DnsClientX.Tests {
         public async Task ShouldWorkForTXTSync(DnsEndpoint endpoint)
         {
             using var client = new ClientX(endpoint);
-            var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT);
+            var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT).ConfigureAwait(false);
 
             Assert.True(response.Answers.Length > 0, "Expected at least one answer");
             foreach (DnsAnswer answer in response.Answers)
@@ -115,7 +115,7 @@ namespace DnsClientX.Tests {
         public async Task ShouldWorkForFirstSyncTXT(DnsEndpoint endpoint)
         {
             using var client = new ClientX(endpoint);
-            var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT);
+            var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT).ConfigureAwait(false);
 
             Assert.True(response.Answers.Length > 0, "Expected at least one answer");
             var answer = response.Answers[0];
@@ -140,7 +140,7 @@ namespace DnsClientX.Tests {
         public async Task ShouldWorkForAllSyncTXT(DnsEndpoint endpoint)
         {
             using var client = new ClientX(endpoint);
-            var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT);
+            var response = await TryResolveWithDiagnostics(client, "github.com", DnsRecordType.TXT).ConfigureAwait(false);
 
             Assert.True(response.Answers.Length > 0, "Expected at least one answer");
             foreach (DnsAnswer answer in response.Answers)
@@ -167,7 +167,7 @@ namespace DnsClientX.Tests {
         public async Task ShouldWorkForASync(DnsEndpoint endpoint)
         {
             using var client = new ClientX(endpoint);
-            var response = await TryResolveWithDiagnostics(client, "evotec.pl", DnsRecordType.A);
+            var response = await TryResolveWithDiagnostics(client, "evotec.pl", DnsRecordType.A).ConfigureAwait(false);
 
             Assert.True(response.Answers.Length > 0, "Expected at least one answer");
             foreach (DnsAnswer answer in response.Answers)

--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -20,7 +20,7 @@ namespace DnsClientX.Tests {
                 return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1 })!;
             }
 
-            await Assert.ThrowsAsync<TimeoutException>(Invoke);
+            await Assert.ThrowsAsync<TimeoutException>(Invoke).ConfigureAwait(false);
             Assert.Equal(3, attempts);
         }
 
@@ -39,7 +39,7 @@ namespace DnsClientX.Tests {
             }
 
             var sw = Stopwatch.StartNew();
-            await Assert.ThrowsAsync<TimeoutException>(Invoke);
+            await Assert.ThrowsAsync<TimeoutException>(Invoke).ConfigureAwait(false);
             sw.Stop();
 
             Assert.Equal(3, attempts);

--- a/DnsClientX.Tests/TcpTimeoutTests.cs
+++ b/DnsClientX.Tests/TcpTimeoutTests.cs
@@ -13,7 +13,7 @@ namespace DnsClientX.Tests {
             // Using a very short timeout to test the timeout functionality
             // Testing with a domain that should exist but using a very short timeout
             var response = await ClientX.QueryDns("google.com", DnsRecordType.A, DnsEndpoint.SystemTcp,
-                timeOutMilliseconds: 10); // Very short timeout - 10ms
+                timeOutMilliseconds: 10).ConfigureAwait(false); // Very short timeout - 10ms
 
             // The response should indicate an error (likely ServerFailure or timeout)
             // With such a short timeout, it should either timeout or complete very quickly
@@ -30,7 +30,7 @@ namespace DnsClientX.Tests {
             }
             // Test that normal operation still works with reasonable timeout
             var response = await ClientX.QueryDns("google.com", DnsRecordType.A, DnsEndpoint.SystemTcp,
-                timeOutMilliseconds: 5000); // 5 second timeout should be sufficient
+                timeOutMilliseconds: 5000).ConfigureAwait(false); // 5 second timeout should be sufficient
 
             // This should work normally - though it might still fail if DNS resolution fails
             // We just check that it doesn't throw an exception and returns a response

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -22,7 +22,7 @@ namespace DnsClientX {
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
             ClientX client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs).ConfigureAwait(false);
             return data;
         }
 
@@ -65,7 +65,7 @@ namespace DnsClientX {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs).ConfigureAwait(false);
             return data;
         }
 
@@ -111,7 +111,7 @@ namespace DnsClientX {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs).ConfigureAwait(false);
             return data;
         }
 
@@ -156,7 +156,7 @@ namespace DnsClientX {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs).ConfigureAwait(false);
             return data;
         }
 
@@ -201,7 +201,7 @@ namespace DnsClientX {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs).ConfigureAwait(false);
             return data;
         }
 
@@ -246,7 +246,7 @@ namespace DnsClientX {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs).ConfigureAwait(false);
             return data;
         }
 
@@ -268,7 +268,7 @@ namespace DnsClientX {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs).ConfigureAwait(false);
             return data;
         }
 
@@ -311,7 +311,7 @@ namespace DnsClientX {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs).ConfigureAwait(false);
             return data;
         }
 

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -36,9 +36,9 @@ namespace DnsClientX {
             int retryDelayMs = 100,
             CancellationToken cancellationToken = default) {
             if (retryOnTransient) {
-                return await RetryAsync(() => ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, cancellationToken), maxRetries, retryDelayMs);
+                return await RetryAsync(() => ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, cancellationToken), maxRetries, retryDelayMs).ConfigureAwait(false);
             } else {
-                return await ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, cancellationToken);
+                return await ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -60,17 +60,17 @@ namespace DnsClientX {
 
             DnsResponse response;
             if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSON) {
-                response = await Client.ResolveJsonFormat(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+                response = await Client.ResolveJsonFormat(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps) {
-                response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+                response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
-                response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+                response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {
-                response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+                response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTCP) {
-                response = await DnsWireResolveTcp.ResolveWireFormatTcp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+                response = await DnsWireResolveTcp.ResolveWireFormatTcp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverUDP) {
-                response = await DnsWireResolveUdp.ResolveWireFormatUdp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+                response = await DnsWireResolveUdp.ResolveWireFormatUdp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else {
                 throw new DnsClientException($"Invalid RequestFormat: {EndpointConfiguration.RequestFormat}");
             }
@@ -93,7 +93,7 @@ namespace DnsClientX {
 
             for (int attempt = 1; attempt <= maxRetries; attempt++) {
                 try {
-                    var result = await action();
+                    var result = await action().ConfigureAwait(false);
 
                     // Special handling for DnsResponse - check if it indicates a transient error
                     if (result is DnsResponse response && IsTransientResponse(response)) {
@@ -103,7 +103,7 @@ namespace DnsClientX {
                             return result;
                         }
                         // Not the last attempt, wait and retry with normal delay
-                        await Task.Delay(delayMs);
+                        await Task.Delay(delayMs).ConfigureAwait(false);
                         continue;
                     }
 
@@ -117,7 +117,7 @@ namespace DnsClientX {
                     }
 
                     // Not the last attempt, wait and retry with normal delay
-                    await Task.Delay(delayMs);
+                    await Task.Delay(delayMs).ConfigureAwait(false);
                     continue;
                 }
             }
@@ -273,12 +273,12 @@ namespace DnsClientX {
                 tasks[i] = Resolve(name, types[i], requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, cancellationToken);
             }
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             DnsResponse[] responses = new DnsResponse[tasks.Length];
 
             for (int i = 0; i < tasks.Length; i++) {
-                responses[i] = await tasks[i];
+                responses[i] = await tasks[i].ConfigureAwait(false);
             }
 
             return responses;
@@ -324,7 +324,7 @@ namespace DnsClientX {
                 }
             }
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             return tasks.Select(task => task.Result).ToArray();
         }
@@ -365,7 +365,7 @@ namespace DnsClientX {
                 tasks.Add(Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, cancellationToken));
             }
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             return tasks.Select(task => task.Result).ToArray();
         }

--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -21,7 +21,7 @@ namespace DnsClientX {
         public async Task<DnsAnswer[]> ResolveAll(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
             DnsResponse res = retryOnTransient
                 ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
-                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0).ConfigureAwait(false);
 
             // If the response is null, return an empty array
             if (res.Answers is null) return Array.Empty<DnsAnswer>();
@@ -45,7 +45,7 @@ namespace DnsClientX {
         public async Task<DnsAnswer[]> ResolveAll(string name, string filter, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
             DnsResponse res = retryOnTransient
                 ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
-                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0).ConfigureAwait(false);
 
             // If the response is null, return an empty array
             if (res.Answers is null) return Array.Empty<DnsAnswer>();
@@ -71,7 +71,7 @@ namespace DnsClientX {
         public async Task<DnsAnswer[]> ResolveAll(string name, Regex regexPattern, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
             DnsResponse res = retryOnTransient
                 ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
-                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0).ConfigureAwait(false);
 
             // If the response is null, return an empty array
             if (res.Answers is null) return Array.Empty<DnsAnswer>();

--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -22,7 +22,7 @@ namespace DnsClientX {
         public async Task<DnsResponse[]> ResolveFilter(string[] names, DnsRecordType type, string filter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
             var tasks = names.Select(name => Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs)).ToList();
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             var responses = tasks.Select(task => task.Result).ToList();
 
@@ -53,7 +53,7 @@ namespace DnsClientX {
         public async Task<DnsResponse[]> ResolveFilter(string[] names, DnsRecordType type, Regex regexFilter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
             var tasks = names.Select(name => Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs)).ToList();
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             var responses = tasks.Select(task => task.Result).ToList();
 
@@ -83,7 +83,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response that matches the filter.</returns>
         public async Task<DnsResponse> ResolveFilter(string name, DnsRecordType type, string filter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
-            var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs);
+            var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(filter) && response.Answers != null) {
                 response.Answers = FilterAnswers(response.Answers, filter, type);
@@ -106,7 +106,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response that matches the filter.</returns>
         public async Task<DnsResponse> ResolveFilter(string name, DnsRecordType type, Regex regexFilter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
-            var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs);
+            var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs).ConfigureAwait(false);
 
             if (response.Answers != null) {
                 response.Answers = FilterAnswersRegex(response.Answers, regexFilter, type);

--- a/DnsClientX/DnsClientX.ResolveFirst.cs
+++ b/DnsClientX/DnsClientX.ResolveFirst.cs
@@ -28,7 +28,7 @@ namespace DnsClientX {
                 returnAllTypes: false,
                 retryOnTransient: retryOnTransient,
                 maxRetries: maxRetries,
-                retryDelayMs: retryDelayMs);
+                retryDelayMs: retryDelayMs).ConfigureAwait(false);
 
             return res.Answers?.FirstOrDefault(x => x.Type == type);
         }

--- a/DnsClientX/ProtocolDnsJson/DnsJson.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJson.cs
@@ -21,13 +21,13 @@ namespace DnsClientX {
         /// <param name="response">The HTTP response message with JSON as a body.</param>
         /// <param name="debug">Whether to print the JSON data to the console.</param>
         internal static async Task<T> Deserialize<T>(this HttpResponseMessage response, bool debug = false) {
-            using Stream stream = await response.Content.ReadAsStreamAsync();
+            using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             if (stream.Length == 0) throw new DnsClientException("Response content is empty, can't parse as JSON.");
             try {
                 if (debug) {
                     // Read the stream as a string
                     StreamReader reader = new StreamReader(stream);
-                    string json = await reader.ReadToEndAsync();
+                    string json = await reader.ReadToEndAsync().ConfigureAwait(false);
                     // Print the JSON data to the console
                     Console.WriteLine(json);
                     // Deserialize the JSON data

--- a/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
@@ -28,9 +28,9 @@ namespace DnsClientX {
 
             using HttpRequestMessage req = new(HttpMethod.Get, url);
             try {
-                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken);
+                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken).ConfigureAwait(false);
 
-                DnsResponse response = await res.Deserialize<DnsResponse>(debug);
+                DnsResponse response = await res.Deserialize<DnsResponse>(debug).ConfigureAwait(false);
                 response.AddServerDetails(configuration);
                 return response;
             } catch (Exception ex) {

--- a/DnsClientX/ProtocolDnsWire/DnsWire.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWire.cs
@@ -35,13 +35,13 @@ namespace DnsClientX {
                 if (bytes != null) {
                     dnsWireFormatBytes = bytes;
                 } else {
-                    using Stream stream = await res.Content.ReadAsStreamAsync();
+                    using Stream stream = await res.Content.ReadAsStreamAsync().ConfigureAwait(false);
                     if (stream.Length == 0) throw new DnsClientException("Response content is empty, can't parse as DNS wire format.");
                     // Ensure the stream's position is at the start
                     stream.Position = 0;
 
                     dnsWireFormatBytes = new byte[stream.Length];
-                    await ReadExactAsync(stream, dnsWireFormatBytes, 0, dnsWireFormatBytes.Length, CancellationToken.None);
+                    await ReadExactAsync(stream, dnsWireFormatBytes, 0, dnsWireFormatBytes.Length, CancellationToken.None).ConfigureAwait(false);
                 }
 
                 if (debug) {
@@ -441,7 +441,7 @@ namespace DnsClientX {
         /// </summary>
         internal static async Task ReadExactAsync(Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
             int read;
-            while (count > 0 && (read = await stream.ReadAsync(buffer, offset, count, cancellationToken)) > 0) {
+            while (count > 0 && (read = await stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false)) > 0) {
                 offset += read;
                 count -= read;
             }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -36,8 +36,8 @@ namespace DnsClientX {
             }
 
             try {
-                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken);
-                DnsResponse response = await res.DeserializeDnsWireFormat(debug);
+                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken).ConfigureAwait(false);
+                DnsResponse response = await res.DeserializeDnsWireFormat(debug).ConfigureAwait(false);
                 response.AddServerDetails(endpointConfiguration);
                 if (res.StatusCode != HttpStatusCode.OK || !string.IsNullOrEmpty(response.Error)) {
                     string message = string.Concat(

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -64,7 +64,7 @@ namespace DnsClientX {
 
             // Create a new TCP client and connect to the DNS server
             var client = new TcpClient();
-            await ConnectAsync(client, dnsServer, port, cancellationToken);
+            await ConnectAsync(client, dnsServer, port, cancellationToken).ConfigureAwait(false);
 
             // Create a new SSL stream for the secure connection
             //var sslStream = new SslStream(client.GetStream(), false, (sender, certificate, chain, sslPolicyErrors) => true);
@@ -76,15 +76,15 @@ namespace DnsClientX {
 
 
             // Authenticate the client using the DNS server's name and the TLS protocol
-            await sslStream.AuthenticateAsClientAsync(dnsServer, null, SslProtocols.Tls12, false);
+            await sslStream.AuthenticateAsClientAsync(dnsServer, null, SslProtocols.Tls12, false).ConfigureAwait(false);
 
             // Write the combined query bytes to the SSL stream and flush it
-            await sslStream.WriteAsync(combinedQueryBytes, 0, combinedQueryBytes.Length, cancellationToken);
-            await sslStream.FlushAsync(cancellationToken);
+            await sslStream.WriteAsync(combinedQueryBytes, 0, combinedQueryBytes.Length, cancellationToken).ConfigureAwait(false);
+            await sslStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
             // Prepare to read the response with handling for length prefix
             var lengthPrefixBuffer = new byte[2];
-            int prefixBytesRead = await sslStream.ReadAsync(lengthPrefixBuffer, 0, 2, cancellationToken);
+            int prefixBytesRead = await sslStream.ReadAsync(lengthPrefixBuffer, 0, 2, cancellationToken).ConfigureAwait(false);
             if (prefixBytesRead != 2) {
                 throw new Exception("Failed to read the length prefix of the response.");
             }
@@ -93,7 +93,7 @@ namespace DnsClientX {
             var responseBuffer = new byte[responseLength];
             int totalBytesRead = 0;
             while (totalBytesRead < responseLength) {
-                int bytesRead = await sslStream.ReadAsync(responseBuffer, totalBytesRead, responseLength - totalBytesRead, cancellationToken);
+                int bytesRead = await sslStream.ReadAsync(responseBuffer, totalBytesRead, responseLength - totalBytesRead, cancellationToken).ConfigureAwait(false);
                 if (bytesRead == 0) {
                     throw new Exception("The stream was closed before the entire response could be read.");
                 }
@@ -101,7 +101,7 @@ namespace DnsClientX {
             }
 
             // Deserialize the response from DNS wire format
-            var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer);
+            var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
             response.AddServerDetails(endpointConfiguration);
             // Close the SSL stream and the TCP client
             sslStream.Close();
@@ -121,13 +121,13 @@ namespace DnsClientX {
             var connectTask = client.ConnectAsync(host, port);
             var delayTask = Task.Delay(Timeout.Infinite, cancellationToken);
 
-            var completed = await Task.WhenAny(connectTask, delayTask);
+            var completed = await Task.WhenAny(connectTask, delayTask).ConfigureAwait(false);
             if (completed != connectTask) {
                 client.Close();
                 throw new OperationCanceledException(cancellationToken);
             }
 
-            await connectTask;
+            await connectTask.ConfigureAwait(false);
         }
     }
 }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -36,8 +36,8 @@ namespace DnsClientX {
             content.Headers.ContentType = new MediaTypeHeaderValue("application/dns-message");
             content.Headers.ContentLength = queryBytes.Length;
 
-            var postAsync = await client.PostAsync(client.BaseAddress, content, cancellationToken);
-            var response = await postAsync.DeserializeDnsWireFormat(debug);
+            var postAsync = await client.PostAsync(client.BaseAddress, content, cancellationToken).ConfigureAwait(false);
+            var response = await postAsync.DeserializeDnsWireFormat(debug).ConfigureAwait(false);
             response.AddServerDetails(endpointConfiguration);
             return response;
         }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -43,10 +43,10 @@ namespace DnsClientX {
             }
             try {
                 // Send the DNS query over TCP and receive the response
-                var responseBuffer = await SendQueryOverTcp(queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken);
+                var responseBuffer = await SendQueryOverTcp(queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
 
                 // Deserialize the response from DNS wire format
-                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer);
+                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
                 response.AddServerDetails(endpointConfiguration);
                 return response;
             } catch (Exception ex) {
@@ -88,7 +88,7 @@ namespace DnsClientX {
             using (var tcpClient = new TcpClient()) {
                 try {
                     // Connect to the server with timeout
-                    await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken);
+                    await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
 
                     // Get the stream
                     var stream = tcpClient.GetStream();
@@ -102,27 +102,27 @@ namespace DnsClientX {
                     // Write operations with timeout
                     var writeTask = stream.WriteAsync(lengthBytes, 0, lengthBytes.Length, cancellationToken);
                     var timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
-                    var completedTask = await Task.WhenAny(writeTask, timeoutTask);
+                    var completedTask = await Task.WhenAny(writeTask, timeoutTask).ConfigureAwait(false);
 
                     if (completedTask == timeoutTask) {
                         throw new TimeoutException($"Writing length to {dnsServer}:{port} timed out after {timeoutMilliseconds} milliseconds.");
                     }
-                    await writeTask;
+                    await writeTask.ConfigureAwait(false);
 
                     // Write the query
                     writeTask = stream.WriteAsync(query, 0, query.Length, cancellationToken);
                     timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
-                    completedTask = await Task.WhenAny(writeTask, timeoutTask);
+                    completedTask = await Task.WhenAny(writeTask, timeoutTask).ConfigureAwait(false);
 
                     if (completedTask == timeoutTask) {
                         throw new TimeoutException($"Writing query to {dnsServer}:{port} timed out after {timeoutMilliseconds} milliseconds.");
                     }
-                    await writeTask;
+                    await writeTask.ConfigureAwait(false);
 
                     // Read the length of the response with timeout
                     lengthBytes = new byte[2];
                     var readTask = ReadExactWithTimeoutAsync(stream, lengthBytes, 0, lengthBytes.Length, timeoutMilliseconds, cancellationToken);
-                    await readTask;
+                    await readTask.ConfigureAwait(false);
 
                     if (BitConverter.IsLittleEndian) {
                         Array.Reverse(lengthBytes); // Ensure big-endian order
@@ -132,7 +132,7 @@ namespace DnsClientX {
                     // Read the response with timeout
                     var responseBuffer = new byte[responseLength];
                     readTask = ReadExactWithTimeoutAsync(stream, responseBuffer, 0, responseBuffer.Length, timeoutMilliseconds, cancellationToken);
-                    await readTask;
+                    await readTask.ConfigureAwait(false);
 
                     return responseBuffer;
                 } catch (OperationCanceledException) {
@@ -147,13 +147,13 @@ namespace DnsClientX {
         private static async Task ReadExactWithTimeoutAsync(Stream stream, byte[] buffer, int offset, int count, int timeoutMilliseconds, CancellationToken cancellationToken) {
             var readTask = DnsWire.ReadExactAsync(stream, buffer, offset, count, cancellationToken);
             var timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
-            var completedTask = await Task.WhenAny(readTask, timeoutTask);
+            var completedTask = await Task.WhenAny(readTask, timeoutTask).ConfigureAwait(false);
 
             if (completedTask == timeoutTask) {
                 throw new TimeoutException($"Reading from stream timed out after {timeoutMilliseconds} milliseconds.");
             }
 
-            await readTask; // Ensure any exceptions from read are propagated
+            await readTask.ConfigureAwait(false); // Ensure any exceptions from read are propagated
         }
 
         /// <summary>
@@ -171,14 +171,14 @@ namespace DnsClientX {
             var connectTask = tcpClient.ConnectAsync(host, port);
             var delayTask = Task.Delay(Timeout.Infinite, linkedCts.Token);
 
-            var completed = await Task.WhenAny(connectTask, delayTask);
+            var completed = await Task.WhenAny(connectTask, delayTask).ConfigureAwait(false);
             if (completed != connectTask) {
                 tcpClient.Close();
                 cancellationToken.ThrowIfCancellationRequested();
                 throw new TimeoutException($"Connection to {host}:{port} timed out after {timeoutMilliseconds} milliseconds.");
             }
 
-            await connectTask; // propagate possible exceptions
+            await connectTask.ConfigureAwait(false); // propagate possible exceptions
         }
     }
 }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -44,14 +44,14 @@ namespace DnsClientX {
 
             try {
                 // Send the DNS query over UDP and receive the response
-                var responseBuffer = await SendQueryOverUdp(queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken);
+                var responseBuffer = await SendQueryOverUdp(queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
 
                 // Deserialize the response from DNS wire format
-                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer);
+                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
                 if (response.IsTruncated) {
                     // If the response is truncated, retry the query over TCP
                     response = await DnsWireResolveTcp.ResolveWireFormatTcp(dnsServer, port, name, type, requestDnsSec,
-                        validateDnsSec, debug, endpointConfiguration, cancellationToken);
+                        validateDnsSec, debug, endpointConfiguration, cancellationToken).ConfigureAwait(false);
                 }
                 response.AddServerDetails(endpointConfiguration);
                 return response;
@@ -98,7 +98,7 @@ namespace DnsClientX {
                 var serverEndpoint = new IPEndPoint(IPAddress.Parse(dnsServer), port);
 
                 // Send the query
-                await udpClient.SendAsync(query, query.Length, serverEndpoint);
+                await udpClient.SendAsync(query, query.Length, serverEndpoint).ConfigureAwait(false);
 
                 // Set up the cancellation token for the timeout
                 using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)) {
@@ -106,7 +106,7 @@ namespace DnsClientX {
                     try {
                         // Receive the response with a timeout
                         var responseTask = udpClient.ReceiveAsync();
-                        var completedTask = await Task.WhenAny(responseTask, Task.Delay(timeoutMilliseconds, cts.Token));
+                        var completedTask = await Task.WhenAny(responseTask, Task.Delay(timeoutMilliseconds, cts.Token)).ConfigureAwait(false);
 
                         if (completedTask == responseTask) {
                             // If the response task completed, return the response buffer

--- a/RetryTest/Program.cs
+++ b/RetryTest/Program.cs
@@ -28,12 +28,12 @@ namespace RetryTest {
                         var client = new ClientX(endpoint);
 
                         // Test ResolveAll which is what the failing test uses
-                        var answers = await client.ResolveAll(domain, recordType);
+                        var answers = await client.ResolveAll(domain, recordType).ConfigureAwait(false);
 
                         Console.WriteLine($"{name}: {answers.Length} records");
                         if (answers.Length == 0) {
                             // Get the full response to see status code
-                            var fullResponse = await client.Resolve(domain, recordType);
+                            var fullResponse = await client.Resolve(domain, recordType).ConfigureAwait(false);
                             Console.WriteLine($"  Status: {fullResponse.Status}");
                             Console.WriteLine($"  Error: {fullResponse.Error ?? "None"}");
                         } else {


### PR DESCRIPTION
## Summary
- append `.ConfigureAwait(false)` to all await calls where the continuation context is not needed
- ensure correct chaining in async loops

## Testing
- `dotnet test` *(fails: The tests attempt network access and fail)*

------
https://chatgpt.com/codex/tasks/task_e_6862cce9eeb4832e9e8766f43ac3f5f2