### PR TITLE
Ensure culture invariant regex

### DIFF
--- a/DnsClientX.Tests/RegexCultureInvariantTests.cs
+++ b/DnsClientX.Tests/RegexCultureInvariantTests.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class RegexCultureInvariantTests {
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("tr-TR")]
+        public void ConvertData_TlsaRecord_ConsistentAcrossCultures(string culture) {
+            var answer = new DnsAnswer {
+                Name = "example.com",
+                Type = DnsRecordType.TLSA,
+                TTL = 3600,
+                DataRaw = "3 1 1 2b6e0f"
+            };
+
+            var original = Thread.CurrentThread.CurrentCulture;
+            try {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+                Assert.Equal("3 1 1 2b6e0f", answer.Data);
+            } finally {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("tr-TR")]
+        public void FilterAnswersRegex_ConsistentAcrossCultures(string culture) {
+            var client = new ClientX();
+            MethodInfo method = typeof(ClientX).GetMethod("FilterAnswersRegex", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] {
+                new DnsAnswer {
+                    Name = "example.com",
+                    Type = DnsRecordType.TXT,
+                    TTL = 300,
+                    DataRaw = "value=test"
+                }
+            };
+            var regex = new Regex("value", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+            var original = Thread.CurrentThread.CurrentCulture;
+            try {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+                var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, regex, DnsRecordType.TXT })!;
+                Assert.Single(result);
+            } finally {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolveFilterNullDataTests.cs
+++ b/DnsClientX.Tests/ResolveFilterNullDataTests.cs
@@ -27,7 +27,7 @@ namespace DnsClientX.Tests {
             var client = new ClientX();
             MethodInfo method = typeof(ClientX).GetMethod("FilterAnswersRegex", BindingFlags.NonPublic | BindingFlags.Instance)!;
             var answers = new[] { CreateAnswer(string.Empty, DnsRecordType.A) };
-            var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, new Regex("test"), DnsRecordType.A })!;
+            var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, new Regex("test", RegexOptions.CultureInvariant), DnsRecordType.A })!;
             Assert.Empty(result);
         }
 
@@ -45,7 +45,7 @@ namespace DnsClientX.Tests {
             var client = new ClientX();
             MethodInfo method = typeof(ClientX).GetMethod("HasMatchingAnswersRegex", BindingFlags.NonPublic | BindingFlags.Instance)!;
             var answers = new[] { CreateAnswer(string.Empty, DnsRecordType.A) };
-            var result = (bool)method.Invoke(client, new object[] { answers, new Regex("test"), DnsRecordType.A })!;
+            var result = (bool)method.Invoke(client, new object[] { answers, new Regex("test", RegexOptions.CultureInvariant), DnsRecordType.A })!;
             Assert.False(result);
         }
     }

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -187,7 +187,7 @@ namespace DnsClientX {
                     var parts = DataRaw.Split(' ')
                         .Where(part => !string.IsNullOrEmpty(part))
                         .Select(part => part.Trim())
-                        .Where(part => Regex.IsMatch(part, @"\A\b[0-9a-fA-F]+\b\Z"))
+                        .Where(part => Regex.IsMatch(part, @"\A\b[0-9a-fA-F]+\b\Z", RegexOptions.CultureInvariant))
                         .Select(part => Convert.ToByte(part, 16))
                         .ToArray();
 
@@ -254,10 +254,10 @@ namespace DnsClientX {
                         .Skip(2) // Skip the first two parts
                         .Where(part => !string.IsNullOrEmpty(part))
                         .Select(part => part.Trim())
-                        .Where(part => Regex.IsMatch(part, @"\A\b[0-9a-fA-F]+\b\Z"))
+                        .Where(part => Regex.IsMatch(part, @"\A\b[0-9a-fA-F]+\b\Z", RegexOptions.CultureInvariant))
                         .Select(part => Convert.ToByte(part, 16)) // Convert from hexadecimal to byte
                         .ToArray();
-                } else if (Regex.IsMatch(DataRaw, @"^\d+ \d+ \d+ [\da-fA-F]+$")) {
+                } else if (Regex.IsMatch(DataRaw, @"^\d+ \d+ \d+ [\da-fA-F]+$", RegexOptions.CultureInvariant)) {
                     // If the DataRaw string is already in the correct format, return it as it is
                     return DataRaw;
                 } else {
@@ -302,7 +302,7 @@ namespace DnsClientX {
                             .Skip(2) // Skip the "\#" and the length byte
                             .Where(part => !string.IsNullOrEmpty(part))
                             .Select(part => part.Trim())
-                            .Where(part => Regex.IsMatch(part, @"\A\b[0-9a-fA-F]{1,2}\b\Z")) // Match 1 or 2 hex chars
+                            .Where(part => Regex.IsMatch(part, @"\A\b[0-9a-fA-F]{1,2}\b\Z", RegexOptions.CultureInvariant)) // Match 1 or 2 hex chars
                             .Select(part => Convert.ToByte(part, 16))
                             .ToArray();
                         if (rdataHex.Length > 4) { // Basic validation for minimum RDATA length


### PR DESCRIPTION
## Summary
- add `RegexOptions.CultureInvariant` to all `Regex.IsMatch` calls
- use culture invariant regex in `ResolveFilterNullDataTests`
- test regex behaviour in different cultures

## Testing
- `dotnet test` *(fails: Failed:   134, Passed:   191, Skipped:    14, Total:   339)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9b248e4832ebe43446d8a2eacb0