### PR TITLE
Implement TCP client reuse

### DIFF
--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -51,6 +51,8 @@ namespace DnsClientX {
                     }
 
                     handlerLocal?.Dispose();
+
+                    DnsWireResolveTcp.DisposeConnections();
                 }
 
                 _disposed = true;


### PR DESCRIPTION
## Summary
- reuse TCP connections for DNS queries with static `ConcurrentDictionary`
- clean up TCP connections during `ClientX` disposal

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: many network tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6863861441c0832eb283a81c3b740c65