### PR TITLE
Remove manual content length header

### DIFF
--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -34,7 +34,6 @@ namespace DnsClientX {
 
             using ByteArrayContent content = new(queryBytes);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/dns-message");
-            content.Headers.ContentLength = queryBytes.Length;
 
             using HttpResponseMessage postAsync = await client.PostAsync(client.BaseAddress, content, cancellationToken);
             var response = await postAsync.DeserializeDnsWireFormat(debug);


### PR DESCRIPTION
## Summary
- let `HttpClient` set the content length

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: SSL connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9c5e254832ebf37aac95e8a31bd