### PR TITLE
Add fallback from QUIC to DoT

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@
 
 **Full Changelog**: https://github.com/EvotecIT/DnsClientX/compare/v...v0.3.4
 
+## 0.4.0 - 2025.07.01
+### What's Changed
+* QUIC queries now automatically fall back to DNS over TLS when QUIC is not supported or connection fails
+
 ## 0.3.2/0.3.3 - 2024.11.15
 ### What's Changed
 * Few improvements, fix PTR by @PrzemyslawKlys in https://github.com/EvotecIT/DnsClientX/pull/12

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -87,7 +87,17 @@ namespace DnsClientX {
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {
                 response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, IgnoreCertificateErrors, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverQuic) {
-                response = await DnsWireResolveQuic.ResolveWireFormatQuic(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+                response = await DnsWireResolveQuic.ResolveWireFormatQuic(
+                    EndpointConfiguration.Hostname,
+                    EndpointConfiguration.Port,
+                    name,
+                    type,
+                    requestDnsSec,
+                    validateDnsSec,
+                    Debug,
+                    EndpointConfiguration,
+                    IgnoreCertificateErrors,
+                    cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTCP) {
                 response = await DnsWireResolveTcp.ResolveWireFormatTcp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverUDP) {


### PR DESCRIPTION
## Summary
- retry QUIC requests via DoT when QUIC is unsupported or encounters connection errors
- expose `ignoreCertificateErrors` on the QUIC resolver
- document fallback behavior in CHANGELOG

## Testing
- `dotnet build -v minimal`
- `dotnet test --no-build -v minimal` *(fails: ConvertToPunycodeTests.ReturnsOriginalForInvalidIdn, ConvertToPtrFormatTests.TrimsAndConvertsIpv6, QueryDnsSpecialCases.ShouldDeliverResponseOnFailedQueries, QueryDnsIDN.ShouldWorkForA, ResolveSync.ShouldWorkForAllSyncTXT, QueryDnsIDN.ShouldWorkForA, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6863d2d33c14832ea60a7609553bd63e