### PR TITLE
Fix async using placement in DOQ resolver

### DIFF
--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -61,9 +61,10 @@ namespace DnsClientX {
                 }
             };
 
+            await using var connection = await QuicConnection.ConnectAsync(options, cancellationToken);
+            await using var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken);
+
             try {
-                await using var connection = await QuicConnection.ConnectAsync(options, cancellationToken);
-                await using var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken);
 
                 await stream.WriteAsync(payload, cancellationToken);
                 stream.CompleteWrites();


### PR DESCRIPTION
## Summary
- move DOQ connection `await using` setup out of try-catch

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68658f37c354832e8c454d3a61b14e11