### PR TITLE
Add DNS over QUIC resolver

### DIFF
--- a/DnsClientX.Tests/QueryDnsByEndpoint.cs
+++ b/DnsClientX.Tests/QueryDnsByEndpoint.cs
@@ -13,6 +13,10 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+#if DNS_OVER_QUIC
+        [InlineData(DnsEndpoint.CloudflareQuic)]
+        [InlineData(DnsEndpoint.GoogleQuic)]
+#endif
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("github.com", DnsRecordType.TXT, endpoint);
             foreach (DnsAnswer answer in response.Answers) {
@@ -35,6 +39,10 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+#if DNS_OVER_QUIC
+        [InlineData(DnsEndpoint.CloudflareQuic)]
+        [InlineData(DnsEndpoint.GoogleQuic)]
+#endif
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint);
             foreach (DnsAnswer answer in response.Answers) {
@@ -57,6 +65,10 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+#if DNS_OVER_QUIC
+        [InlineData(DnsEndpoint.CloudflareQuic)]
+        [InlineData(DnsEndpoint.GoogleQuic)]
+#endif
         public async Task ShouldWorkForPTR(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("1.1.1.1", DnsRecordType.PTR, endpoint);
             foreach (DnsAnswer answer in response.Answers) {

--- a/DnsClientX.Tests/QueryDnsOverQuic.cs
+++ b/DnsClientX.Tests/QueryDnsOverQuic.cs
@@ -1,0 +1,16 @@
+#if DNS_OVER_QUIC && NET8_0_OR_GREATER
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class QueryDnsOverQuic {
+        [Theory]
+        [InlineData(DnsEndpoint.CloudflareQuic)]
+        [InlineData(DnsEndpoint.GoogleQuic)]
+        public async Task ShouldResolveA(DnsEndpoint endpoint) {
+            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint);
+            Assert.NotEmpty(response.Answers);
+        }
+    }
+}
+#endif

--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -16,6 +16,10 @@ namespace DnsClientX.Tests {
 
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+#if DNS_OVER_QUIC
+        [InlineData(DnsEndpoint.CloudflareQuic)]
+        [InlineData(DnsEndpoint.GoogleQuic)]
+#endif
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll("github.com", DnsRecordType.TXT);
@@ -42,6 +46,10 @@ namespace DnsClientX.Tests {
 
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+#if DNS_OVER_QUIC
+        [InlineData(DnsEndpoint.CloudflareQuic)]
+        [InlineData(DnsEndpoint.GoogleQuic)]
+#endif
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll("evotec.pl", DnsRecordType.A);
@@ -67,6 +75,10 @@ namespace DnsClientX.Tests {
 
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+#if DNS_OVER_QUIC
+        [InlineData(DnsEndpoint.CloudflareQuic)]
+        [InlineData(DnsEndpoint.GoogleQuic)]
+#endif
         public void ShouldWorkForTXT_Sync(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = Client.ResolveAllSync("github.com", DnsRecordType.TXT);
@@ -93,6 +105,10 @@ namespace DnsClientX.Tests {
 
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
+#if DNS_OVER_QUIC
+        [InlineData(DnsEndpoint.CloudflareQuic)]
+        [InlineData(DnsEndpoint.GoogleQuic)]
+#endif
         public void ShouldWorkForA_Sync(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = Client.ResolveAllSync("evotec.pl", DnsRecordType.A);

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -96,7 +96,7 @@ namespace DnsClientX {
             BaseUri = new Uri(string.Format(baseUriFormat, hostname));
             hostnameIndex = 0;
 
-            if (requestFormat == DnsRequestFormat.DnsOverTLS) {
+            if (requestFormat == DnsRequestFormat.DnsOverTLS || requestFormat == DnsRequestFormat.DnsOverQuic) {
                 Port = 853;
             } else if (requestFormat == DnsRequestFormat.DnsOverUDP || requestFormat == DnsRequestFormat.DnsOverTCP) {
                 Port = 53;
@@ -117,7 +117,7 @@ namespace DnsClientX {
             hostnames = new List<string> { baseUri.Host };
             hostnameIndex = 0;
 
-            if (requestFormat == DnsRequestFormat.DnsOverTLS) {
+            if (requestFormat == DnsRequestFormat.DnsOverTLS || requestFormat == DnsRequestFormat.DnsOverQuic) {
                 Port = 853;
             } else if (requestFormat == DnsRequestFormat.DnsOverUDP || requestFormat == DnsRequestFormat.DnsOverTCP) {
                 Port = 53;
@@ -209,6 +209,11 @@ namespace DnsClientX {
                     RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
+                case DnsEndpoint.CloudflareQuic:
+                    hostnames = new List<string> { "1.1.1.1", "1.0.0.1" };
+                    RequestFormat = DnsRequestFormat.DnsOverQuic;
+                    baseUriFormat = "https://{0}/dns-query";
+                    break;
                 case DnsEndpoint.Google:
                     hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };
                     RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
@@ -222,6 +227,11 @@ namespace DnsClientX {
                 case DnsEndpoint.GoogleWireFormatPost:
                     hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };
                     RequestFormat = DnsRequestFormat.DnsOverHttpsPOST;
+                    baseUriFormat = "https://{0}/dns-query";
+                    break;
+                case DnsEndpoint.GoogleQuic:
+                    hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };
+                    RequestFormat = DnsRequestFormat.DnsOverQuic;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.Quad9:
@@ -259,7 +269,7 @@ namespace DnsClientX {
 
             SelectHostNameStrategy();
 
-            if (RequestFormat == DnsRequestFormat.DnsOverTLS) {
+            if (RequestFormat == DnsRequestFormat.DnsOverTLS || RequestFormat == DnsRequestFormat.DnsOverQuic) {
                 Port = 853;
             } else if (RequestFormat == DnsRequestFormat.DnsOverUDP || RequestFormat == DnsRequestFormat.DnsOverTCP) {
                 Port = 53;

--- a/DnsClientX/Definitions/DnsEndpoint.cs
+++ b/DnsClientX/Definitions/DnsEndpoint.cs
@@ -64,6 +64,14 @@ namespace DnsClientX {
         /// <summary>
         /// OpenDNS's family-friendly DNS-over-HTTPS endpoint.
         /// </summary>
-        OpenDNSFamily
+        OpenDNSFamily,
+        /// <summary>
+        /// Cloudflare's DNS-over-QUIC endpoint.
+        /// </summary>
+        CloudflareQuic,
+        /// <summary>
+        /// Google's DNS-over-QUIC endpoint.
+        /// </summary>
+        GoogleQuic
     }
 }

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -29,5 +29,9 @@ namespace DnsClientX {
         /// Wire format using the DOT protocol for DNS requests.
         /// </summary>
         DnsOverTLS,
+        /// <summary>
+        /// DNS over QUIC, defined in <a href="https://www.rfc-editor.org/rfc/rfc9250">RFC 9250</a>.
+        /// </summary>
+        DnsOverQuic,
     }
 }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -79,6 +79,8 @@ namespace DnsClientX {
                 response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {
                 response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, IgnoreCertificateErrors, cancellationToken);
+            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverQuic) {
+                response = await DnsWireResolveQuic.ResolveWireFormatQuic(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTCP) {
                 response = await DnsWireResolveTcp.ResolveWireFormatTcp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverUDP) {

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Net;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+#if NET8_0_OR_GREATER
+    #pragma warning disable CA2252
+    internal static class DnsWireResolveQuic {
+        internal static async Task<DnsResponse> ResolveWireFormatQuic(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
+
+            var query = new DnsMessage(name, type, requestDnsSec);
+            var queryBytes = query.SerializeDnsWireFormat();
+
+            var lengthPrefix = BitConverter.GetBytes((ushort)queryBytes.Length);
+            if (BitConverter.IsLittleEndian) {
+                Array.Reverse(lengthPrefix);
+            }
+
+            var payload = new byte[lengthPrefix.Length + queryBytes.Length];
+            Buffer.BlockCopy(lengthPrefix, 0, payload, 0, lengthPrefix.Length);
+            Buffer.BlockCopy(queryBytes, 0, payload, lengthPrefix.Length, queryBytes.Length);
+
+            if (debug) {
+                Settings.Logger.WriteDebug($"Query Name: {name} type: {type}");
+                Settings.Logger.WriteDebug($"Sending combined query: {BitConverter.ToString(payload)}");
+            }
+
+            var endPoint = new IPEndPoint(IPAddress.Parse(dnsServer), port);
+            var options = new QuicClientConnectionOptions {
+                RemoteEndPoint = endPoint,
+                ClientAuthenticationOptions = new SslClientAuthenticationOptions {
+                    ApplicationProtocols = [ new SslApplicationProtocol("doq") ],
+                    EnabledSslProtocols = SslProtocols.Tls13
+                }
+            };
+
+            try {
+                await using var connection = await QuicConnection.ConnectAsync(options, cancellationToken);
+                await using var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken);
+
+                await stream.WriteAsync(payload, cancellationToken);
+                stream.CompleteWrites();
+
+                var lengthBuffer = new byte[2];
+                await DnsWire.ReadExactAsync(stream, lengthBuffer, 0, 2, cancellationToken);
+                if (BitConverter.IsLittleEndian) {
+                    Array.Reverse(lengthBuffer);
+                }
+                int responseLength = BitConverter.ToUInt16(lengthBuffer, 0);
+                var responseBuffer = new byte[responseLength];
+                await DnsWire.ReadExactAsync(stream, responseBuffer, 0, responseLength, cancellationToken);
+
+                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer);
+                response.AddServerDetails(endpointConfiguration);
+                return response;
+            } catch (Exception ex) {
+                DnsResponseCode responseCode = ex is TimeoutException ? DnsResponseCode.ServerFailure : DnsResponseCode.Refused;
+                var response = new DnsResponse {
+                    Questions = [ new DnsQuestion { Name = name, RequestFormat = DnsRequestFormat.DnsOverQuic, Type = type, OriginalName = name } ],
+                    Status = responseCode
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" => {ex.Message}";
+                return response;
+            }
+        }
+    }
+    #pragma warning restore CA2252
+#endif
+}


### PR DESCRIPTION
## Summary
- add `DnsOverQuic` request format and cloudflare/google QUIC endpoints
- implement QUIC resolver using `System.Net.Quic`
- integrate QUIC endpoints in configuration
- run QUIC tests conditionally via `DNS_OVER_QUIC`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: The SSL connection could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_6862f8d53b5c832e8d297b0e4bb16c03