### PR TITLE
Add DNS response cache

### DIFF
--- a/DnsClientX.Tests/DnsResponseCacheTests.cs
+++ b/DnsClientX.Tests/DnsResponseCacheTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsResponseCacheTests {
+        [Fact]
+        public void ShouldStoreAndRetrieve() {
+            var cache = new DnsResponseCache();
+            var response = new DnsResponse { Status = DnsResponseCode.NoError };
+            cache.Set("a", response, TimeSpan.FromSeconds(1));
+            Assert.True(cache.TryGet("a", out var cached));
+            Assert.Same(response, cached);
+        }
+
+        [Fact]
+        public void ShouldEvictAfterExpiration() {
+            var cache = new DnsResponseCache();
+            var response = new DnsResponse { Status = DnsResponseCode.NoError };
+            cache.Set("a", response, TimeSpan.FromMilliseconds(100));
+            Thread.Sleep(150);
+            Assert.False(cache.TryGet("a", out _));
+        }
+
+        [Fact]
+        public void ClientConstructorEnablesCache() {
+            using var client = new ClientX(enableCache: true);
+            PropertyInfo property = typeof(ClientX).GetProperty("CacheEnabled")!;
+            Assert.True((bool)property.GetValue(client)!);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -63,6 +63,11 @@ namespace DnsClientX {
             // Get the HttpClient for the current strategy
             Client = GetClient(EndpointConfiguration.SelectionStrategy);
 
+            string cacheKey = $"{EndpointConfiguration.BaseUri}|{type}|{name}";
+            if (_cacheEnabled && _cache.TryGet(cacheKey, out var cached)) {
+                return cached;
+            }
+
             if (type == DnsRecordType.PTR) {
                 // if we have PTR we need to convert it to proper format, just in case user didn't provide as with one
                 name = ConvertToPtrFormat(name);
@@ -110,6 +115,10 @@ namespace DnsClientX {
                         response.Error = string.IsNullOrEmpty(response.Error) ? validationError : $"{response.Error} {validationError}";
                     }
                 }
+            }
+
+            if (_cacheEnabled) {
+                _cache.Set(cacheKey, response, CacheExpiration);
             }
 
             return response;

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -68,6 +68,11 @@ namespace DnsClientX {
         /// </summary>
         private readonly Dictionary<DnsSelectionStrategy, HttpClient> _clients = new Dictionary<DnsSelectionStrategy, HttpClient>();
 
+        private static readonly DnsResponseCache _cache = new();
+        private readonly bool _cacheEnabled;
+        public bool CacheEnabled => _cacheEnabled;
+        public TimeSpan CacheExpiration { get; set; } = TimeSpan.FromMinutes(1);
+
         /// <summary>
         /// Gets or sets the security protocol. The default value is <see cref="SecurityProtocolType.Tls12"/> which is required by Quad 9.
         /// </summary>
@@ -94,13 +99,15 @@ namespace DnsClientX {
         /// <param name="dnsSelectionStrategy">Dns selection strategy</param>
         /// <param name="timeOutMilliseconds"></param>
         /// <param name="ignoreCertificateErrors">Ignore certificate validation errors.</param>
+        /// <param name="enableCache">Enable in-memory caching of responses.</param>
         public ClientX(
             DnsEndpoint endpoint = DnsEndpoint.Cloudflare,
             DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First,
             int timeOutMilliseconds = 1000,
             string? userAgent = null,
             Version? httpVersion = null,
-            bool ignoreCertificateErrors = false) {
+            bool ignoreCertificateErrors = false,
+            bool enableCache = false) {
             EndpointConfiguration = new Configuration(endpoint, dnsSelectionStrategy) {
                 TimeOut = timeOutMilliseconds
             };
@@ -111,6 +118,7 @@ namespace DnsClientX {
                 EndpointConfiguration.HttpVersion = httpVersion;
             }
             IgnoreCertificateErrors = ignoreCertificateErrors;
+            _cacheEnabled = enableCache;
             ConfigureClient();
         }
 
@@ -121,13 +129,15 @@ namespace DnsClientX {
         /// <param name="requestFormat">The request format.</param>
         /// <param name="timeOutMilliseconds"></param>
         /// <param name="ignoreCertificateErrors">Ignore certificate validation errors.</param>
+        /// <param name="enableCache">Enable in-memory caching of responses.</param>
         public ClientX(
             string hostname,
             DnsRequestFormat requestFormat,
             int timeOutMilliseconds = 1000,
             string? userAgent = null,
             Version? httpVersion = null,
-            bool ignoreCertificateErrors = false) {
+            bool ignoreCertificateErrors = false,
+            bool enableCache = false) {
             EndpointConfiguration = new Configuration(hostname, requestFormat) {
                 TimeOut = timeOutMilliseconds
             };
@@ -138,6 +148,7 @@ namespace DnsClientX {
                 EndpointConfiguration.HttpVersion = httpVersion;
             }
             IgnoreCertificateErrors = ignoreCertificateErrors;
+            _cacheEnabled = enableCache;
             ConfigureClient();
         }
 
@@ -148,13 +159,15 @@ namespace DnsClientX {
         /// <param name="requestFormat">The request format.</param>
         /// <param name="timeOutMilliseconds"></param>
         /// <param name="ignoreCertificateErrors">Ignore certificate validation errors.</param>
+        /// <param name="enableCache">Enable in-memory caching of responses.</param>
         public ClientX(
             Uri baseUri,
             DnsRequestFormat requestFormat,
             int timeOutMilliseconds = 1000,
             string? userAgent = null,
             Version? httpVersion = null,
-            bool ignoreCertificateErrors = false) {
+            bool ignoreCertificateErrors = false,
+            bool enableCache = false) {
             EndpointConfiguration = new Configuration(baseUri, requestFormat) {
                 TimeOut = timeOutMilliseconds
             };
@@ -165,6 +178,7 @@ namespace DnsClientX {
                 EndpointConfiguration.HttpVersion = httpVersion;
             }
             IgnoreCertificateErrors = ignoreCertificateErrors;
+            _cacheEnabled = enableCache;
             ConfigureClient();
         }
 

--- a/DnsClientX/DnsResponseCache.cs
+++ b/DnsClientX/DnsResponseCache.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace DnsClientX {
+    internal class DnsResponseCache {
+        private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
+
+        private record CacheEntry(DnsResponse Response, DateTimeOffset Expiration);
+
+        public bool TryGet(string key, out DnsResponse response) {
+            if (_cache.TryGetValue(key, out var entry)) {
+                if (DateTimeOffset.UtcNow < entry.Expiration) {
+                    response = entry.Response;
+                    return true;
+                }
+                _cache.TryRemove(key, out _);
+            }
+            response = default;
+            return false;
+        }
+
+        public void Set(string key, DnsResponse response, TimeSpan ttl) {
+            var entry = new CacheEntry(response, DateTimeOffset.UtcNow.Add(ttl));
+            _cache[key] = entry;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add basic `DnsResponseCache` with TTL
- enable cache via `ClientX` constructor
- cache results within `ResolveInternal`
- test cache hits and eviction

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: HttpRequestException)*

------
https://chatgpt.com/codex/tasks/task_e_686301412730832e811904bd0999d665