### PR TITLE
Update hostname handling for Uri constructor

### DIFF
--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -100,7 +100,8 @@ namespace DnsClientX {
         public Configuration(Uri baseUri, DnsRequestFormat requestFormat) {
             BaseUri = baseUri;
             RequestFormat = requestFormat;
-            hostnames = new List<string> { Hostname };
+            Hostname = baseUri.Host;
+            hostnames = new List<string> { baseUri.Host };
 
             if (requestFormat == DnsRequestFormat.DnsOverTLS) {
                 Port = 853;


### PR DESCRIPTION
## Summary
- initialize `hostnames` from `baseUri.Host`
- set `Hostname` when constructing from `Uri`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: network errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862dfeedb00832e928728c6a2213a90