### PR TITLE
Fix overlapping occurrence count

### DIFF
--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -700,7 +700,8 @@ namespace DnsClientX {
             int index = 0;
             while ((index = text.IndexOf(pattern, index, StringComparison.OrdinalIgnoreCase)) >= 0) {
                 count++;
-                index += pattern.Length;
+                // Move forward by one to allow overlapping pattern detection
+                index += 1;
             }
             return count;
         }


### PR DESCRIPTION
## Summary
- count overlapping occurrences in `CountOccurrences`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: HttpConnectionPool.ConnectAsync)*

------
https://chatgpt.com/codex/tasks/task_e_68676972f568832e9dc2c4ce9ca2bde3