### PR TITLE
Implement TCP connection pooling

### DIFF
--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -51,6 +51,7 @@ namespace DnsClientX {
                     }
 
                     handlerLocal?.Dispose();
+                    TcpConnectionStore.DisposeAll();
                 }
 
                 _disposed = true;

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -62,12 +62,14 @@ namespace DnsClientX {
                 Settings.Logger.WriteDebug($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
             }
 
-            // Create a new TCP client and connect to the DNS server
-            using var client = new TcpClient();
-            await ConnectAsync(client, dnsServer, port, cancellationToken);
+            // Get or create TCP connection to the DNS server
+            TcpClient client = await TcpConnectionStore.GetConnectionAsync(
+                dnsServer,
+                port,
+                c => ConnectAsync(c, dnsServer, port, cancellationToken));
 
             // Create a new SSL stream for the secure connection
-            using var sslStream = new SslStream(client.GetStream(), false, (sender, certificate, chain, sslPolicyErrors) =>
+            using var sslStream = new SslStream(client.GetStream(), true, (sender, certificate, chain, sslPolicyErrors) =>
                 sslPolicyErrors == SslPolicyErrors.None || ignoreCertificateErrors);
 
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -85,13 +85,13 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
-            using var tcpClient = new TcpClient();
+            TcpClient tcpClient = await TcpConnectionStore.GetConnectionAsync(
+                dnsServer,
+                port,
+                client => ConnectAsync(client, dnsServer, port, timeoutMilliseconds, cancellationToken));
             try {
-                // Connect to the server with timeout
-                await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken);
-
-                // Stream operations wrapped in using to ensure disposal on exceptions
-                using var stream = tcpClient.GetStream();
+                // Stream for the existing connection
+                var stream = tcpClient.GetStream();
 
                 // Write the length of the query as a 16-bit big-endian integer
                 var lengthBytes = BitConverter.GetBytes((ushort)query.Length);

--- a/DnsClientX/TcpConnectionStore.cs
+++ b/DnsClientX/TcpConnectionStore.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    internal static class TcpConnectionStore {
+        private static readonly ConcurrentDictionary<string, TcpClient> _connections = new();
+
+        internal static async Task<TcpClient> GetConnectionAsync(string host, int port, Func<TcpClient, Task> connectAsync) {
+            string key = $"{host}:{port}";
+            if (_connections.TryGetValue(key, out var existing)) {
+                if (existing.Connected) {
+                    return existing;
+                }
+
+                RemoveConnection(key, existing);
+            }
+
+            var client = new TcpClient();
+            await connectAsync(client);
+            _connections[key] = client;
+            return client;
+        }
+
+        private static void RemoveConnection(string key, TcpClient client) {
+            try {
+                client.Dispose();
+            } catch {
+                // Ignore disposal errors
+            }
+
+            _connections.TryRemove(key, out _);
+        }
+
+        internal static void DisposeAll() {
+            foreach (var kvp in _connections) {
+                RemoveConnection(kvp.Key, kvp.Value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- maintain reusable TCP connections with a new `TcpConnectionStore`
- leverage connection pool in DNS wire resolvers for TCP and TLS
- dispose pooled connections from `ClientX`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: 140 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68638c1a042c832e9ff7d1d4c991a841