### PR TITLE
Add HTTP/3 resolver

### DIFF
--- a/DnsClientX.Tests/QueryDnsOverHttp3.cs
+++ b/DnsClientX.Tests/QueryDnsOverHttp3.cs
@@ -1,0 +1,15 @@
+#if DNS_OVER_HTTP3 && NET8_0_OR_GREATER
+using System.Threading.Tasks;
+
+namespace DnsClientX.Tests {
+    public class QueryDnsOverHttp3 {
+        [Theory]
+        [InlineData("1.1.1.1")]
+        [InlineData("8.8.8.8")]
+        public async Task ShouldResolveA(string hostName) {
+            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, hostName, DnsRequestFormat.DnsOverHttp3);
+            Assert.NotEmpty(response.Answers);
+        }
+    }
+}
+#endif

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -33,5 +33,9 @@ namespace DnsClientX {
         /// DNS over QUIC, defined in <a href="https://www.rfc-editor.org/rfc/rfc9250">RFC 9250</a>.
         /// </summary>
         DnsOverQuic,
+        /// <summary>
+        /// DNS over HTTP/3 using wire format.
+        /// </summary>
+        DnsOverHttp3,
     }
 }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -82,6 +82,8 @@ namespace DnsClientX {
                 response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
                 response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3) {
+                response = await Client.ResolveWireFormatHttp3(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {
                 response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, IgnoreCertificateErrors, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverQuic) {

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -245,7 +245,8 @@ namespace DnsClientX {
 
             // Set the accept header based on the request format, which is required for proper processing
             if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps ||
-                EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
+                EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||
+                EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3) {
                 client.DefaultRequestHeaders.Accept.Add(
                     new MediaTypeWithQualityHeaderValue("application/dns-message"));
             } else {

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    internal static class DnsWireResolveHttp3 {
+        internal static async Task<DnsResponse> ResolveWireFormatHttp3(this HttpClient client, string name,
+            DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
+            Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec);
+            var base64UrlDnsMessage = dnsMessage.ToBase64Url();
+            string url = $"?dns={base64UrlDnsMessage}";
+
+            using HttpRequestMessage req = new(HttpMethod.Get, url);
+#if NET8_0_OR_GREATER
+            req.Version = HttpVersion.Version30;
+#else
+            req.Version = new Version(3, 0);
+#endif
+            if (debug) {
+                Settings.Logger.WriteDebug("Query Name: " + name + " type: " + type + " url: " + req.RequestUri);
+                Settings.Logger.WriteDebug("Query DnsWireFormatBytes: " + base64UrlDnsMessage);
+            }
+
+            try {
+                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken);
+                DnsResponse response = await res.DeserializeDnsWireFormat(debug);
+                response.AddServerDetails(endpointConfiguration);
+                if (res.StatusCode != HttpStatusCode.OK || !string.IsNullOrEmpty(response.Error)) {
+                    string message = string.Concat(
+                        $"Failed to query type {type} of \"{name}\", received HTTP status code {res.StatusCode}.",
+                        string.IsNullOrEmpty(response.Error) ? string.Empty : $"\nError: {response.Error}",
+                        response.Comments is null ? string.Empty : $"\nComments: {string.Join(", ", response.Comments)}");
+                    throw new DnsClientException(message, response);
+                }
+
+                return response;
+            } catch (HttpRequestException ex) {
+                DnsResponseCode responseCode;
+                if (ex.InnerException is TaskCanceledException || ex.InnerException is TimeoutException) {
+                    responseCode = DnsResponseCode.ServerFailure;
+                } else if (ex.InnerException is WebException webEx) {
+                    switch (webEx.Status) {
+                        case WebExceptionStatus.Timeout:
+                            responseCode = DnsResponseCode.ServerFailure;
+                            break;
+                        case WebExceptionStatus.ConnectFailure:
+                            responseCode = DnsResponseCode.Refused;
+                            break;
+                        case WebExceptionStatus.NameResolutionFailure:
+                            responseCode = DnsResponseCode.ServerFailure;
+                            break;
+                        case WebExceptionStatus.TrustFailure:
+                        case WebExceptionStatus.SecureChannelFailure:
+                            responseCode = DnsResponseCode.Refused;
+                            break;
+                        default:
+                            responseCode = DnsResponseCode.ServerFailure;
+                            break;
+                    }
+                } else {
+                    var error = (ex.InnerException?.Message ?? string.Empty).ToLowerInvariant();
+                    if (error.Contains("ssl") || error.Contains("certificate") || error.Contains("handshake")) {
+                        responseCode = DnsResponseCode.Refused;
+                    } else if (error.Contains("timeout")) {
+                        responseCode = DnsResponseCode.ServerFailure;
+                    } else {
+                        responseCode = DnsResponseCode.ServerFailure;
+                    }
+                }
+
+                DnsResponse response = new DnsResponse {
+                    Questions = [
+                        new DnsQuestion {
+                            Name = name,
+                            RequestFormat = DnsRequestFormat.DnsOverHttp3,
+                            HostName = client.BaseAddress.Host,
+                            Port = client.BaseAddress.Port,
+                            Type = type,
+                            OriginalName = name
+                        }
+                    ],
+                    Status = responseCode
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" =>{ex.Message} {ex.InnerException?.Message}";
+                return response;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `DnsRequestFormat` with `DnsOverHttp3`
- implement HTTP/3 resolver
- update client switch logic for new format
- allow HTTP/3 accept header selection
- add basic HTTP/3 test

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Failed: 140, Passed: 198, Skipped: 14)*

------
https://chatgpt.com/codex/tasks/task_e_6863863df7dc832e87510553bcbb9dd8