### PR TITLE
Add DNS Service Discovery support

### DIFF
--- a/DnsClientX.Examples/DemoServiceDiscovery.cs
+++ b/DnsClientX.Examples/DemoServiceDiscovery.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    internal class DemoServiceDiscovery {
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var results = await client.DiscoverServices("example.com");
+            foreach (var r in results) {
+                Console.WriteLine($"{r.ServiceName} -> {r.Target}:{r.Port}");
+            }
+        }
+    }
+}

--- a/DnsClientX.Examples/Program.cs
+++ b/DnsClientX.Examples/Program.cs
@@ -9,6 +9,7 @@ namespace DnsClientX.Examples {
             // await DemoQuery.ExamplePTR3();
 
             await DemoDnsAnswer.ExampleDnsAnswerParsing();
+            await DemoServiceDiscovery.Example();
 
             //await DemoQuery.ExampleTXTAll();
             return;

--- a/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
+++ b/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
@@ -1,0 +1,16 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DnsClientX.PowerShell {
+    [Cmdlet(VerbsCommon.Get, "DnsService")]
+    public sealed class CmdletDiscoverDnsService : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Domain { get; set; } = string.Empty;
+
+        protected override async Task ProcessRecordAsync() {
+            using var client = new ClientX();
+            var results = await client.DiscoverServices(Domain);
+            WriteObject(results, true);
+        }
+    }
+}

--- a/DnsClientX.Tests/DiscoverServicesTests.cs
+++ b/DnsClientX.Tests/DiscoverServicesTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DiscoverServicesTests {
+        [Fact]
+        public async Task ShouldParseResponses() {
+            var ptrResponse = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer { Name = "_services._dns-sd._udp.example.com", Type = DnsRecordType.PTR, DataRaw = "_http._tcp.example.com." }
+                }
+            };
+            var srvResponse = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer { Name = "_http._tcp.example.com", Type = DnsRecordType.SRV, DataRaw = "0 0 80 host.example.com." }
+                }
+            };
+            var txtResponse = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer { Name = "_http._tcp.example.com", Type = DnsRecordType.TXT, DataRaw = "path=/" }
+                }
+            };
+
+            using var client = new ClientX(DnsEndpoint.System);
+            client.ResolverOverride = (name, type, ct) => {
+                if (name == "_services._dns-sd._udp.example.com" && type == DnsRecordType.PTR) return Task.FromResult(ptrResponse);
+                if (name == "_http._tcp.example.com" && type == DnsRecordType.SRV) return Task.FromResult(srvResponse);
+                if (name == "_http._tcp.example.com" && type == DnsRecordType.TXT) return Task.FromResult(txtResponse);
+                return Task.FromResult(new DnsResponse { Answers = Array.Empty<DnsAnswer>() });
+            };
+
+            var results = await client.DiscoverServices("example.com", CancellationToken.None);
+            Assert.Single(results);
+            var r = results[0];
+            Assert.Equal("_http._tcp.example.com", r.ServiceName);
+            Assert.Equal("host.example.com", r.Target);
+            Assert.Equal(80, r.Port);
+            Assert.True(r.Metadata != null && r.Metadata["path"] == "/");
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsServiceDiscovery.cs
+++ b/DnsClientX/Definitions/DnsServiceDiscovery.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace DnsClientX {
+    public class DnsServiceDiscovery {
+        public string ServiceName { get; set; } = string.Empty;
+        public string Target { get; set; } = string.Empty;
+        public int Port { get; set; }
+        public int Priority { get; set; }
+        public int Weight { get; set; }
+        public Dictionary<string, string>? Metadata { get; set; }
+    }
+}

