### PR TITLE
Handle comments in resolv.conf parser

### DIFF
--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -144,7 +144,7 @@ namespace DnsClientX {
             try {
                 foreach (var line in File.ReadAllLines(path)) {
                     var trimmed = line.Trim();
-                    if (trimmed.StartsWith("#")) {
+                    if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#")) {
                         continue;
                     }
                     if (trimmed.StartsWith("nameserver", StringComparison.OrdinalIgnoreCase)) {


### PR DESCRIPTION
## Summary
- skip empty and commented lines when scanning resolv.conf

## Testing
- `dotnet build`
- `dotnet test` *(fails: could not reach network resources)*

------
https://chatgpt.com/codex/tasks/task_e_6864c63cb468832e9b7fe0d97574209e