### PR TITLE
Add IPv6 multicast address filter

### DIFF
--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -261,6 +261,9 @@ namespace DnsClientX {
                 // Filter out multicast addresses (ff00:)
                 if (ipString.StartsWith("ff00:")) return false;
 
+                // Filter out other multicast addresses starting with ff
+                if (ipString.StartsWith("ff")) return false;
+
                 return true;
             }
 


### PR DESCRIPTION
## Summary
- update IPv6 address filtering logic in `SystemInformation.IsValidDnsAddress`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: cannot reach DNS endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68658f26deb0832e8b098ae40699301f