### PR TITLE
Add DNSSEC root validation

### DIFF
--- a/DnsClientX.Tests/RootDnssecValidatorTests.cs
+++ b/DnsClientX.Tests/RootDnssecValidatorTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class RootDnssecValidatorTests {
+        [Fact]
+        public void ValidateAgainstRoot_DsRecord() {
+            var response = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer {
+                        Name = ".",
+                        Type = DnsRecordType.DS,
+                        TTL = 3600,
+                        DataRaw = "20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"
+                    }
+                }
+            };
+            Assert.True(DnsSecValidator.ValidateAgainstRoot(response));
+        }
+
+        [Fact]
+        public void ValidateAgainstRoot_DnsKeyRecord() {
+            var response = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer {
+                        Name = ".",
+                        Type = DnsRecordType.DNSKEY,
+                        TTL = 3600,
+                        DataRaw = "257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU="
+                    }
+                }
+            };
+            Assert.True(DnsSecValidator.ValidateAgainstRoot(response));
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -58,6 +58,11 @@ namespace DnsClientX {
         public int TimeOut = 1000;
 
         /// <summary>
+        /// Validates DS and DNSKEY records against a builtin root key set.
+        /// </summary>
+        public bool ValidateRootDnsSec { get; set; }
+
+        /// <summary>
         /// Gets or sets the format of the DNS requests.
         /// </summary>
         public DnsRequestFormat RequestFormat { get; set; }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -102,6 +102,12 @@ namespace DnsClientX {
                     string validationError = "DNSSEC validation failed.";
                     response.Error = string.IsNullOrEmpty(response.Error) ? validationError : $"{response.Error} {validationError}";
                 }
+                if (EndpointConfiguration.ValidateRootDnsSec && (type == DnsRecordType.DS || type == DnsRecordType.DNSKEY)) {
+                    if (!DnsSecValidator.ValidateAgainstRoot(response)) {
+                        string validationError = "Root DNSSEC validation failed.";
+                        response.Error = string.IsNullOrEmpty(response.Error) ? validationError : $"{response.Error} {validationError}";
+                    }
+                }
             }
 
             return response;

