### PR TITLE
Improve DNSSEC validation handling

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -84,6 +84,14 @@ namespace DnsClientX {
                 response.Answers = Array.Empty<DnsAnswer>();
             }
 
+            if (validateDnsSec) {
+                bool hasRrsig = response.Answers != null && response.Answers.Any(a => a.Type == DnsRecordType.RRSIG);
+                if (!response.AuthenticData && !hasRrsig) {
+                    string validationError = "DNSSEC validation failed.";
+                    response.Error = string.IsNullOrEmpty(response.Error) ? validationError : $"{response.Error} {validationError}";
+                }
+            }
+
             return response;
         }
 


### PR DESCRIPTION
## Summary
- add minimal DNSSEC validation check when `validateDnsSec` is requested

## Testing
- `dotnet build --no-restore -c Release`
- `dotnet test -c Release -v minimal` *(fails: SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_6862d16af294832e8073376da22977ce