### PR TITLE
Fix RetryAsync zero retries

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -191,6 +191,10 @@ namespace DnsClientX {
         /// <see cref="DnsClientException"/> is thrown with the last response.
         /// </remarks>
         private static async Task<T> RetryAsync<T>(Func<Task<T>> action, int maxRetries = 3, int delayMs = 100, Action? beforeRetry = null, bool useJitter = true) {
+            if (maxRetries == 0) {
+                return await action();
+            }
+
             Exception lastException = null;
             T lastResult = default(T);
 


### PR DESCRIPTION
## Summary
- ensure RetryAsync executes once when maxRetries is zero

## Testing
- `dotnet build DnsClientX.sln -c Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6867696c9084832e8c25b0abddc6bb25