### PR TITLE
Fix Cloudflare spelling in docs

### DIFF
--- a/DnsClientX/Definitions/DnsEndpoint.cs
+++ b/DnsClientX/Definitions/DnsEndpoint.cs
@@ -29,7 +29,7 @@ namespace DnsClientX {
         /// </summary>
         CloudflareWireFormat,
         /// <summary>
-        /// Cloudfare's DNS-over-HTTPS endpoint using wire format with POST method.
+        /// Cloudflare's DNS-over-HTTPS endpoint using wire format with POST method.
         /// </summary>
         CloudflareWireFormatPost,
         /// <summary>


### PR DESCRIPTION
## Summary
- fix Cloudflare spelling in `DnsEndpoint` enum XML docs

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: SSL authentication errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9ce46e8832eb50fb0e9a5d63503