### PR TITLE
Validate algorithm for DNSSEC parsing

### DIFF
--- a/DnsClientX.Tests/RootDnssecValidatorTests.cs
+++ b/DnsClientX.Tests/RootDnssecValidatorTests.cs
@@ -31,5 +31,35 @@ namespace DnsClientX.Tests {
             };
             Assert.True(DnsSecValidator.ValidateAgainstRoot(response));
         }
+
+        [Fact]
+        public void ValidateAgainstRoot_InvalidDsAlgorithm_ReturnsFalse() {
+            var response = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer {
+                        Name = ".",
+                        Type = DnsRecordType.DS,
+                        TTL = 3600,
+                        DataRaw = "20326 9 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"
+                    }
+                }
+            };
+            Assert.False(DnsSecValidator.ValidateAgainstRoot(response));
+        }
+
+        [Fact]
+        public void ValidateAgainstRoot_InvalidDnsKeyAlgorithm_ReturnsFalse() {
+            var response = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer {
+                        Name = ".",
+                        Type = DnsRecordType.DNSKEY,
+                        TTL = 3600,
+                        DataRaw = "257 3 9 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU="
+                    }
+                }
+            };
+            Assert.False(DnsSecValidator.ValidateAgainstRoot(response));
+        }
     }
 }

--- a/DnsClientX/Security/DnsSecValidator.cs
+++ b/DnsClientX/Security/DnsSecValidator.cs
@@ -49,6 +49,9 @@ namespace DnsClientX {
             } else if (!byte.TryParse(parts[1], out algVal)) {
                 return false;
             }
+            if (!Enum.IsDefined(typeof(DnsKeyAlgorithm), (int)algVal)) {
+                return false;
+            }
             if (!byte.TryParse(parts[2], out byte digestType)) {
                 return false;
             }
@@ -79,6 +82,9 @@ namespace DnsClientX {
             if (Enum.TryParse(typeof(DnsKeyAlgorithm), parts[2], true, out object? algEnum)) {
                 algVal = (byte)(DnsKeyAlgorithm)algEnum;
             } else if (!byte.TryParse(parts[2], out algVal)) {
+                return false;
+            }
+            if (!Enum.IsDefined(typeof(DnsKeyAlgorithm), (int)algVal)) {
                 return false;
             }
             algorithm = (DnsKeyAlgorithm)algVal;


### PR DESCRIPTION
## Summary
- ensure DS and DNSKEY parsing only accepts defined algorithms
- test invalid algorithms for DS and DNSKEY

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: QueryDnsShouldCancelEarly, ShouldWorkForPTR, ShouldWorkForTXT_Sync, QueryDnsIDN.ShouldWorkForA, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68638f652658832ea198bc9352963e2e