### PR TITLE
Add IPv6 PTR conversion helper

### DIFF
--- a/DnsClientX.Examples/DemoConvertIPv6ToPtr.cs
+++ b/DnsClientX.Examples/DemoConvertIPv6ToPtr.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace DnsClientX.Examples {
+    internal class DemoConvertIPv6ToPtr {
+        public static void Example() {
+            const string ipv6 = "2001:db8::1";
+            string ptr = ClientX.ConvertIPv6ToPtr(ipv6);
+            Settings.Logger.WriteInformation($"{ipv6} => {ptr}");
+        }
+    }
+}

--- a/DnsClientX.Tests/ConvertIPv6ToPtrTests.cs
+++ b/DnsClientX.Tests/ConvertIPv6ToPtrTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ConvertIPv6ToPtrTests {
+        [Fact]
+        public void ConvertsIpv6AndTrims() {
+            var result = ClientX.ConvertIPv6ToPtr(" 2001:db8::1 ");
+            Assert.Equal("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", result);
+        }
+
+        [Fact]
+        public void ReturnsInputForInvalidOrIpv4() {
+            Assert.Equal("1.2.3.4", ClientX.ConvertIPv6ToPtr("1.2.3.4"));
+            Assert.Equal("notanipv6", ClientX.ConvertIPv6ToPtr("notanipv6"));
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -321,13 +321,32 @@ namespace DnsClientX {
                     return string.Join(".", ip.GetAddressBytes().Reverse()) + ".in-addr.arpa";
                 } else if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6) {
                     // IPv6
-                    return string.Join(".", ip.GetAddressBytes()
-                        .SelectMany(b => b.ToString("x2"))
-                        .Reverse()) + ".ip6.arpa";
+                    return ConvertIPv6ToPtr(ipAddress);
                 }
             }
             // Invalid IP address, we return as is
             return ipAddress;
+        }
+
+        /// <summary>
+        /// Converts an IPv6 address to its PTR format. This is useful for reverse DNS lookups.
+        /// </summary>
+        /// <param name="address">The IPv6 address.</param>
+        /// <returns>PTR representation of the IPv6 address.</returns>
+        public static string ConvertIPv6ToPtr(string address) {
+            if (string.IsNullOrWhiteSpace(address)) {
+                return address;
+            }
+
+            address = address.Trim();
+            if (IPAddress.TryParse(address, out IPAddress? ip) &&
+                ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6) {
+                return string.Join(".", ip.GetAddressBytes()
+                        .SelectMany(b => b.ToString("x2"))
+                        .Reverse()) + ".ip6.arpa";
+            }
+
+            return address;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `ClientX.ConvertIPv6ToPtr` to convert IPv6 addresses to PTR
- demo using the new helper in examples
- test `ConvertIPv6ToPtr`
- use helper inside existing `ConvertToPtrFormat`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build -c Release --framework net8.0` *(fails: DnsResponseCacheTests.ShouldStoreAndRetrieve, DnssecTests.QueryDnskey_WithDnssec, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6863d2c9e8a8832e99eb6153d187e13a