### PR TITLE
Fix newline normalization

### DIFF
--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -61,7 +61,7 @@ namespace DnsClientX {
         /// the value of the DNS record for the given name and type after being processed and converted to a string.
         /// </summary>
         [JsonIgnore]
-        public string Data => _filteredData is null ? ConvertData() : _filteredData;
+        public string Data => NormalizeLineEndings(_filteredData is null ? ConvertData() : _filteredData);
 
         /// <summary>
         /// The value of the DNS record for the given name and type, split into multiple strings if necessary.
@@ -404,6 +404,17 @@ namespace DnsClientX {
                 .ToArray();
 
             return string.Join("\n", lines);
+        }
+
+        /// <summary>
+        /// Normalizes line endings to '\n' regardless of the original platform.
+        /// </summary>
+        /// <param name="data">Input string</param>
+        /// <returns>String with '\n' line endings</returns>
+        private static string NormalizeLineEndings(string data) {
+            if (string.IsNullOrEmpty(data)) return string.Empty;
+
+            return data.Replace("\r\n", "\n").Replace("\r", "\n");
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This library supports multiple NET versions:
 - [x] No external dependencies on .NET 6, .NET 7 and .NET 8
 - [x] Minimal dependencies on .NET Standard 2.0 and .NET 4.7.2
 - [x] Implements IDisposable to release cached HttpClient resources
+- [x] Multi-line record data normalized to use `\n` line endings
 
 ## Understanding DNS Query Behavior
 


### PR DESCRIPTION
## Summary
- normalize line endings in returned DNS record data
- document newline behaviour in README

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862ebb1a2a4832ebaf24b6af0fe6e70