### PR TITLE
Add CloudflareQuic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,13 @@ using var client = new ClientX(DnsEndpoint.Cloudflare, userAgent: "MyApp/1.0", h
 ```
 You can also modify `client.EndpointConfiguration.UserAgent` and `client.EndpointConfiguration.HttpVersion` after construction.
 
+### Querying DNS over QUIC via Cloudflare
+
+```csharp
+var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.CloudflareQuic);
+data.Answers
+```
+
 ### Querying DS record with DNSSEC
 
 ```csharp


### PR DESCRIPTION
## Summary
- document usage of DnsEndpoint.CloudflareQuic in README

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686398c8b600832e98c33d00f3828421