### PR TITLE
Fix RetryAsync transient failure logic

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -145,8 +145,8 @@ namespace DnsClientX {
                     if (result is DnsResponse response && IsTransientResponse(response)) {
                         lastResult = result;
                         if (attempt == maxRetries) {
-                            // This was the last attempt, return the result (don't throw)
-                            return result;
+                            // Break out of the loop so the transient result can be evaluated below
+                            break;
                         }
 
                         beforeRetry?.Invoke();


### PR DESCRIPTION
## Summary
- ensure RetryAsync handles transient response on final attempt
- break out of loop and evaluate result instead of returning early

## Testing
- `dotnet test -c Debug --filter "FullyQualifiedName~RetryAsync_ShouldAdvanceHostnameOnFailure"`


------
https://chatgpt.com/codex/tasks/task_e_686428f92274832eada2b88a2e03d25d