### PR TITLE
Fix reflection tests

### DIFF
--- a/DnsClientX.Tests/ConvertToPtrFormatTests.cs
+++ b/DnsClientX.Tests/ConvertToPtrFormatTests.cs
@@ -18,7 +18,7 @@ namespace DnsClientX.Tests {
         [Fact]
         public void TrimsAndConvertsIpv6() {
             var result = Invoke(" 2001:db8::1 ");
-            Assert.Equal("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", result);
+            Assert.Equal("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", result);
         }
     }
 }

--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -17,7 +17,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1 })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1, null })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -35,7 +35,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50 })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, null })!;
             }
 
             var sw = Stopwatch.StartNew();
@@ -59,7 +59,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50 })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, null })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -78,7 +78,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<DnsResponse> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(DnsResponse));
-                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1 })!;
+                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, null })!;
             }
 
             var ex = await Assert.ThrowsAsync<DnsClientException>(Invoke);


### PR DESCRIPTION
## Summary
- fix RetryAsyncTests to include optional argument
- update IPv6 PTR format expectation

## Testing
- `dotnet test --verbosity minimal` *(fails: The argument /workspace/DnsClientX/DnsClientX.Tests/bin/Debug/net8.0/DnsClientX.Tests.dll is invalid. Please use the /help option to check the list of valid arguments.)*
- `dotnet test --verbosity minimal` *(fails: 134 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68640d904c98832e8ab45955c9a4ece3