### PR TITLE
Handle transient DNS responses with exception

### DIFF
--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -19,9 +19,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public async Task<DnsAnswer[]> ResolveAll(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
-            DnsResponse res = retryOnTransient
-                ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
-                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+            DnsResponse res;
+            try {
+                res = retryOnTransient
+                    ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
+                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+            } catch (DnsClientException ex) {
+                res = ex.Response;
+            }
 
             // If the response is null, return an empty array
             if (res.Answers is null) return Array.Empty<DnsAnswer>();
@@ -43,9 +48,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public async Task<DnsAnswer[]> ResolveAll(string name, string filter, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
-            DnsResponse res = retryOnTransient
-                ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
-                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+            DnsResponse res;
+            try {
+                res = retryOnTransient
+                    ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
+                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+            } catch (DnsClientException ex) {
+                res = ex.Response;
+            }
 
             // If the response is null, return an empty array
             if (res.Answers is null) return Array.Empty<DnsAnswer>();
@@ -69,9 +79,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public async Task<DnsAnswer[]> ResolveAll(string name, Regex regexPattern, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100) {
-            DnsResponse res = retryOnTransient
-                ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
-                : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+            DnsResponse res;
+            try {
+                res = retryOnTransient
+                    ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
+                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
+            } catch (DnsClientException ex) {
+                res = ex.Response;
+            }
 
             // If the response is null, return an empty array
             if (res.Answers is null) return Array.Empty<DnsAnswer>();


### PR DESCRIPTION
## Summary
- throw `DnsClientException` when retries still yield transient responses
- catch `DnsClientException` in `Resolve` and `ResolveAll`
- update retry tests for new behavior

## Testing
- `dotnet build`
- `dotnet test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6862e0280fc0832eb1a035ef4c1d39ea