### PR TITLE
Fix certificate validation callback handling

### DIFF
--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -213,7 +213,7 @@ namespace DnsClientX {
 #endif
 
             // Create handler with proper connection management
-            var handler = new HttpClientHandler();
+            handler = new HttpClientHandler();
             if (IgnoreCertificateErrors) {
                 handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
             }
@@ -265,9 +265,6 @@ namespace DnsClientX {
                 handler?.Dispose();
 
                 Client = CreateOptimizedHttpClient();
-                handler = (HttpClientHandler)((HttpClient)Client).GetType()
-                    .GetField("_handler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                    ?.GetValue(Client) as HttpClientHandler;
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure `HttpClientHandler` is stored when created
- remove reflection that failed to access the handler

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --filter "FullyQualifiedName~IgnoreCertificateErrorsTests.ShouldEnableCertificateValidationCallback"`


------
https://chatgpt.com/codex/tasks/task_e_68642906dad8832ea92c34786d120e55