### PR TITLE
Set OriginalName via constructor

### DIFF
--- a/DnsClientX.Tests/OriginalNameTests.cs
+++ b/DnsClientX.Tests/OriginalNameTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class OriginalNameTests {
+        [Fact]
+        public void QuestionSetterSetsOriginalName() {
+            DnsQuestion q = new() { Name = "example.com." };
+            Assert.Equal("example.com.", q.OriginalName);
+            Assert.Equal("example.com", q.Name);
+        }
+
+        [Fact]
+        public void AnswerSetterSetsOriginalName() {
+            DnsAnswer a = new() { Name = "example.net." };
+            Assert.Equal("example.net.", a.OriginalName);
+            Assert.Equal("example.net", a.Name);
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -11,6 +11,18 @@ namespace DnsClientX {
     /// </summary>
     public struct DnsAnswer {
         private string _name;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DnsAnswer"/> struct.
+        /// </summary>
+        public DnsAnswer() {
+            _name = string.Empty;
+            OriginalName = string.Empty;
+            Type = DnsRecordType.A;
+            TTL = 0;
+            DataRaw = string.Empty;
+            _filteredData = null;
+        }
         /// <summary>
         /// This is the name of the record.
         /// Retains original name as returned by the server.
@@ -34,7 +46,11 @@ namespace DnsClientX {
             get => _name;
             set {
                 OriginalName = value;
-                _name = value.EndsWith(".") ? value.TrimEnd('.') : value;
+                if (string.IsNullOrEmpty(value)) {
+                    _name = value;
+                } else {
+                    _name = value.EndsWith(".") ? value.TrimEnd('.') : value;
+                }
             }
         }
 

--- a/DnsClientX/Definitions/DnsQuestion.cs
+++ b/DnsClientX/Definitions/DnsQuestion.cs
@@ -9,6 +9,19 @@ namespace DnsClientX {
         private string _name;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="DnsQuestion"/> struct.
+        /// </summary>
+        public DnsQuestion() {
+            _name = string.Empty;
+            OriginalName = string.Empty;
+            Type = DnsRecordType.A;
+            HostName = string.Empty;
+            BaseUri = null!;
+            RequestFormat = DnsRequestFormat.DnsOverHttps;
+            Port = 0;
+        }
+
+        /// <summary>
         /// The FQDN record name requested.
         /// Retains original name as set by the client.
         /// </summary>
@@ -23,7 +36,11 @@ namespace DnsClientX {
             get => _name;
             set {
                 OriginalName = value;
-                _name = value.EndsWith(".") ? value.TrimEnd('.') : value;
+                if (string.IsNullOrEmpty(value)) {
+                    _name = value;
+                } else {
+                    _name = value.EndsWith(".") ? value.TrimEnd('.') : value;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure `OriginalName` is initialized in `DnsQuestion` and `DnsAnswer`
- handle null assignment for `Name` in both structs
- add unit tests verifying `OriginalName` is set

## Testing
- `dotnet test --no-build` *(fails: Failed: 134, Passed: 187, Skipped: 14)*
- `dotnet test --filter FullyQualifiedName~OriginalNameTests`

------
https://chatgpt.com/codex/tasks/task_e_6862e9d4ec10832e8904fe831176512a