### PR TITLE
Enable camelCase JSON serialization

### DIFF
--- a/DnsClientX.Tests/DnsJsonSerializationTests.cs
+++ b/DnsClientX.Tests/DnsJsonSerializationTests.cs
@@ -1,0 +1,23 @@
+using DnsClientX;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsJsonSerializationTests {
+        [Fact]
+        public void Serialize_UsesCamelCasePropertyNames() {
+            var minimal = new DnsAnswerMinimal {
+                Name = "example.com",
+                TTL = 60,
+                Type = DnsRecordType.A,
+                Data = "1.1.1.1"
+            };
+
+            string json = DnsJson.Serialize(minimal);
+
+            Assert.Contains("\"name\":\"example.com\"", json);
+            Assert.Contains("\"type\":1", json);
+            Assert.Contains("\"ttl\":60", json);
+            Assert.Contains("\"data\":\"1.1.1.1\"", json);
+        }
+    }
+}

--- a/DnsClientX/AssemblyInfo.cs
+++ b/DnsClientX/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("DnsClientX.Tests")]

--- a/DnsClientX/ProtocolDnsJson/DnsJson.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJson.cs
@@ -7,12 +7,15 @@ using System.Threading.Tasks;
 
 namespace DnsClientX {
     internal static class DnsJson {
+        internal static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
         /// <summary>
         /// Encode URL
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns></returns>
         internal static string UrlEncode(this string value) => WebUtility.UrlEncode(value);
+
+        internal static string Serialize<T>(T value) => JsonSerializer.Serialize(value, JsonOptions);
 
         /// <summary>
         /// Deserialize a JSON HTTP response into a given type.
@@ -31,9 +34,9 @@ namespace DnsClientX {
                     // Write the JSON data using logger
                     Settings.Logger.WriteDebug(json);
                     // Deserialize the JSON data
-                    return JsonSerializer.Deserialize<T>(json);
+                    return JsonSerializer.Deserialize<T>(json, JsonOptions);
                 }
-                return JsonSerializer.Deserialize<T>(stream);
+                return JsonSerializer.Deserialize<T>(stream, JsonOptions);
             } catch (JsonException jsonEx) {
                 throw new DnsClientException($"Failed to parse JSON due to a JsonException: {jsonEx.Message}");
             } catch (IOException ioEx) {


### PR DESCRIPTION
## Summary
- configure common `JsonSerializerOptions` with camelCase naming
- add internal access for tests
- test camelCase serialization of `DnsAnswerMinimal`

## Testing
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: 139 failed, 193 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6862f9042df4832e879415655b3ae0a6