### PR TITLE
Remove UrlEncode extension method

### DIFF
--- a/DnsClientX/ProtocolDnsJson/DnsJson.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJson.cs
@@ -1,19 +1,11 @@
 using System;
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
     internal static class DnsJson {
-        /// <summary>
-        /// Encode URL
-        /// </summary>
-        /// <param name="value">The value.</param>
-        /// <returns></returns>
-        internal static string UrlEncode(this string value) => WebUtility.UrlEncode(value);
-
         /// <summary>
         /// Deserialize a JSON HTTP response into a given type.
         /// </summary>

--- a/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
@@ -22,9 +22,9 @@ namespace DnsClientX {
         /// <exception cref="DnsClientException">Thrown when the HTTP request fails or the server returns an error.</exception>
         internal static async Task<DnsResponse> ResolveJsonFormat(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration configuration, CancellationToken cancellationToken) {
-            string url = string.Concat($"?name={name.UrlEncode()}",
-                type == DnsRecordType.A ? "" : $"&type={type.ToString().UrlEncode()}",
-                requestDnsSec == false ? "" : $"&do=1", validateDnsSec == false ? "" : $"&cd=1");
+            string url = string.Concat($"?name={WebUtility.UrlEncode(name)}",
+                type == DnsRecordType.A ? "" : $"&type={WebUtility.UrlEncode(type.ToString())}",
+                requestDnsSec == false ? "" : "&do=1", validateDnsSec == false ? "" : "&cd=1");
 
             using HttpRequestMessage req = new(HttpMethod.Get, url);
             try {


### PR DESCRIPTION
## Summary
- remove the private UrlEncode extension
- call `WebUtility.UrlEncode` directly

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6862f8203fdc832ebda53e68cc82f1dd