### PR TITLE
Add basic bind zone parser

### DIFF
--- a/DnsClientX.Tests/ParseBindFileTests.cs
+++ b/DnsClientX.Tests/ParseBindFileTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ParseBindFileTests {
+        [Fact]
+        public void MissingFile_ReturnsEmptyList() {
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ParsesBasicZoneFile() {
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
+            File.WriteAllText(tempPath, "$TTL 3600\n@ IN SOA ns.example.com. admin.example.com. 2024010101 7200 3600 1209600 3600\n@ IN NS ns.example.com.\nwww 600 IN A 203.0.113.10\nmail IN MX 10 mail.example.com.\n");
+            MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            File.Delete(tempPath);
+            Assert.Equal(4, result.Count);
+            Assert.Equal(DnsRecordType.SOA, result[0].Type);
+            Assert.Equal(3600, result[0].TTL);
+            Assert.Equal(DnsRecordType.A, result[2].Type);
+            Assert.Equal(600, result[2].TTL);
+        }
+    }
+}

--- a/DnsClientX/BindFileParser.cs
+++ b/DnsClientX/BindFileParser.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DnsClientX {
+    internal static class BindFileParser {
+        internal static List<DnsAnswer> ParseZoneFile(string path, Action<string>? debugPrint = null) {
+            var records = new List<DnsAnswer>();
+
+            if (!File.Exists(path)) {
+                debugPrint?.Invoke($"Skipping {path}; file not found");
+                return records;
+            }
+
+            int defaultTtl = 3600;
+
+            foreach (var raw in File.ReadLines(path)) {
+                var line = raw.Trim();
+                if (string.IsNullOrEmpty(line) || line.StartsWith(";")) {
+                    continue;
+                }
+
+                int commentIndex = line.IndexOf(';');
+                if (commentIndex >= 0) {
+                    line = line.Substring(0, commentIndex).Trim();
+                }
+
+                if (line.StartsWith("$TTL", StringComparison.OrdinalIgnoreCase)) {
+                    var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length > 1 && int.TryParse(parts[1], out int ttlDirective)) {
+                        defaultTtl = ttlDirective;
+                    }
+                    continue;
+                }
+
+                if (line.StartsWith("$ORIGIN", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                var tokens = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                if (tokens.Length < 3) {
+                    continue;
+                }
+
+                string name = tokens[0];
+                int index = 1;
+                int ttl = defaultTtl;
+
+                if (int.TryParse(tokens[index], out int ttlVal)) {
+                    ttl = ttlVal;
+                    index++;
+                }
+
+                string typeToken = tokens[index];
+                if (!Enum.TryParse(typeToken, true, out DnsRecordType type)) {
+                    index++;
+                    if (index >= tokens.Length) {
+                        continue;
+                    }
+                    typeToken = tokens[index];
+                    if (!Enum.TryParse(typeToken, true, out type)) {
+                        continue;
+                    }
+                } else {
+                    index++;
+                }
+
+                if (index >= tokens.Length) {
+                    continue;
+                }
+
+                string data = string.Join(" ", tokens.Skip(index));
+
+                records.Add(new DnsAnswer {
+                    Name = name,
+                    TTL = ttl,
+                    Type = type,
+                    DataRaw = data
+                });
+            }
+
+            return records;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- parse simple BIND zone files
- add unit tests for parser

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: Network is unreachable, build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68659fffb988832e91d57c3a853c9283