### PR TITLE
Add initial ODoH resolver stub

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -86,7 +86,7 @@ namespace DnsClientX {
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
                 response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.ObliviousDnsOverHttps) {
-                response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
+                response = await Client.ResolveWireFormatOdoh(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3) {
                 response = await Client.ResolveWireFormatHttp3(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveOdoh.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveOdoh.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+#if NET8_0_OR_GREATER
+    internal static class DnsWireResolveOdoh {
+        internal static Task<DnsResponse> ResolveWireFormatOdoh(this HttpClient client, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            throw new NotSupportedException("System.Security.Cryptography.Hpke is not available in this environment.");
+        }
+    }
+#else
+    internal static class DnsWireResolveOdoh {
+        internal static Task<DnsResponse> ResolveWireFormatOdoh(this HttpClient client, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            throw new NotSupportedException("Oblivious DNS over HTTPS is not supported on this framework.");
+        }
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- add stub for ODoH resolution
- call the new method when using `ObliviousDnsOverHttps`

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68669a216620832e913e3a25e9ab3600