### PR TITLE
Fix StreamReader disposal in JSON deserialization

### DIFF
--- a/DnsClientX/ProtocolDnsJson/DnsJson.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJson.cs
@@ -26,7 +26,7 @@ namespace DnsClientX {
             try {
                 if (debug) {
                     // Read the stream as a string
-                    StreamReader reader = new StreamReader(stream);
+                    using StreamReader reader = new StreamReader(stream);
                     string json = await reader.ReadToEndAsync();
                     // Write the JSON data using logger
                     Settings.Logger.WriteDebug(json);


### PR DESCRIPTION
## Summary
- dispose of StreamReader using a `using` statement in `DnsJson`

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6862dff7b8a0832ea33ee56b768e21c7