### PR TITLE
Use HashSet for DNS server deduplication

### DIFF
--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -175,7 +174,16 @@ namespace DnsClientX {
         }
 
         private static List<string> DeduplicateDnsServers(IEnumerable<string> servers) {
-            return servers.Distinct().ToList();
+            var unique = new HashSet<string>();
+            var result = new List<string>();
+
+            foreach (var server in servers) {
+                if (unique.Add(server)) {
+                    result.Add(server);
+                }
+            }
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- improve deduplication in `SystemInformation` using `HashSet`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: networking required)*

------
https://chatgpt.com/codex/tasks/task_e_686386597e2c832e8f177a7c5c1ce1cb