--- a/DnsClientX/Security/DnsSecValidator.cs
+++ b/DnsClientX/Security/DnsSecValidator.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DnsClientX {
+    public static class DnsSecValidator {
+        public static bool ValidateAgainstRoot(DnsResponse response) {
+            if (response.Answers == null) {
+                return false;
+            }
+
+            foreach (DnsAnswer answer in response.Answers) {
+                if (answer.Type == DnsRecordType.DS) {
+                    if (TryParseDs(answer.DataRaw, out RootDsRecord ds) &&
+                        RootTrustAnchors.DsRecords.Any(r => r.KeyTag == ds.KeyTag && r.Algorithm == ds.Algorithm && r.DigestType == ds.DigestType && string.Equals(r.Digest, ds.Digest, StringComparison.OrdinalIgnoreCase))) {
+                        return true;
+                    }
+                } else if (answer.Type == DnsRecordType.DNSKEY) {
+                    if (TryParseDnsKey(answer, out ushort flags, out byte protocol, out DnsKeyAlgorithm algorithm, out byte[] publicKey)) {
+                        ushort keyTag = ComputeKeyTag(flags, protocol, algorithm, publicKey);
+                        string digest = ComputeDigest(answer.Name, flags, protocol, algorithm, publicKey);
+                        if (RootTrustAnchors.DsRecords.Any(r => r.KeyTag == keyTag && r.Algorithm == algorithm && r.DigestType == 2 && string.Equals(r.Digest, digest, StringComparison.OrdinalIgnoreCase))) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        private static bool TryParseDs(string dataRaw, out RootDsRecord record) {
+            record = default;
+            if (string.IsNullOrWhiteSpace(dataRaw)) {
+                return false;
+            }
+            string[] parts = dataRaw.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 4) {
+                return false;
+            }
+            if (!ushort.TryParse(parts[0], out ushort keyTag)) {
+                return false;
+            }
+            byte algVal;
+            if (Enum.TryParse(typeof(DnsKeyAlgorithm), parts[1], true, out object? algEnum)) {
+                algVal = (byte)(DnsKeyAlgorithm)algEnum;
+            } else if (!byte.TryParse(parts[1], out algVal)) {
+                return false;
+            }
+            if (!byte.TryParse(parts[2], out byte digestType)) {
+                return false;
+            }
+            record = new RootDsRecord(keyTag, (DnsKeyAlgorithm)algVal, digestType, parts[3].ToUpperInvariant());
+            return true;
+        }
+
+        private static bool TryParseDnsKey(DnsAnswer answer, out ushort flags, out byte protocol, out DnsKeyAlgorithm algorithm, out byte[] publicKey) {
+            flags = 0;
+            protocol = 0;
+            algorithm = 0;
+            publicKey = Array.Empty<byte>();
+            string dataRaw = answer.DataRaw;
+            if (string.IsNullOrWhiteSpace(dataRaw)) {
+                return false;
+            }
+            string[] parts = dataRaw.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 4) {
+                return false;
+            }
+            if (!ushort.TryParse(parts[0], out flags)) {
+                return false;
+            }
+            if (!byte.TryParse(parts[1], out protocol)) {
+                return false;
+            }
+            byte algVal;
+            if (Enum.TryParse(typeof(DnsKeyAlgorithm), parts[2], true, out object? algEnum)) {
+                algVal = (byte)(DnsKeyAlgorithm)algEnum;
+            } else if (!byte.TryParse(parts[2], out algVal)) {
+                return false;
+            }
+            algorithm = (DnsKeyAlgorithm)algVal;
+            string keyBase64 = string.Join(string.Empty, parts.Skip(3));
+            try {
+                publicKey = Convert.FromBase64String(keyBase64);
+            } catch {
+                return false;
+            }
+            return true;
+        }
+
+        private static ushort ComputeKeyTag(ushort flags, byte protocol, DnsKeyAlgorithm algorithm, byte[] publicKey) {
+            byte[] rdata = new byte[4 + publicKey.Length];
+            BinaryPrimitives.WriteUInt16BigEndian(rdata, flags);
+            rdata[2] = protocol;
+            rdata[3] = (byte)algorithm;
+            Buffer.BlockCopy(publicKey, 0, rdata, 4, publicKey.Length);
+            uint acc = 0;
+            for (int i = 0; i < rdata.Length; i++) {
+                acc += (i & 1) == 0 ? (uint)rdata[i] << 8 : rdata[i];
+            }
+            acc += acc >> 16;
+            return (ushort)(acc & 0xFFFF);
+        }
+
+        private static string ComputeDigest(string name, ushort flags, byte protocol, DnsKeyAlgorithm algorithm, byte[] publicKey) {
+            byte[] owner = DomainToWireFormat(name);
+            byte[] rdata = new byte[4 + publicKey.Length];
+            BinaryPrimitives.WriteUInt16BigEndian(rdata, flags);
+            rdata[2] = protocol;
+            rdata[3] = (byte)algorithm;
+            Buffer.BlockCopy(publicKey, 0, rdata, 4, publicKey.Length);
+            byte[] message = new byte[owner.Length + rdata.Length];
+            Buffer.BlockCopy(owner, 0, message, 0, owner.Length);
+            Buffer.BlockCopy(rdata, 0, message, owner.Length, rdata.Length);
+            using SHA256 sha256 = SHA256.Create();
+            byte[] digestBytes = sha256.ComputeHash(message);
+            return BitConverter.ToString(digestBytes).Replace("-", string.Empty).ToUpperInvariant();
+        }
+
+        private static byte[] DomainToWireFormat(string domain) {
+            if (string.IsNullOrEmpty(domain) || domain == ".") {
+                return new byte[] { 0 };
+            }
+            string[] labels = domain.TrimEnd('.').Split('.');
+            var data = new List<byte>();
+            foreach (string label in labels) {
+                byte[] bytes = Encoding.ASCII.GetBytes(label.ToLowerInvariant());
+                data.Add((byte)bytes.Length);
+                data.AddRange(bytes);
+            }
+            data.Add(0);
+            return data.ToArray();
+        }
+    }
+}

--- a/DnsClientX/Security/RootTrustAnchors.cs
+++ b/DnsClientX/Security/RootTrustAnchors.cs
@@ -1,0 +1,22 @@
+namespace DnsClientX {
+    internal readonly struct RootDsRecord {
+        public ushort KeyTag { get; }
+        public DnsKeyAlgorithm Algorithm { get; }
+        public byte DigestType { get; }
+        public string Digest { get; }
+
+        public RootDsRecord(ushort keyTag, DnsKeyAlgorithm algorithm, byte digestType, string digest) {
+            KeyTag = keyTag;
+            Algorithm = algorithm;
+            DigestType = digestType;
+            Digest = digest;
+        }
+    }
+
+    internal static class RootTrustAnchors {
+        internal static readonly RootDsRecord[] DsRecords = {
+            new RootDsRecord(20326, DnsKeyAlgorithm.RSASHA256, 2, "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"),
+            new RootDsRecord(38696, DnsKeyAlgorithm.RSASHA256, 2, "683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16")
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- implement validator for DNSSEC DS/DNSKEY based on local root keys
- expose `ValidateRootDnsSec` configuration option
- use the validator when DNSSEC validation is enabled
- include unit tests for the validator

## Testing
- `dotnet test` *(fails: The argument ... bin/Debug/net8.0/DnsClientX.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6862f90d7b9c832ea1026dbe4657550e