### PR TITLE
Fix RetryAsync tests

### DIFF
--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -17,7 +17,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1 })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1, null })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -35,7 +35,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50 })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, null })!;
             }
 
             var sw = Stopwatch.StartNew();
@@ -59,7 +59,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50 })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, null })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -78,7 +78,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<DnsResponse> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(DnsResponse));
-                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1 })!;
+                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, null })!;
             }
 
             var ex = await Assert.ThrowsAsync<DnsClientException>(Invoke);


### PR DESCRIPTION
## Summary
- update RetryAsync test invocations to match new signature

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --framework net8.0 --filter "FullyQualifiedName=DnsClientX.Tests.RetryAsyncTests.ShouldThrowDnsClientExceptionOnTransientResponse" --verbosity minimal`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --framework net8.0 --filter "FullyQualifiedName=DnsClientX.Tests.RetryAsyncTests.ShouldRetrySpecifiedNumberOfTimes" --verbosity minimal`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --framework net8.0 --filter "FullyQualifiedName=DnsClientX.Tests.RetryAsyncTests.ShouldDelayBetweenRetries" --verbosity minimal`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --framework net8.0 --filter "FullyQualifiedName=DnsClientX.Tests.RetryAsyncTests.ShouldUseExponentialBackoff" --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68642e5a5c68832eb9fdb3d29da9a6fb