### PR TITLE
Fix spaced base64 DNSKEY parsing

### DIFF
--- a/DnsClientX/Security/DnsSecValidator.cs
+++ b/DnsClientX/Security/DnsSecValidator.cs
@@ -88,7 +88,7 @@ namespace DnsClientX {
                 return false;
             }
             algorithm = (DnsKeyAlgorithm)algVal;
-            string keyBase64 = string.Join(string.Empty, parts, 3, parts.Length - 3);
+            string keyBase64 = string.Concat(parts.Skip(3));
             try {
                 publicKey = Convert.FromBase64String(keyBase64);
             } catch {


### PR DESCRIPTION
## Summary
- handle spaced Base64 DNSKEY values by concatenating all parts after index 3

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ConnectAsync)*

------
https://chatgpt.com/codex/tasks/task_e_686396a914c0832ea2a0efec7fbffcfd