### PR TITLE
Implement hostname failover strategy

### DIFF
--- a/DnsClientX.Tests/FailoverStrategyTests.cs
+++ b/DnsClientX.Tests/FailoverStrategyTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class FailoverStrategyTests {
+        [Fact]
+        public void SelectHostNameStrategy_ShouldUseCurrentIndex() {
+            var config = new Configuration(DnsEndpoint.Cloudflare, DnsSelectionStrategy.Failover);
+            // Cloudflare endpoints have two hostnames
+            Assert.Equal("1.1.1.1", config.Hostname);
+
+            typeof(Configuration).GetMethod("AdvanceToNextHostname", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(config, null);
+            config.SelectHostNameStrategy();
+            Assert.Equal("1.0.0.1", config.Hostname);
+
+            typeof(Configuration).GetMethod("AdvanceToNextHostname", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(config, null);
+            config.SelectHostNameStrategy();
+            Assert.Equal("1.1.1.1", config.Hostname);
+        }
+
+        [Fact]
+        public async Task RetryAsync_ShouldAdvanceHostnameOnFailure() {
+            var config = new Configuration(DnsEndpoint.Cloudflare, DnsSelectionStrategy.Failover);
+            MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.Static | BindingFlags.NonPublic)!;
+            Func<Task<DnsResponse>> action = () => Task.FromResult(new DnsResponse { Status = DnsResponseCode.ServerFailure });
+            var generic = method.MakeGenericMethod(typeof(DnsResponse));
+            var advance = (Action)Delegate.CreateDelegate(typeof(Action), config, "AdvanceToNextHostname", false)!;
+            await Assert.ThrowsAsync<DnsClientException>(async () =>
+            {
+                await (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, advance })!;
+            });
+
+            config.SelectHostNameStrategy();
+            Assert.Equal("1.0.0.1", config.Hostname);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -22,7 +22,11 @@ namespace DnsClientX {
             DnsResponse res;
             try {
                 res = retryOnTransient
-                    ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
+                    ? await RetryAsync(
+                        () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0),
+                        maxRetries,
+                        retryDelayMs,
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null)
                     : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
             } catch (DnsClientException ex) {
                 res = ex.Response;
@@ -51,7 +55,11 @@ namespace DnsClientX {
             DnsResponse res;
             try {
                 res = retryOnTransient
-                    ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
+                    ? await RetryAsync(
+                        () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0),
+                        maxRetries,
+                        retryDelayMs,
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null)
                     : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
             } catch (DnsClientException ex) {
                 res = ex.Response;
@@ -82,7 +90,11 @@ namespace DnsClientX {
             DnsResponse res;
             try {
                 res = retryOnTransient
-                    ? await RetryAsync(() => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0), maxRetries, retryDelayMs)
+                    ? await RetryAsync(
+                        () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0),
+                        maxRetries,
+                        retryDelayMs,
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null)
                     : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0);
             } catch (DnsClientException ex) {
                 res = ex.Response;


### PR DESCRIPTION
## Summary
- implement hostname failover logic
- retry queries on alternate hostnames
- cover failover logic with new tests

## Testing
- `dotnet test` *(fails: 138, passed: 185, skipped: 14)*

------
https://chatgpt.com/codex/tasks/task_e_6862ea565a18832ea4d673010d55e074