### PR TITLE
Adjust server order randomization

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -148,7 +148,10 @@ namespace DnsClientX.PowerShell {
             string types = string.Join(", ", Type);
             if (Server.Count > 0) {
                 IEnumerable<string> serverOrder = Server;
-                if (RandomServer.IsPresent) {
+                // When both AllServers and Fallback are specified, randomize server
+                // selection to avoid always hitting the same order. RandomServer also
+                // triggers randomization.
+                if (RandomServer.IsPresent || (AllServers.IsPresent && Fallback.IsPresent)) {
                     var random = new Random();
                     serverOrder = serverOrder.OrderBy(_ => random.Next()).ToList();
                 }


### PR DESCRIPTION
## Summary
- randomize server selection if both `AllServers` and `Fallback` switches are used, or if `RandomServer` is specified

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68638f7a9e2c832e9d5609406401d712