### PR TITLE
Fix fallback DNS address formatting

### DIFF
--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -121,8 +121,8 @@ namespace DnsClientX {
             // Final fallback: if no system DNS servers found, use well-known public DNS
             if (dnsServers.Count == 0) {
                 DebugPrint("No system DNS found, using fallback public DNS: 1.1.1.1, 8.8.8.8");
-                dnsServers.Add("1.1.1.1");    // Cloudflare Primary
-                dnsServers.Add("8.8.8.8");    // Google Primary
+                dnsServers.Add(FormatDnsAddress(IPAddress.Parse("1.1.1.1"))); // Cloudflare Primary
+                dnsServers.Add(FormatDnsAddress(IPAddress.Parse("8.8.8.8"))); // Google Primary
             }
 
             dnsServers = DeduplicateDnsServers(dnsServers);


### PR DESCRIPTION
## Summary
- ensure fallback servers pass through `FormatDnsAddress`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: QueryDns tests)*

------
https://chatgpt.com/codex/tasks/task_e_68658f3ffb9c832ebfce093fd17c3b9b