### PR TITLE
Fix TCP read timeout

### DIFF
--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -152,7 +152,11 @@ namespace DnsClientX {
                 throw new TimeoutException($"Reading from stream timed out after {timeoutMilliseconds} milliseconds.");
             }
 
-            await readTask; // Ensure any exceptions from read are propagated
+            try {
+                await readTask; // Ensure any exceptions from read are propagated
+            } catch (OperationCanceledException) {
+                throw new TimeoutException($"Reading from stream timed out after {timeoutMilliseconds} milliseconds.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- propagate read errors in `DnsWireResolveTcp`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: 130, passed: 210, skipped: 14)*

------
https://chatgpt.com/codex/tasks/task_e_6864c6499630832eb1eb39b1d8e9f5c2