### PR TITLE
Add ResolveServiceAsync API for SRV lookups

### DIFF
--- a/DnsClientX.Tests/ResolveServiceAsyncTests.cs
+++ b/DnsClientX.Tests/ResolveServiceAsyncTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveServiceAsyncTests {
+        [Fact]
+        public async Task ShouldOrderByPriorityAndWeight() {
+            var srvResponse = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer { Name = "_http._tcp.example.com", Type = DnsRecordType.SRV, DataRaw = "10 5 80 host1.example.com." },
+                    new DnsAnswer { Name = "_http._tcp.example.com", Type = DnsRecordType.SRV, DataRaw = "10 10 80 host2.example.com." },
+                    new DnsAnswer { Name = "_http._tcp.example.com", Type = DnsRecordType.SRV, DataRaw = "5 1 80 host3.example.com." }
+                }
+            };
+
+            using var client = new ClientX(DnsEndpoint.System);
+            client.ResolverOverride = (name, type, ct) => Task.FromResult(srvResponse);
+
+            var records = await client.ResolveServiceAsync("http", "tcp", "example.com");
+            Assert.Equal(3, records.Length);
+            Assert.Equal("host3.example.com", records[0].Target); // priority 5 first
+            Assert.Equal("host2.example.com", records[1].Target); // higher weight within same priority
+            Assert.Equal("host1.example.com", records[2].Target);
+        }
+
+        [Fact]
+        public async Task ShouldResolveHostAddresses() {
+            var srvResponse = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer { Name = "_ldap._tcp.example.com", Type = DnsRecordType.SRV, DataRaw = "0 0 389 host.example.com." }
+                }
+            };
+            var aResponse = new DnsResponse {
+                Answers = new[] { new DnsAnswer { Name = "host.example.com", Type = DnsRecordType.A, DataRaw = "10.0.0.1" } }
+            };
+            var aaaaResponse = new DnsResponse {
+                Answers = new[] { new DnsAnswer { Name = "host.example.com", Type = DnsRecordType.AAAA, DataRaw = "::1" } }
+            };
+
+            using var client = new ClientX(DnsEndpoint.System);
+            client.ResolverOverride = (name, type, ct) => {
+                if (name == "_ldap._tcp.example.com" && type == DnsRecordType.SRV) return Task.FromResult(srvResponse);
+                if (name == "host.example.com" && type == DnsRecordType.A) return Task.FromResult(aResponse);
+                if (name == "host.example.com" && type == DnsRecordType.AAAA) return Task.FromResult(aaaaResponse);
+                return Task.FromResult(new DnsResponse { Answers = Array.Empty<DnsAnswer>() });
+            };
+
+            var records = await client.ResolveServiceAsync("ldap", "tcp", "example.com", resolveHosts: true);
+            Assert.Single(records);
+            var r = records[0];
+            Assert.NotNull(r.Addresses);
+            Assert.Contains(IPAddress.Parse("10.0.0.1"), r.Addresses!);
+            Assert.Contains(IPAddress.Parse("::1"), r.Addresses!);
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsSrvRecord.cs
+++ b/DnsClientX/Definitions/DnsSrvRecord.cs
@@ -1,0 +1,23 @@
+using System.Net;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Represents a SRV record optionally including resolved target addresses.
+    /// </summary>
+    public class DnsSrvRecord {
+        /// <summary>Gets or sets the target host.</summary>
+        public string Target { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the service port.</summary>
+        public int Port { get; set; }
+
+        /// <summary>Gets or sets the record priority.</summary>
+        public int Priority { get; set; }
+
+        /// <summary>Gets or sets the record weight.</summary>
+        public int Weight { get; set; }
+
+        /// <summary>Gets or sets resolved IP addresses for the target, if requested.</summary>
+        public IPAddress[]? Addresses { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -511,6 +511,17 @@ foreach (var svc in services) {
 }
 ```
 
+You can also query a specific service to get its SRV records directly:
+
+```csharp
+using var client = new ClientX();
+var records = await client.ResolveServiceAsync("ldap", "tcp", "example.com", resolveHosts: true);
+foreach (var r in records) {
+    Console.WriteLine($"{r.Target}:{r.Port} (pri {r.Priority}, weight {r.Weight})");
+    if (r.Addresses != null) Console.WriteLine(string.Join(", ", r.Addresses));
+}
+```
+
 ```powershell
 Get-DnsService -Domain 'example.com'
 ```


### PR DESCRIPTION
## Summary
- support querying SRV records with new `ResolveServiceAsync`
- include new `DnsSrvRecord` type
- document service resolution in README
- add unit tests for service discovery ordering and address lookup

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: HttpConnectionPool.ConnectAsync: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68663e372a78832ea53aa131c47e4cbf