### PR TITLE
Fix IPv6 PTR conversion test

### DIFF
--- a/DnsClientX.Tests/ConvertToPtrFormatTests.cs
+++ b/DnsClientX.Tests/ConvertToPtrFormatTests.cs
@@ -18,7 +18,7 @@ namespace DnsClientX.Tests {
         [Fact]
         public void TrimsAndConvertsIpv6() {
             var result = Invoke(" 2001:db8::1 ");
-            Assert.Equal("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", result);
+            Assert.Equal("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa", result);
         }
     }
 }


### PR DESCRIPTION
## Summary
- correct expected result for `TrimsAndConvertsIpv6`

## Testing
- `dotnet restore DnsClientX.sln --verbosity minimal`
- `dotnet build DnsClientX.sln --no-restore --verbosity minimal`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter FullyQualifiedName~DnsClientX.Tests.ConvertToPtrFormatTests.TrimsAndConvertsIpv6 --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686428c8f25c832eae85de379dee2401