### PR TITLE
Fix resolv.conf parsing for tab-delimited entries

### DIFF
--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -148,7 +148,7 @@ namespace DnsClientX {
                         continue;
                     }
                     if (trimmed.StartsWith("nameserver", StringComparison.OrdinalIgnoreCase)) {
-                        var parts = trimmed.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                        var parts = trimmed.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                         if (parts.Length > 1) {
                             var address = parts[1];
                             debugPrint?.Invoke($"[resolv.conf] Found nameserver: {address}");


### PR DESCRIPTION
## Summary
- handle tab characters when splitting `nameserver` lines in `SystemInformation`

## Testing
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68658f660748832ea9f983c5b99a8b0f