### PR TITLE
Implement DNAME and LOC decoding

### DIFF
--- a/DnsClientX.Tests/DnameLocRecordTests.cs
+++ b/DnsClientX.Tests/DnameLocRecordTests.cs
@@ -10,7 +10,8 @@ namespace DnsClientX.Tests {
             using var ms = new System.IO.MemoryStream();
             foreach (var part in parts) {
                 ms.WriteByte((byte)part.Length);
-                ms.Write(System.Text.Encoding.ASCII.GetBytes(part));
+                var bytes = System.Text.Encoding.ASCII.GetBytes(part);
+                ms.Write(bytes, 0, bytes.Length);
             }
             ms.WriteByte(0);
             return ms.ToArray();

--- a/DnsClientX.Tests/DnameLocRecordTests.cs
+++ b/DnsClientX.Tests/DnameLocRecordTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnameLocRecordTests {
+        private static byte[] EncodeDnsName(string name) {
+            name = name.TrimEnd('.');
+            var parts = name.Split('.');
+            using var ms = new System.IO.MemoryStream();
+            foreach (var part in parts) {
+                ms.WriteByte((byte)part.Length);
+                ms.Write(System.Text.Encoding.ASCII.GetBytes(part));
+            }
+            ms.WriteByte(0);
+            return ms.ToArray();
+        }
+
+        [Fact]
+        public void ProcessRecordData_DecodesDnameWireFormat() {
+            byte[] rdata = EncodeDnsName("target.example.com.");
+            Type wireType = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWire")!;
+            MethodInfo method = wireType.GetMethod("ProcessRecordData", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (string)method.Invoke(null, new object?[] { Array.Empty<byte>(), 0, DnsRecordType.DNAME, rdata, (ushort)rdata.Length, 0L })!;
+            Assert.Equal("target.example.com.", result);
+        }
+
+        [Fact]
+        public void ProcessRecordData_DecodesLocWireFormat() {
+            byte[] rdata = new byte[16];
+            rdata[0] = 0x00; // version
+            rdata[1] = 0x12; // size 1m
+            rdata[2] = 0x16; // horiz prec 10000m
+            rdata[3] = 0x13; // vert prec 10m
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(rdata.AsSpan(4), 0x80000000u);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(rdata.AsSpan(8), 0x80000000u);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(rdata.AsSpan(12), 0x00989680u);
+            Type wireType = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWire")!;
+            MethodInfo method = wireType.GetMethod("ProcessRecordData", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (string)method.Invoke(null, new object?[] { Array.Empty<byte>(), 0, DnsRecordType.LOC, rdata, (ushort)rdata.Length, 0L })!;
+            Assert.Equal("0 0 0.000 N 0 0 0.000 E 0m 1m 10000m 10m", result);
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using System.Reflection;
 
 namespace DnsClientX {
     /// <summary>
@@ -254,6 +255,15 @@ namespace DnsClientX {
                         : parts[1];
                     return $"{keyTag} {algorithmName} {digestType} {parts[3]}";
                 } else {
+                    return DataRaw;
+                }
+            } else if (Type == DnsRecordType.LOC) {
+                try {
+                    byte[] rdata = Convert.FromBase64String(DataRaw);
+                    Type wireType = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWire")!;
+                    MethodInfo method = wireType.GetMethod("ProcessRecordData", BindingFlags.NonPublic | BindingFlags.Static)!;
+                    return (string)method.Invoke(null, new object?[] { Array.Empty<byte>(), 0, DnsRecordType.LOC, rdata, (ushort)rdata.Length, 0L })!;
+                } catch (FormatException) {
                     return DataRaw;
                 }
             } else if (Type == DnsRecordType.NSEC) {


### PR DESCRIPTION
## Summary
- decode DNAME and LOC records in DnsWire
- expose helper to decode LOC record including precision fields
- parse LOC base64 data in `DnsAnswer`
- add tests for new decoding logic

## Testing
- `dotnet build`
- `dotnet test` *(fails: The argument /workspace/DnsClientX/DnsClientX.Tests/bin/Debug/net8.0/DnsClientX.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68659fe71c14832ea694512cd99e6b04