### PR TITLE
Add ResolveStream async enumerator

### DIFF
--- a/DnsClientX.Tests/ResolveStream.cs
+++ b/DnsClientX.Tests/ResolveStream.cs
@@ -1,0 +1,23 @@
+using DnsClientX;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveStream {
+        [Fact]
+        public async Task ShouldStreamMultipleResponses() {
+            using var client = new ClientX(DnsEndpoint.System);
+            var names = new[] { "github.com", "microsoft.com" };
+            var types = new[] { DnsRecordType.A, DnsRecordType.MX };
+            int count = 0;
+
+            await foreach (var response in client.ResolveStream(names, types, retryOnTransient: false)) {
+                Assert.NotNull(response);
+                Assert.NotNull(response.Answers);
+                count++;
+            }
+
+            Assert.Equal(names.Length * types.Length, count);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.ResolveStream.cs
+++ b/DnsClientX/DnsClientX.ResolveStream.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    public partial class ClientX {
+        /// <summary>
+        /// Resolves multiple DNS record types for a single domain name and streams the responses.
+        /// </summary>
+        public async IAsyncEnumerable<DnsResponse> ResolveStream(
+            string name,
+            DnsRecordType[] types,
+            bool requestDnsSec = false,
+            bool validateDnsSec = false,
+            bool returnAllTypes = false,
+            bool retryOnTransient = true,
+            int maxRetries = 3,
+            int retryDelayMs = 200,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            foreach (DnsRecordType type in types) {
+                yield return await Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Resolves multiple domain names for multiple DNS record types and streams the responses.
+        /// </summary>
+        public async IAsyncEnumerable<DnsResponse> ResolveStream(
+            string[] names,
+            DnsRecordType[] types,
+            bool requestDnsSec = false,
+            bool validateDnsSec = false,
+            bool returnAllTypes = false,
+            bool retryOnTransient = true,
+            int maxRetries = 3,
+            int retryDelayMs = 200,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            foreach (string name in names) {
+                foreach (DnsRecordType type in types) {
+                    yield return await Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolves multiple domain names for a single DNS record type and streams the responses.
+        /// </summary>
+        public async IAsyncEnumerable<DnsResponse> ResolveStream(
+            string[] names,
+            DnsRecordType type,
+            bool requestDnsSec = false,
+            bool validateDnsSec = false,
+            bool returnAllTypes = false,
+            bool retryOnTransient = true,
+            int maxRetries = 3,
+            int retryDelayMs = 200,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            foreach (string name in names) {
+                yield return await Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -56,11 +56,13 @@
     <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net472' OR '$(TargetFramework)'=='net48'">
         <Reference Include="System.Net.Http" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -438,6 +438,10 @@ foreach (var endpoint in dnsEndpoints) {
             response.DisplayToConsole();
         }
     }
+
+    await foreach (var response in client.ResolveStream(domains.ToArray(), recordTypes.ToArray())) {
+        response.DisplayToConsole();
+    }
 }
 ```
 


### PR DESCRIPTION
## Summary
- add async streaming `ResolveStream` API
- update project references for async enumerable support
- document streaming usage in README
- test enumerator over multiple names and types

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6864c5f54f0c832e854e4c28d6a55553