### PR TITLE
Ensure DNS list is unique

### DIFF
--- a/DnsClientX.Tests/DeduplicateDnsServersTests.cs
+++ b/DnsClientX.Tests/DeduplicateDnsServersTests.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DeduplicateDnsServersTests {
+        [Fact]
+        public void DuplicateDnsServers_AreRemoved() {
+            MethodInfo method = typeof(SystemInformation).GetMethod("DeduplicateDnsServers", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var input = new List<string> { "1.1.1.1", "1.1.1.1", "[2001:db8::1]", "[2001:db8::1]" };
+            var result = (List<string>)method.Invoke(null, new object[] { input })!;
+            Assert.Equal(new[] { "1.1.1.1", "[2001:db8::1]" }, result);
+        }
+    }
+}

--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -126,6 +126,7 @@ namespace DnsClientX {
                 dnsServers.Add("8.8.8.8");    // Google Primary
             }
 
+            dnsServers = DeduplicateDnsServers(dnsServers);
             DebugPrint($"Final DNS server list: {string.Join(", ", dnsServers)}");
 
             return dnsServers;
@@ -171,6 +172,10 @@ namespace DnsClientX {
             }
 
             return servers;
+        }
+
+        private static List<string> DeduplicateDnsServers(IEnumerable<string> servers) {
+            return servers.Distinct().ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- remove duplicate DNS server entries before caching
- add unit test for DNS de-duplication

## Testing
- `dotnet test --filter FullyQualifiedName~DeduplicateDnsServersTests`

------
https://chatgpt.com/codex/tasks/task_e_6862dfd1eef8832e92542fa4b17d9216