### PR TITLE
Fix invalid IDN handling

### DIFF
--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -296,6 +296,14 @@ namespace DnsClientX {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 return domainName;
             }
+            foreach (char c in domainName) {
+                UnicodeCategory cat = char.GetUnicodeCategory(c);
+                if (cat is UnicodeCategory.OtherSymbol
+                    or UnicodeCategory.PrivateUse
+                    or UnicodeCategory.Surrogate) {
+                    return domainName;
+                }
+            }
 
             IdnMapping idn = new IdnMapping();
             try {


### PR DESCRIPTION
## Summary
- return original domain when IDN contains unsupported characters

## Testing
- `dotnet test DnsClientX.Tests --filter FullyQualifiedName~ConvertToPunycodeTests.ReturnsOriginalForInvalidIdn --verbosity minimal`
- `dotnet test --no-build --verbosity quiet` *(fails: DnssecTests.QueryDnskey_WithDnssec(endpoint: Cloudflare))*

------
https://chatgpt.com/codex/tasks/task_e_686430b98c74832e9d98548758fa4436