### PR TITLE
Pass cancellation tokens to socket operations

### DIFF
--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -110,6 +110,9 @@ namespace DnsClientX {
         /// <param name="port">Target port.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         private static async Task ConnectAsync(TcpClient client, string host, int port, CancellationToken cancellationToken) {
+#if NET5_0_OR_GREATER
+            await client.ConnectAsync(host, port, cancellationToken);
+#else
             var connectTask = client.ConnectAsync(host, port);
             var delayTask = Task.Delay(Timeout.Infinite, cancellationToken);
 
@@ -120,6 +123,7 @@ namespace DnsClientX {
             }
 
             await connectTask;
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- propagate CancellationToken into socket APIs

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release --no-build` *(fails: HttpRequestException)*

------
https://chatgpt.com/codex/tasks/task_e_6862f82832cc832e879371c77eb3e09f