### PR TITLE
Fix disposal for POST DNS requests

### DIFF
--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -32,11 +32,11 @@ namespace DnsClientX {
                 Settings.Logger.WriteDebug($"Sending query: {BitConverter.ToString(queryBytes)}");
             }
 
-            var content = new ByteArrayContent(queryBytes);
+            using ByteArrayContent content = new(queryBytes);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/dns-message");
             content.Headers.ContentLength = queryBytes.Length;
 
-            var postAsync = await client.PostAsync(client.BaseAddress, content, cancellationToken);
+            using HttpResponseMessage postAsync = await client.PostAsync(client.BaseAddress, content, cancellationToken);
             var response = await postAsync.DeserializeDnsWireFormat(debug);
             response.AddServerDetails(endpointConfiguration);
             return response;


### PR DESCRIPTION
## Summary
- dispose `ByteArrayContent` with a `using` block in `ResolveWireFormatPost`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test` *(fails: The SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_6862dfca6840832eb23736b359fad90e