### PR TITLE
Fix jitter flakiness

### DIFF
--- a/DnsClientX.Tests/FailoverStrategyTests.cs
+++ b/DnsClientX.Tests/FailoverStrategyTests.cs
@@ -29,7 +29,7 @@ namespace DnsClientX.Tests {
             var advance = (Action)Delegate.CreateDelegate(typeof(Action), config, "AdvanceToNextHostname", false)!;
             await Assert.ThrowsAsync<DnsClientException>(async () =>
             {
-                await (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, advance })!;
+                await (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, advance, true })!;
             });
 
             config.SelectHostNameStrategy();

--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -17,7 +17,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1, null })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1, null, true })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -35,7 +35,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, null })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, null, true })!;
             }
 
             var sw = Stopwatch.StartNew();
@@ -61,7 +61,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, null })!;
+                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, null, false })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -81,7 +81,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<DnsResponse> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(DnsResponse));
-                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, null })!;
+                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, null, true })!;
             }
 
             var ex = await Assert.ThrowsAsync<DnsClientException>(Invoke);

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -154,13 +154,14 @@ namespace DnsClientX {
         /// <param name="maxRetries">Maximum number of attempts before giving up.</param>
         /// <param name="delayMs">Base delay between retries in milliseconds. The actual wait time grows exponentially with a random jitter.</param>
         /// <param name="beforeRetry">Optional callback invoked before each retry attempt.</param>
+        /// <param name="useJitter">Whether to randomize delays with jitter for exponential backoff.</param>
         /// <remarks>
         /// The method retries when a transient exception occurs or when a <see cref="DnsResponse"/>
         /// returned by <paramref name="action"/> indicates a transient failure. Exponential backoff with
         /// jitter is used between attempts. If the final result still signals a transient error, a
         /// <see cref="DnsClientException"/> is thrown with the last response.
         /// </remarks>
-        private static async Task<T> RetryAsync<T>(Func<Task<T>> action, int maxRetries = 3, int delayMs = 100, Action? beforeRetry = null) {
+        private static async Task<T> RetryAsync<T>(Func<Task<T>> action, int maxRetries = 3, int delayMs = 100, Action? beforeRetry = null, bool useJitter = true) {
             Exception lastException = null;
             T lastResult = default(T);
 
@@ -178,7 +179,7 @@ namespace DnsClientX {
 
                         beforeRetry?.Invoke();
                         int exponentialDelay = delayMs * (int)Math.Pow(2, attempt - 1);
-                        int jitter = GetJitter(delayMs);
+                        int jitter = useJitter ? GetJitter(delayMs) : 0;
                         await Task.Delay(exponentialDelay + jitter);
                         continue;
                     }
@@ -194,7 +195,7 @@ namespace DnsClientX {
 
                     beforeRetry?.Invoke();
                     int exponentialDelay = delayMs * (int)Math.Pow(2, attempt - 1);
-                    int jitter = GetJitter(delayMs);
+                    int jitter = useJitter ? GetJitter(delayMs) : 0;
                     await Task.Delay(exponentialDelay + jitter);
                     continue;
                 }


### PR DESCRIPTION
## Summary
- add optional `useJitter` argument to `RetryAsync` to disable jitter when needed
- update tests to use new parameter for deterministic behavior

## Testing
- `dotnet build`
- `dotnet test --filter FullyQualifiedName~RetryAsyncTests -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68661da51d84832e85a67cad5a5568f8