--- a/DnsClientX/DnsClientX.ServiceDiscovery.cs
+++ b/DnsClientX/DnsClientX.ServiceDiscovery.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    public partial class ClientX {
+        internal Func<string, DnsRecordType, CancellationToken, Task<DnsResponse>>? ResolverOverride;
+
+        private Task<DnsResponse> ResolveForSd(string name, DnsRecordType type, CancellationToken cancellationToken) {
+            if (ResolverOverride != null) {
+                return ResolverOverride(name, type, cancellationToken);
+            }
+
+            return Resolve(name, type, requestDnsSec: false, validateDnsSec: false, returnAllTypes: false, retryOnTransient: true, maxRetries: 3, retryDelayMs: 100, cancellationToken: cancellationToken);
+        }
+
+        public async Task<DnsServiceDiscovery[]> DiscoverServices(string domain, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(domain)) throw new ArgumentNullException(nameof(domain));
+            string ptrQuery = $"_services._dns-sd._udp.{domain}";
+            var ptrResponse = await ResolveForSd(ptrQuery, DnsRecordType.PTR, cancellationToken);
+            if (ptrResponse.Answers == null) return Array.Empty<DnsServiceDiscovery>();
+
+            var results = new List<DnsServiceDiscovery>();
+            foreach (var ptr in ptrResponse.Answers.Where(a => a.Type == DnsRecordType.PTR)) {
+                string serviceDomain = ptr.Data.TrimEnd('.');
+                var srvResponse = await ResolveForSd(serviceDomain, DnsRecordType.SRV, cancellationToken);
+                var txtResponse = await ResolveForSd(serviceDomain, DnsRecordType.TXT, cancellationToken);
+
+                var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var txt in txtResponse.Answers?.Where(a => a.Type == DnsRecordType.TXT) ?? Array.Empty<DnsAnswer>()) {
+                    foreach (string part in txt.DataStringsEscaped) {
+                        var idx = part.IndexOf('=');
+                        if (idx > 0) {
+                            string key = part.Substring(0, idx);
+                            string val = part.Substring(idx + 1);
+                            metadata[key] = val;
+                        } else {
+                            metadata[part] = string.Empty;
+                        }
+                    }
+                }
+
+                foreach (var srv in srvResponse.Answers?.Where(a => a.Type == DnsRecordType.SRV) ?? Array.Empty<DnsAnswer>()) {
+                    var bits = srv.Data.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (bits.Length == 4 &&
+                        int.TryParse(bits[0], out int priority) &&
+                        int.TryParse(bits[1], out int weight) &&
+                        int.TryParse(bits[2], out int port)) {
+                        string target = bits[3].TrimEnd('.');
+                        results.Add(new DnsServiceDiscovery {
+                            ServiceName = serviceDomain,
+                            Target = target,
+                            Port = port,
+                            Priority = priority,
+                            Weight = weight,
+                            Metadata = metadata.Count > 0 ? new Dictionary<string, string>(metadata) : null
+                        });
+                    }
+                }
+            }
+
+            return results.ToArray();
+        }
+    }
+}

--- a/Module/DnsClientX.psd1
+++ b/Module/DnsClientX.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @('Resolve-DnsQuery')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Resolve-Dns')
+    CmdletsToExport      = @('Resolve-Dns','Get-DnsService')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Examples/Example.DiscoverService.ps1
+++ b/Module/Examples/Example.DiscoverService.ps1
@@ -1,0 +1,3 @@
+Import-Module $PSScriptRoot\..\DnsClientX.psd1 -Force
+
+Get-DnsService -Domain 'example.com'

--- a/README.md
+++ b/README.md
@@ -498,6 +498,22 @@ $Output = Resolve-DnsQuery -Name 'evotec.pl' -Type A -Server '1.1.1.1','8.8.8.8'
 $Output.AnswersMinimal | Format-Table
 ```
 
+### DNS Service Discovery
+
+DnsClientX can discover services advertised via DNS-SD.
+
+```csharp
+using var client = new ClientX();
+var services = await client.DiscoverServices("example.com");
+foreach (var svc in services) {
+    Console.WriteLine($"{svc.ServiceName} -> {svc.Target}:{svc.Port}");
+}
+```
+
+```powershell
+Get-DnsService -Domain 'example.com'
+```
+
 ## Please share with the community
 
 Please consider sharing a post about DnsClientX and the value it provides. It really does help!


### PR DESCRIPTION
## Summary
- add `DnsServiceDiscovery` type and discovery APIs
- expose service discovery via `ClientX.DiscoverServices`
- demonstrate DNS-SD in examples and PowerShell module
- document DNS Service Discovery usage
- fix string splitting for older frameworks

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68660b2395e8832e8785e41d1d015dbc