### PR TITLE
Add AdGuard providers

### DIFF
--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -244,6 +244,21 @@ namespace DnsClientX {
                     RequestFormat = DnsRequestFormat.DnsOverQuic;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
+                case DnsEndpoint.AdGuard:
+                    hostnames = new List<string> { "dns.adguard.com" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
+                    baseUriFormat = "https://{0}/dns-query";
+                    break;
+                case DnsEndpoint.AdGuardFamily:
+                    hostnames = new List<string> { "dns-family.adguard.com" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
+                    baseUriFormat = "https://{0}/dns-query";
+                    break;
+                case DnsEndpoint.AdGuardNonFiltering:
+                    hostnames = new List<string> { "dns-unfiltered.adguard.com" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
+                    baseUriFormat = "https://{0}/dns-query";
+                    break;
                 case DnsEndpoint.Quad9:
                     hostnames = new List<string> { "dns.quad9.net" };
                     RequestFormat = DnsRequestFormat.DnsOverHttps;

--- a/DnsClientX/Definitions/DnsEndpoint.cs
+++ b/DnsClientX/Definitions/DnsEndpoint.cs
@@ -73,5 +73,18 @@ namespace DnsClientX {
         /// Google's DNS-over-QUIC endpoint.
         /// </summary>
         GoogleQuic
+        ,
+        /// <summary>
+        /// AdGuard DNS-over-HTTPS endpoint.
+        /// </summary>
+        AdGuard,
+        /// <summary>
+        /// AdGuard family protection DNS-over-HTTPS endpoint.
+        /// </summary>
+        AdGuardFamily,
+        /// <summary>
+        /// AdGuard non-filtering DNS-over-HTTPS endpoint.
+        /// </summary>
+        AdGuardNonFiltering
     }
 }

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ Different DNS providers have distinct characteristics:
 - **Quad9 (9.9.9.9)**: Security-focused, blocks malicious domains
 - **OpenDNS**: Content filtering options, enterprise features
 
+| Provider | Hostname | Request Format |
+|----------|----------|----------------|
+| Cloudflare | `1.1.1.1` / `1.0.0.1` | JSON |
+| Google | `8.8.8.8` / `8.8.4.4` | JSON |
+| Quad9 | `dns.quad9.net` | Wire |
+| OpenDNS | `208.67.222.222` / `208.67.220.220` | Wire |
+| AdGuard | `dns.adguard.com` | Wire |
+| AdGuardFamily | `dns-family.adguard.com` | Wire |
+| AdGuardNonFiltering | `dns-unfiltered.adguard.com` | Wire |
+
 These differences can result in:
 - Varying response times (typically 10-500ms)
 - Different cached TTL values


### PR DESCRIPTION
## Summary
- add AdGuard providers to `DnsEndpoint`
- handle AdGuard providers in configuration
- document new providers in the README table

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68658fcfd234832ebabac3975fb3e785