### PR TITLE
Add IWebProxy support

### DIFF
--- a/DnsClientX.Tests/ProxyTests.cs
+++ b/DnsClientX.Tests/ProxyTests.cs
@@ -1,0 +1,17 @@
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ProxyTests {
+        [Fact]
+        public void ShouldConfigureProxyOnHandler() {
+            var proxy = new WebProxy("http://localhost:1234");
+            using var client = new ClientX(DnsEndpoint.Cloudflare, proxy: proxy);
+            var handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var handler = (HttpClientHandler)handlerField.GetValue(client)!;
+            Assert.Equal(proxy, handler.Proxy);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -69,6 +69,11 @@ namespace DnsClientX {
         private readonly Dictionary<DnsSelectionStrategy, HttpClient> _clients = new Dictionary<DnsSelectionStrategy, HttpClient>();
 
         /// <summary>
+        /// Optional proxy to use for HTTP requests
+        /// </summary>
+        private readonly IWebProxy? _proxy;
+
+        /// <summary>
         /// Gets or sets the security protocol. The default value is <see cref="SecurityProtocolType.Tls12"/> which is required by Quad 9.
         /// </summary>
         /// <value>
@@ -100,7 +105,8 @@ namespace DnsClientX {
             int timeOutMilliseconds = 1000,
             string? userAgent = null,
             Version? httpVersion = null,
-            bool ignoreCertificateErrors = false) {
+            bool ignoreCertificateErrors = false,
+            IWebProxy? proxy = null) {
             EndpointConfiguration = new Configuration(endpoint, dnsSelectionStrategy) {
                 TimeOut = timeOutMilliseconds
             };
@@ -111,6 +117,7 @@ namespace DnsClientX {
                 EndpointConfiguration.HttpVersion = httpVersion;
             }
             IgnoreCertificateErrors = ignoreCertificateErrors;
+            _proxy = proxy;
             ConfigureClient();
         }
 
@@ -127,7 +134,8 @@ namespace DnsClientX {
             int timeOutMilliseconds = 1000,
             string? userAgent = null,
             Version? httpVersion = null,
-            bool ignoreCertificateErrors = false) {
+            bool ignoreCertificateErrors = false,
+            IWebProxy? proxy = null) {
             EndpointConfiguration = new Configuration(hostname, requestFormat) {
                 TimeOut = timeOutMilliseconds
             };
@@ -138,6 +146,7 @@ namespace DnsClientX {
                 EndpointConfiguration.HttpVersion = httpVersion;
             }
             IgnoreCertificateErrors = ignoreCertificateErrors;
+            _proxy = proxy;
             ConfigureClient();
         }
 
@@ -154,7 +163,8 @@ namespace DnsClientX {
             int timeOutMilliseconds = 1000,
             string? userAgent = null,
             Version? httpVersion = null,
-            bool ignoreCertificateErrors = false) {
+            bool ignoreCertificateErrors = false,
+            IWebProxy? proxy = null) {
             EndpointConfiguration = new Configuration(baseUri, requestFormat) {
                 TimeOut = timeOutMilliseconds
             };
@@ -165,6 +175,7 @@ namespace DnsClientX {
                 EndpointConfiguration.HttpVersion = httpVersion;
             }
             IgnoreCertificateErrors = ignoreCertificateErrors;
+            _proxy = proxy;
             ConfigureClient();
         }
 
@@ -186,6 +197,10 @@ namespace DnsClientX {
 
             // Create handler with proper connection management
             var handler = new HttpClientHandler();
+            if (_proxy != null) {
+                handler.Proxy = _proxy;
+                handler.UseProxy = true;
+            }
             if (IgnoreCertificateErrors) {
                 handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
             }

--- a/README.md
+++ b/README.md
@@ -349,6 +349,11 @@ data.Answers
 ```csharp
 using var client = new ClientX(DnsEndpoint.Cloudflare, userAgent: "MyApp/1.0", httpVersion: new Version(1, 1));
 ```
+You can also pass a custom `IWebProxy`:
+```csharp
+var proxy = new WebProxy("http://proxy:3128");
+using var client = new ClientX(DnsEndpoint.Cloudflare, proxy: proxy);
+```
 You can also modify `client.EndpointConfiguration.UserAgent` and `client.EndpointConfiguration.HttpVersion` after construction.
 
 ### Querying DS record with DNSSEC


### PR DESCRIPTION
## Summary
- accept `IWebProxy` in `ClientX` constructors
- set `HttpClientHandler.Proxy` when a proxy is supplied
- document proxy usage
- test proxy configuration

## Testing
- `dotnet test DnsClientX.sln` *(fails: QueryDns over network)*

------
https://chatgpt.com/codex/tasks/task_e_6863011ca6fc832ebe1a9b54ed97b453