### PR TITLE
Add timeout validation

### DIFF
--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -20,6 +20,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
@@ -40,6 +41,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             var data = client.ResolveSync(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs);
@@ -60,6 +62,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -83,6 +86,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -106,6 +110,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(dnsUri, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -129,6 +134,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(dnsUri, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -151,6 +157,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(dnsUri, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -173,6 +180,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(dnsUri, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -196,6 +204,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -219,6 +228,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -241,6 +251,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -263,6 +274,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -285,6 +297,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -306,6 +319,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(endpoint: dnsEndpoint) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
@@ -328,6 +342,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = 1000, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200) {
+            ValidateTimeout(timeOutMilliseconds);
             using var client = new ClientX(endpoint: dnsEndpoint) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds

--- a/DnsClientX/DnsClientX.TimeoutValidation.cs
+++ b/DnsClientX/DnsClientX.TimeoutValidation.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace DnsClientX {
+    public partial class ClientX {
+        private static void ValidateTimeout(int timeOutMilliseconds) {
+            if (timeOutMilliseconds < 1) {
+                throw new ArgumentOutOfRangeException(nameof(timeOutMilliseconds), "Timeout must be greater than zero.");
+            }
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -101,6 +101,7 @@ namespace DnsClientX {
             string? userAgent = null,
             Version? httpVersion = null,
             bool ignoreCertificateErrors = false) {
+            ValidateTimeout(timeOutMilliseconds);
             EndpointConfiguration = new Configuration(endpoint, dnsSelectionStrategy) {
                 TimeOut = timeOutMilliseconds
             };
@@ -128,6 +129,7 @@ namespace DnsClientX {
             string? userAgent = null,
             Version? httpVersion = null,
             bool ignoreCertificateErrors = false) {
+            ValidateTimeout(timeOutMilliseconds);
             EndpointConfiguration = new Configuration(hostname, requestFormat) {
                 TimeOut = timeOutMilliseconds
             };
@@ -155,6 +157,7 @@ namespace DnsClientX {
             string? userAgent = null,
             Version? httpVersion = null,
             bool ignoreCertificateErrors = false) {
+            ValidateTimeout(timeOutMilliseconds);
             EndpointConfiguration = new Configuration(baseUri, requestFormat) {
                 TimeOut = timeOutMilliseconds
             };

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -85,6 +85,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
+            if (timeoutMilliseconds < 1) throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds));
             using var tcpClient = new TcpClient();
             try {
                 // Connect to the server with timeout
@@ -144,6 +145,7 @@ namespace DnsClientX {
         /// Helper to read exactly the requested number of bytes from a stream with timeout.
         /// </summary>
         private static async Task ReadExactWithTimeoutAsync(Stream stream, byte[] buffer, int offset, int count, int timeoutMilliseconds, CancellationToken cancellationToken) {
+            if (timeoutMilliseconds < 1) throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds));
             var readTask = DnsWire.ReadExactAsync(stream, buffer, offset, count, cancellationToken);
             var timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
             var completedTask = await Task.WhenAny(readTask, timeoutTask);
@@ -164,6 +166,7 @@ namespace DnsClientX {
         /// <param name="timeoutMilliseconds">Timeout in milliseconds.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         private static async Task ConnectAsync(TcpClient tcpClient, string host, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
+            if (timeoutMilliseconds < 1) throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds));
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             linkedCts.CancelAfter(timeoutMilliseconds);
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -93,6 +93,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverUdp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
+            if (timeoutMilliseconds < 1) throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds));
             using (var udpClient = new UdpClient()) {
                 // Set the server IP address and port number
                 var serverEndpoint = new IPEndPoint(IPAddress.Parse(dnsServer), port);


### PR DESCRIPTION
## Summary
- add ValidateTimeout helper and check timeOutMilliseconds across constructors and QueryDns methods
- guard UDP and TCP helper methods against invalid timeout values

## Testing
- `dotnet test --verbosity minimal` *(fails: The argument /workspace/DnsClientX/DnsClientX.Tests/bin/Debug/net8.0/DnsClientX.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9fadc38832e981fef49406b39cd