### PR TITLE
Fix DNSSEC spaced base64 parsing

### DIFF
--- a/DnsClientX/Security/DnsSecValidator.cs
+++ b/DnsClientX/Security/DnsSecValidator.cs
@@ -82,7 +82,7 @@ namespace DnsClientX {
                 return false;
             }
             algorithm = (DnsKeyAlgorithm)algVal;
-            string keyBase64 = string.Join(string.Empty, parts.Skip(3));
+            string keyBase64 = string.Join(string.Empty, parts, 3, parts.Length - 3);
             try {
                 publicKey = Convert.FromBase64String(keyBase64);
             } catch {


### PR DESCRIPTION
## Summary
- fix spaced base64 parsing in `DnsSecValidator` for DNSKEY records

## Testing
- `dotnet test --no-build` *(fails: System.Reflection.TargetParameterCountException)*

------
https://chatgpt.com/codex/tasks/task_e_68638f5d760c832e8880b318494820cf