### PR TITLE
Fix transient detection for DnsClientException

### DIFF
--- a/DnsClientX.Tests/TransientDetectionTests.cs
+++ b/DnsClientX.Tests/TransientDetectionTests.cs
@@ -19,8 +19,7 @@ namespace DnsClientX.Tests {
         [Fact]
         public void IsTransient_DnsClientExceptionWithServerFailure_ShouldBeTrue() {
             var response = new DnsResponse { Status = DnsResponseCode.ServerFailure };
-            var ex = new DnsClientException("error");
-            ex.Data["DnsResponse"] = response;
+            var ex = new DnsClientException("error", response);
 
             Assert.True(InvokeIsTransient(ex));
         }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -203,8 +203,16 @@ namespace DnsClientX {
 
         private static bool IsTransient(Exception ex) {
             // Handle DnsClientException with specific response codes
-            if (ex is DnsClientException dnsEx && dnsEx.Data.Contains("DnsResponse")) {
-                if (dnsEx.Data["DnsResponse"] is DnsResponse response) {
+            if (ex is DnsClientException dnsEx) {
+                DnsResponse? response = null;
+
+                if (dnsEx.Response is not null) {
+                    response = dnsEx.Response;
+                } else if (dnsEx.Data.Contains("DnsResponse") && dnsEx.Data["DnsResponse"] is DnsResponse resp) {
+                    response = resp;
+                }
+
+                if (response is not null) {
                     // Consider these DNS response codes as transient (should retry)
                     return response.Status == DnsResponseCode.ServerFailure ||
                            response.Status == DnsResponseCode.Refused ||


### PR DESCRIPTION
## Summary
- handle `DnsClientException.Response` when determining if an exception is transient
- update test to match new logic

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter IsTransient_DnsClientExceptionWithServerFailure_ShouldBeTrue --verbosity minimal`
- `dotnet build DnsClientX.sln --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_686429243af4832eab7c49a8ffb2bc81