### PR TITLE
Update server ordering logic

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -162,13 +162,17 @@ namespace DnsClientX.PowerShell {
                 }
 
                 IEnumerable<string> serverOrder = validServers;
-                if (RandomServer.IsPresent || (AllServers.IsPresent && Fallback.IsPresent)) {
+                if (RandomServer.IsPresent) {
                     var random = new Random();
                     serverOrder = serverOrder.OrderBy(_ => random.Next()).ToList();
                 }
 
                 IEnumerable<DnsResponse> results;
                 if (AllServers.IsPresent) {
+                    if (Fallback.IsPresent && !RandomServer.IsPresent) {
+                        var random = new Random();
+                        serverOrder = serverOrder.OrderBy(_ => random.Next()).ToList();
+                    }
                     var aggregatedResults = new List<DnsResponse>();
                     foreach (string serverName in serverOrder) {
                         _logger.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, serverName);


### PR DESCRIPTION
## Summary
- randomize server order when `AllServers` and `Fallback` switches are used together

## Testing
- `dotnet test DnsClientX.sln -c Release` *(fails: System.Net.Sockets.Socket)*
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68658f581924832e81771b8ea098c56e