### PR TITLE
Wrap TcpClient usage with using block

### DIFF
--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -85,13 +85,13 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
-            using (var tcpClient = new TcpClient()) {
-                try {
-                    // Connect to the server with timeout
-                    await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken);
+            using var tcpClient = new TcpClient();
+            try {
+                // Connect to the server with timeout
+                await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken);
 
-                    // Get the stream
-                    var stream = tcpClient.GetStream();
+                // Get the stream
+                using var stream = tcpClient.GetStream();
 
                     // Write the length of the query as a 16-bit big-endian integer
                     var lengthBytes = BitConverter.GetBytes((ushort)query.Length);
@@ -138,7 +138,6 @@ namespace DnsClientX {
                 } catch (OperationCanceledException) {
                     throw new TimeoutException($"The TCP DNS query timed out after {timeoutMilliseconds} milliseconds.");
                 }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- dispose `TcpClient` and its `NetworkStream` via `using`
- keep method logic intact while ensuring resources free on exceptions

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: DNS tests require network)*

------
https://chatgpt.com/codex/tasks/task_e_6862e00946ec832eb338f2abf58a793e