### PR TITLE
Fix DNS server parsing for QUIC

### DIFF
--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -38,7 +38,7 @@ namespace DnsClientX {
             // brackets when constructing the endpoint string.
             IPAddress ipAddress;
             if (!IPAddress.TryParse(dnsServer, out ipAddress)) {
-                var hostEntry = await Dns.GetHostEntryAsync(dnsServer, cancellationToken);
+                var hostEntry = Dns.GetHostEntry(dnsServer);
                 ipAddress = hostEntry.AddressList[0];
             }
 


### PR DESCRIPTION
## Summary
- ensure DNS server strings get resolved if not an IP address

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj` *(fails: The argument ...)*

------
https://chatgpt.com/codex/tasks/task_e_68658f7573b0832eb9aa48f03ba2eb02