### PR TITLE
Implement DNS service discovery

### DIFF
--- a/DnsClientX.Examples/DemoServiceDiscovery.cs
+++ b/DnsClientX.Examples/DemoServiceDiscovery.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Spectre.Console;
+
+namespace DnsClientX.Examples {
+    internal class DemoServiceDiscovery {
+        public static async Task Example() {
+            var client = new ClientX();
+            var services = await client.DiscoverServices("test");
+            foreach (var sd in services) {
+                AnsiConsole.MarkupLine($"[green]{sd.ServiceName}[/] -> {sd.Host}:{sd.Port}");
+                foreach (var kv in sd.Txt) {
+                    AnsiConsole.MarkupLine($"  [blue]{kv.Key}[/]: {kv.Value}");
+                }
+            }
+        }
+    }
+}

--- a/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
+++ b/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
@@ -1,0 +1,25 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DnsClientX.PowerShell {
+    /// <summary>
+    /// Discovers DNS-SD services for a given domain.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Get, "DnsService")]
+    [OutputType(typeof(DnsServiceDiscovery))]
+    public sealed class CmdletDiscoverDnsService : AsyncPSCmdlet {
+        /// <summary>
+        /// Domain to discover services for.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Domain { get; set; } = string.Empty;
+
+        protected override async Task ProcessRecordAsync() {
+            var client = new ClientX();
+            var results = await client.DiscoverServices(Domain);
+            foreach (var sd in results) {
+                WriteObject(sd);
+            }
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsServiceDiscoveryTests.cs
+++ b/DnsClientX.Tests/DnsServiceDiscoveryTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsServiceDiscoveryTests {
+        private class StubHandler : HttpMessageHandler {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                string name = string.Empty;
+                string type = "A";
+                foreach (var part in request.RequestUri!.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries)) {
+                    var kv = part.Split('=', 2);
+                    if (kv.Length != 2) continue;
+                    if (kv[0] == "name") name = Uri.UnescapeDataString(kv[1]);
+                    if (kv[0] == "type") type = Uri.UnescapeDataString(kv[1]);
+                }
+                string json = "{}";
+                if (name == "_services._dns-sd._udp.test" && type == "PTR") {
+                    json = "{\"Status\":0,\"Answer\":[{\"name\":\"_services._dns-sd._udp.test\",\"type\":12,\"TTL\":60,\"data\":\"_http._tcp.test.\"}]}";
+                } else if (name == "_http._tcp.test" && type == "SRV") {
+                    json = "{\"Status\":0,\"Answer\":[{\"name\":\"_http._tcp.test\",\"type\":33,\"TTL\":60,\"data\":\"0 0 80 server.test.\"}]}";
+                } else if (name == "_http._tcp.test" && type == "TXT") {
+                    json = "{\"Status\":0,\"Answer\":[{\"name\":\"_http._tcp.test\",\"type\":16,\"TTL\":60,\"data\":\"path=/\"}]}";
+                }
+                var resp = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+                return Task.FromResult(resp);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldDiscoverService() {
+            var handler = new StubHandler();
+            using var client = new ClientX("https://example.com/dns-query", DnsRequestFormat.DnsOverHttpsJSON);
+            var custom = new HttpClient(handler) { BaseAddress = client.EndpointConfiguration.BaseUri };
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(client)!;
+            clients[client.EndpointConfiguration.SelectionStrategy] = custom;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(client, custom);
+
+            var results = await client.DiscoverServices("test");
+            Assert.Single(results);
+            var sd = results[0];
+            Assert.Equal("_http._tcp.test", sd.ServiceName);
+            Assert.Equal("server.test", sd.Host);
+            Assert.Equal(80, sd.Port);
+            Assert.True(sd.Txt.ContainsKey("path"));
+            Assert.Equal("/", sd.Txt["path"]);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.DiscoverServices.cs
+++ b/DnsClientX/DnsClientX.DiscoverServices.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    public partial class ClientX {
+        /// <summary>
+        /// Discovers services using DNS Service Discovery (DNS-SD).
+        /// </summary>
+        /// <param name="domain">The domain to query.</param>
+        /// <returns>List of discovered services.</returns>
+        public async Task<DnsServiceDiscovery[]> DiscoverServices(string domain) {
+            if (string.IsNullOrWhiteSpace(domain)) {
+                throw new ArgumentNullException(nameof(domain));
+            }
+
+            var list = new List<DnsServiceDiscovery>();
+            string ptrName = $"_services._dns-sd._udp.{domain}";
+            var ptrResponse = await Resolve(ptrName, DnsRecordType.PTR, retryOnTransient: false);
+            var services = ptrResponse.Answers?.Where(a => a.Type == DnsRecordType.PTR) ?? Array.Empty<DnsAnswer>();
+
+            foreach (var service in services) {
+                string serviceName = service.Data.TrimEnd('.');
+                var srv = await ResolveFirst(serviceName, DnsRecordType.SRV, retryOnTransient: false);
+                var txt = await ResolveFirst(serviceName, DnsRecordType.TXT, retryOnTransient: false);
+
+                string host = string.Empty;
+                int port = 0;
+                if (srv.HasValue) {
+                    var parts = srv.Value.Data.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 4) {
+                        int.TryParse(parts[2], out port);
+                        host = parts[3].TrimEnd('.');
+                    }
+                }
+
+                var meta = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if (txt.HasValue) {
+                    foreach (var entry in txt.Value.DataStringsEscaped) {
+                        var idx = entry.IndexOf('=');
+                        if (idx > 0) {
+                            meta[entry[..idx]] = entry[(idx + 1)..];
+                        } else {
+                            meta[entry] = string.Empty;
+                        }
+                    }
+                }
+
+                list.Add(new DnsServiceDiscovery {
+                    ServiceName = serviceName,
+                    Host = host,
+                    Port = port,
+                    Txt = meta
+                });
+            }
+
+            return list.ToArray();
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.DiscoverServices.cs
+++ b/DnsClientX/DnsClientX.DiscoverServices.cs
@@ -29,7 +29,7 @@ namespace DnsClientX {
                 string host = string.Empty;
                 int port = 0;
                 if (srv.HasValue) {
-                    var parts = srv.Value.Data.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    var parts = srv.Value.Data.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                     if (parts.Length >= 4) {
                         int.TryParse(parts[2], out port);
                         host = parts[3].TrimEnd('.');

--- a/DnsClientX/DnsServiceDiscovery.cs
+++ b/DnsClientX/DnsServiceDiscovery.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Represents a discovered service using DNS-SD.
+    /// </summary>
+    public class DnsServiceDiscovery {
+        /// <summary>
+        /// The full service name, e.g. <c>_http._tcp.example.com</c>.
+        /// </summary>
+        public string ServiceName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Target host offering the service.
+        /// </summary>
+        public string Host { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Target port for the service.
+        /// </summary>
+        public int Port { get; set; }
+
+        /// <summary>
+        /// Additional metadata from TXT records.
+        /// </summary>
+        public Dictionary<string, string> Txt { get; set; } = new();
+    }
+}

--- a/Module/DnsClientX.psd1
+++ b/Module/DnsClientX.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @('Resolve-DnsQuery')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Resolve-Dns')
+    CmdletsToExport      = @('Resolve-Dns', 'Get-DnsService')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This library supports multiple NET versions:
 - [x] Supports DNS over TCP
 - [x] Supports DNSSEC
 - [x] Supports multiple DNS record types
+- [x] Supports DNS Service Discovery (DNS‑SD)
 - [x] Supports parallel queries
 - [x] No external dependencies on .NET 6, .NET 7 and .NET 8
 - [x] Minimal dependencies on .NET Standard 2.0 and .NET 4.7.2
@@ -283,6 +284,15 @@ var systemDnsServers = SystemInformation.GetDnsFromActiveNetworkCard();
 var refreshedDnsServers = SystemInformation.GetDnsFromActiveNetworkCard(refresh: true);
 ```
 
+```csharp
+// Discover services using DNS-SD
+var client = new ClientX();
+var services = await client.DiscoverServices("example.com");
+foreach (var svc in services) {
+    Console.WriteLine($"{svc.ServiceName} -> {svc.Host}:{svc.Port}");
+}
+```
+
 ### Advantages of System DNS
 
 1. **Respects local configuration**: Uses DNS servers configured by network admin/DHCP
@@ -465,6 +475,11 @@ Resolve-DnsQuery -Name 'evotec.pl' -Type A -DnsProvider Cloudflare -Verbose | Fo
 Resolve-DnsQuery -Name 'evotec.pl' -Type TXT -DnsProvider System -Verbose | Format-Table
 Resolve-DnsQuery -Name 'evotec.pl' -Type DS -DnsProvider Cloudflare -Verbose | Format-Table
 Resolve-DnsQuery -Name 'github.com', 'evotec.pl', 'google.com' -Type TXT -DnsProvider System -Verbose | Format-Table
+```
+
+```powershell
+# Discover DNS-SD services
+Get-DnsService -Domain 'example.com'
 ```
 
 It can also deliver more detailed information.


### PR DESCRIPTION
## Summary
- add `DnsServiceDiscovery` class
- implement `ClientX.DiscoverServices` method
- cover service discovery with new unit test
- demo service discovery in examples
- expose `Get-DnsService` PowerShell cmdlet
- document DNS-SD feature and usage

## Testing
- `dotnet test DnsClientX.sln -c Release` *(fails: network unreachable)*
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6865a112428c832eab96aa0244cfa5cf