### PR TITLE
Fix ParseResolvConf comment handling

### DIFF
--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -144,6 +144,9 @@ namespace DnsClientX {
             try {
                 foreach (var line in File.ReadAllLines(path)) {
                     var trimmed = line.Trim();
+                    if (trimmed.StartsWith("#")) {
+                        continue;
+                    }
                     if (trimmed.StartsWith("nameserver", StringComparison.OrdinalIgnoreCase)) {
                         var parts = trimmed.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                         if (parts.Length > 1) {


### PR DESCRIPTION
## Summary
- ignore comment lines in `ParseResolvConf`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68638f50e6b4832eb06bf0b9b5470113