### PR TITLE
Handle IPv6 loopback formatting

### DIFF
--- a/DnsClientX.Tests/FormatDnsAddressTests.cs
+++ b/DnsClientX.Tests/FormatDnsAddressTests.cs
@@ -19,6 +19,7 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData("2001:db8::1", "[2001:db8::1]")]
         [InlineData("fe80::1%12", "[fe80::1]")]
+        [InlineData("::1", "[::1]")]
         public void FormatIpv6_RemovesZoneAndAddsBrackets(string input, string expected) {
             var result = InvokeFormatDnsAddress(input);
             Assert.Equal(expected, result);

--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -195,6 +195,11 @@ namespace DnsClientX {
                     addressString = addressString.Substring(0, zoneIndex);
                 }
 
+                // Normalize loopback address so it is always ::1
+                if (IPAddress.IPv6Loopback.Equals(address)) {
+                    addressString = "::1";
+                }
+
                 // Wrap IPv6 addresses in brackets for proper DNS formatting
                 addressString = $"[{addressString}]";
             }


### PR DESCRIPTION
## Summary
- normalize IPv6 loopback address in `FormatDnsAddress`
- add a test case for IPv6 loopback formatting

## Testing
- `dotnet test --no-build --verbosity normal`
- `dotnet format --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6862ea04c3a4832e8ce0b0f5c424e975