### PR TITLE
Implement server fallback and random queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,12 @@ $Output.AnswersMinimal | Format-Table
 $Output = Resolve-DnsQuery -Name 'github.com', 'evotec.pl', 'google.com' -Type TXT, A -Verbose -Server "192.168.241.5" -FullResponse
 $Output.Questions | Format-Table
 $Output.AnswersMinimal | Format-Table
+
+$Output = Resolve-DnsQuery -Name 'evotec.pl' -Type A -Server '1.1.1.1','8.8.8.8' -Fallback
+$Output.AnswersMinimal | Format-Table
+
+$Output = Resolve-DnsQuery -Name 'evotec.pl' -Type A -Server '1.1.1.1','8.8.8.8' -Fallback -RandomServer
+$Output.AnswersMinimal | Format-Table
 ```
 
 ## Please share with the community


### PR DESCRIPTION
## Summary
- add `Fallback` and `RandomServer` switches
- randomize order of servers when requested
- stop on first successful server when using `-Fallback`
- update README with new switch examples

## Testing
- `dotnet build`
- `dotnet test` *(fails: SSL and invalid request errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862e0167580832ebdb549153433c4d9