### PR TITLE
Handle empty hostnames when forming BaseUri

### DIFF
--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -352,7 +352,9 @@ namespace DnsClientX {
                 Port = 443;
             }
 
-            BaseUri = new Uri(string.Format(baseUriFormat, Hostname));
+            if (hostnames.Count > 0 && baseUriFormat != null) {
+                BaseUri = new Uri(string.Format(baseUriFormat, Hostname));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- guard BaseUri creation in endpoint constructor when hostname list is empty

## Testing
- `dotnet build DnsClientX/DnsClientX.csproj -c Release -f net8.0`
- `dotnet build DnsClientX/DnsClientX.csproj -c Release -f net472` *(fails: reference assemblies missing)*
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release -f net8.0` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68676a480f10832e8a28fd4031064c63