### PR TITLE
Add EDNS options to configuration

### DIFF
--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -73,6 +73,18 @@ namespace DnsClientX {
         public bool UseTcpFallback { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the UDP buffer size used when sending EDNS queries.
+        /// </summary>
+        /// <value>The size of the UDP buffer.</value>
+        public int UdpBufferSize { get; set; } = 4096;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether EDNS should be enabled for queries.
+        /// </summary>
+        /// <value><c>true</c> to include the OPT record; otherwise, <c>false</c>.</value>
+        public bool EnableEdns { get; set; }
+
+        /// <summary>
         /// Gets or sets the format of the DNS requests.
         /// </summary>
         public DnsRequestFormat RequestFormat { get; set; }

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -9,7 +9,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatHttp3(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -16,7 +16,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatQuic(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
             var queryBytes = query.SerializeDnsWireFormat();
 
             var lengthPrefix = BitConverter.GetBytes((ushort)queryBytes.Length);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
             // For OpenDNS, we need to create a DNS message and base64url encode it
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -31,7 +31,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatDoT(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, bool ignoreCertificateErrors, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
             var queryBytes = query.SerializeDnsWireFormat();
 
             // Calculate the length prefix for the query

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatPost(this HttpClient client, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatTcp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatUdp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {


### PR DESCRIPTION
## Summary
- add `UdpBufferSize` and `EnableEdns` options to `Configuration`
- update `DnsMessage` to honour EDNS settings
- propagate new options through wire resolvers
- extend EDNS tests with DO bit and buffer size checks

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: System.Net.Sockets.Socket)*

------
https://chatgpt.com/codex/tasks/task_e_68662b765d28832e9ab6a7da7a15013f