### PR TITLE
Handle malformed server entries in PowerShell cmdlet

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -150,10 +150,11 @@ namespace DnsClientX.PowerShell {
             if (Server.Count > 0) {
                 var validServers = new List<string>();
                 foreach (string serverEntry in Server) {
-                    if (IPAddress.TryParse(serverEntry, out _)) {
-                        validServers.Add(serverEntry);
+                    string trimmed = serverEntry.Trim();
+                    if (IPAddress.TryParse(trimmed, out _)) {
+                        validServers.Add(trimmed);
                     } else {
-                        _logger.WriteError("Server address '{0}' is not a valid IP address.", serverEntry);
+                        _logger.WriteError("Malformed server address '{0}'.", serverEntry);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- validate DNS server strings by trimming whitespace and parsing via `IPAddress.TryParse`
- log an error when a server entry does not contain a valid IP address

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: Could not connect to network resources)*

------
https://chatgpt.com/codex/tasks/task_e_68658f51ecc4832e9e1d66037a8007b9