### PR TITLE
Improve RFC references for Definitions

### DIFF
--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -7,7 +7,9 @@ using System.Text.RegularExpressions;
 
 namespace DnsClientX {
     /// <summary>
-    /// DNS answer sent by the server.
+    /// Represents a DNS resource record returned by the server.
+    /// See <a href="https://www.rfc-editor.org/rfc/rfc1035">RFC 1035</a>
+    /// for the resource record format.
     /// </summary>
     public struct DnsAnswer {
         private string _name;

--- a/DnsClientX/Definitions/DnsAnswerMinimal.cs
+++ b/DnsClientX/Definitions/DnsAnswerMinimal.cs
@@ -2,8 +2,10 @@ using System.Linq;
 
 namespace DnsClientX {
     /// <summary>
-    /// DnsAnswerMinimal is a minimal representation of a DNS answer.
-    /// Since DnsAnswer is much larger, this struct is used to reduce the size of the data sent to the client.
+    /// Provides a lightweight representation of a DNS resource record.
+    /// Useful for reducing the payload size returned to callers.
+    /// See <a href="https://www.rfc-editor.org/rfc/rfc1035">RFC 1035</a>
+    /// for the resource record definition.
     /// </summary>
     public struct DnsAnswerMinimal {
         /// <summary>

--- a/DnsClientX/Definitions/DnsEndpoint.cs
+++ b/DnsClientX/Definitions/DnsEndpoint.cs
@@ -1,6 +1,7 @@
 namespace DnsClientX {
     /// <summary>
-    /// Enum representing the available DNS-over-HTTPS endpoints.
+    /// Enumerates known DNS-over-HTTPS endpoints and system resolvers.
+    /// DNS-over-HTTPS is defined in <a href="https://www.rfc-editor.org/rfc/rfc8484">RFC 8484</a>.
     /// </summary>
     public enum DnsEndpoint {
         /// <summary>

--- a/DnsClientX/Definitions/DnsKeyAlgorithm.cs
+++ b/DnsClientX/Definitions/DnsKeyAlgorithm.cs
@@ -3,7 +3,10 @@ using System;
 namespace DnsClientX {
 
     /// <summary>
-    /// An enumeration of the DNSKEY algorithms.
+    /// Enumerates DNSSEC algorithm identifiers used in DNSKEY records.
+    /// Algorithm numbers are assigned by IANA as described in
+    /// <a href="https://www.rfc-editor.org/rfc/rfc4034">RFC 4034</a>
+    /// and <a href="https://www.rfc-editor.org/rfc/rfc8624">RFC 8624</a>.
     /// </summary>
     public enum DnsKeyAlgorithm {
         /// <summary>

--- a/DnsClientX/Definitions/DnsQuestion.cs
+++ b/DnsClientX/Definitions/DnsQuestion.cs
@@ -2,8 +2,9 @@ using System;
 using System.Text.Json.Serialization;
 
 namespace DnsClientX {
-    /// <summary>   
-    /// DNS question sent by the client.
+    /// <summary>
+    /// Represents a DNS question as defined in
+    /// <a href="https://www.rfc-editor.org/rfc/rfc1035#section-4.1.2">RFC 1035 section 4.1.2</a>.
     /// </summary>
     public struct DnsQuestion {
         private string _name;

--- a/DnsClientX/Definitions/DnsRecordType.cs
+++ b/DnsClientX/Definitions/DnsRecordType.cs
@@ -1,7 +1,8 @@
 namespace DnsClientX;
 /// <summary>
-/// Type of DNS record as defined in RFC 1035.
-/// c.f. https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
+/// Enumerates DNS record types as defined in
+/// <a href="https://www.rfc-editor.org/rfc/rfc1035#section-3.2.2">RFC 1035 section 3.2.2</a>.
+/// See also the <a href="https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4">IANA DNS Parameters</a> registry.
 /// </summary>
 public enum DnsRecordType : ushort {
     /// <summary>

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -1,6 +1,8 @@
 namespace DnsClientX {
     /// <summary>
-    /// Enum representing the available formats for DNS requests.
+    /// Specifies the transport formats supported for DNS queries.
+    /// Includes DNS over HTTPS (<a href="https://www.rfc-editor.org/rfc/rfc8484">RFC 8484</a>)
+    /// and DNS over TLS (<a href="https://www.rfc-editor.org/rfc/rfc7858">RFC 7858</a>).
     /// </summary>
     public enum DnsRequestFormat {
         /// <summary>

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -6,7 +6,9 @@ using System.Text.Json.Serialization;
 
 namespace DnsClientX {
     /// <summary>
-    /// Represents the response from a DNS query over HTTPS. This can be in either JSON or wire format.
+    /// Represents a DNS message returned by a resolver.
+    /// The structure mirrors the response format described in
+    /// <a href="https://www.rfc-editor.org/rfc/rfc1035">RFC 1035</a>.
     /// </summary>
     public struct DnsResponse {
         /// <summary>

--- a/DnsClientX/Definitions/DnsResponseCode.cs
+++ b/DnsClientX/Definitions/DnsResponseCode.cs
@@ -1,7 +1,8 @@
 namespace DnsClientX {
     /// <summary>
-    /// Enumerates the possible status codes (DNS RCODEs) for a DNS query.
-    /// For more information, see the <a href="https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml">IANA DNS Parameters</a> and the relevant RFCs: <a href="https://www.iana.org/go/rfc6895">RFC 6895</a> and <a href="https://www.iana.org/go/rfc1035">RFC 1035</a>.
+    /// Enumerates the DNS RCODE values returned in a response.
+    /// See <a href="https://www.rfc-editor.org/rfc/rfc1035#section-4.1.1">RFC 1035 section 4.1.1</a>
+    /// and <a href="https://www.rfc-editor.org/rfc/rfc6895">RFC 6895</a> for details.
     /// </summary>
     public enum DnsResponseCode : byte {
         /// <summary>

--- a/DnsClientX/Definitions/DnsSelectionStrategy.cs
+++ b/DnsClientX/Definitions/DnsSelectionStrategy.cs
@@ -1,6 +1,7 @@
 namespace DnsClientX {
     /// <summary>
-    /// Defines the strategy for selecting a DNS server.
+    /// Defines how <see cref="DnsClientX"/> chooses between multiple DNS endpoints.
+    /// This behavior is implementation specific and not defined by any RFC.
     /// </summary>
     public enum DnsSelectionStrategy {
         /// <summary>


### PR DESCRIPTION
## Summary
- clarify RFC references in definition summaries
- regenerate XML documentation

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: Failed: 134, Passed: 187, Skipped: 14)*

------
https://chatgpt.com/codex/tasks/task_e_6862ea1e1e18832eb0e41ccbad52e58c