### PR TITLE
Handle unsupported QUIC

### DIFF
--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -58,6 +58,14 @@ namespace DnsClientX {
                 var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer);
                 response.AddServerDetails(endpointConfiguration);
                 return response;
+            } catch (PlatformNotSupportedException ex) {
+                var response = new DnsResponse {
+                    Questions = [ new DnsQuestion { Name = name, RequestFormat = DnsRequestFormat.DnsOverQuic, Type = type, OriginalName = name } ],
+                    Status = DnsResponseCode.NotImplemented
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"DNS over QUIC is not supported on this platform: {ex.Message}";
+                return response;
             } catch (Exception ex) {
                 DnsResponseCode responseCode = ex is TimeoutException ? DnsResponseCode.ServerFailure : DnsResponseCode.Refused;
                 var response = new DnsResponse {


### PR DESCRIPTION
## Summary
- handle PlatformNotSupportedException when creating a QUIC connection

## Testing
- `dotnet restore DnsClientX.sln`
- `dotnet build DnsClientX.sln --configuration Release --no-restore`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration Release --framework net8.0 --no-build --verbosity normal --logger "trx" --collect:"XPlat Code Coverage"` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863868037a4832eb602b6ea94546d1c