### PR TITLE
Fix DNSKEY spaced base64 parsing

### DIFF
--- a/DnsClientX/Security/DnsSecValidator.cs
+++ b/DnsClientX/Security/DnsSecValidator.cs
@@ -86,7 +86,7 @@ namespace DnsClientX {
             } else {
                 return false;
             }
-            string keyBase64 = string.Join(string.Empty, parts, 3, parts.Length - 3);
+            string keyBase64 = string.Concat(parts.Skip(3));
             try {
                 publicKey = Convert.FromBase64String(keyBase64);
             } catch {


### PR DESCRIPTION
## Summary
- handle DNSKEY data containing whitespace by concatenating all parts from index 3 onward before base64 decoding

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68639f0b3c78832e85818f3da28e9dee