### PR TITLE
Fix DataStringsEscaped prefix check

### DIFF
--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -96,7 +96,11 @@ namespace DnsClientX {
             get {
                 var data = new List<string>();
                 foreach (var item in DataStrings) {
-                    data.Add(item.StartsWith("\"") ? item.Replace("\"", "") : item);
+                    if (item.StartsWith("\\\"")) {
+                        data.Add(item.Replace("\\\"", string.Empty).Replace("\"", string.Empty));
+                    } else {
+                        data.Add(item);
+                    }
                 }
                 return data.ToArray();
             }


### PR DESCRIPTION
## Summary
- modify the escaping logic in `DnsAnswer` so that DataStringsEscaped only strips quotes when the string begins with `\"`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_686398a269ac832eb0f49b7bc074a49d