### PR TITLE
Fix randomization for AllServers+Fallback

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -162,7 +162,7 @@ namespace DnsClientX.PowerShell {
                 }
 
                 IEnumerable<string> serverOrder = validServers;
-                if (RandomServer.IsPresent) {
+                if (RandomServer.IsPresent || (AllServers.IsPresent && Fallback.IsPresent)) {
                     var random = new Random();
                     serverOrder = serverOrder.OrderBy(_ => random.Next()).ToList();
                 }


### PR DESCRIPTION
## Summary
- randomize server order when both AllServers and Fallback switches are used

## Testing
- `dotnet build DnsClientX.sln --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_686395c45794832e93bcdd9ae42ca552