### PR TITLE
Replace _jitterRandom with Random.Shared

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -99,7 +99,6 @@ namespace DnsClientX {
             return response;
         }
 
-        private static readonly Random _jitterRandom = new();
 
         private static async Task<T> RetryAsync<T>(Func<Task<T>> action, int maxRetries = 3, int delayMs = 100) {
             Exception lastException = null;
@@ -118,10 +117,7 @@ namespace DnsClientX {
                         }
 
                         int exponentialDelay = delayMs * (int)Math.Pow(2, attempt - 1);
-                        int jitter;
-                        lock (_jitterRandom) {
-                            jitter = _jitterRandom.Next(0, delayMs);
-                        }
+                        int jitter = Random.Shared.Next(0, delayMs);
                         await Task.Delay(exponentialDelay + jitter);
                         continue;
                     }
@@ -136,10 +132,7 @@ namespace DnsClientX {
                     }
 
                     int exponentialDelay = delayMs * (int)Math.Pow(2, attempt - 1);
-                    int jitter;
-                    lock (_jitterRandom) {
-                        jitter = _jitterRandom.Next(0, delayMs);
-                    }
+                    int jitter = Random.Shared.Next(0, delayMs);
                     await Task.Delay(exponentialDelay + jitter);
                     continue;
                 }


### PR DESCRIPTION
## Summary
- swap out `_jitterRandom` for `Random.Shared`
- remove locking around RNG access

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_6862ea097798832e980e9b886c466511