### PR TITLE
Fix trailing empty TXT segments

### DIFF
--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -160,11 +160,11 @@ namespace DnsClientX {
 
             // Clean up empty strings and whitespace-only entries for TXT records
             if (Type == DnsRecordType.TXT) {
-                bool keepLastEmpty = data.Count > 0 && string.IsNullOrWhiteSpace(data[^1].Trim('"'));
+                int count = data.Count;
+                bool keepLastEmpty = count > 0 && string.IsNullOrWhiteSpace(data[count - 1].Trim('"'));
                 data = data.Where((s, index) =>
-                        keepLastEmpty && index == data.Count - 1
-                            ? true
-                            : !string.IsNullOrWhiteSpace(s) && s.Trim('"').Trim().Length > 0)
+                        (keepLastEmpty && index == count - 1)
+                            || (!string.IsNullOrWhiteSpace(s) && s.Trim('"').Trim().Length > 0))
                     .ToList();
             }
 

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -160,7 +160,12 @@ namespace DnsClientX {
 
             // Clean up empty strings and whitespace-only entries for TXT records
             if (Type == DnsRecordType.TXT) {
-                data = data.Where(s => !string.IsNullOrWhiteSpace(s) && s.Trim('"').Trim().Length > 0).ToList();
+                bool keepLastEmpty = data.Count > 0 && string.IsNullOrWhiteSpace(data[^1].Trim('"'));
+                data = data.Where((s, index) =>
+                        keepLastEmpty && index == data.Count - 1
+                            ? true
+                            : !string.IsNullOrWhiteSpace(s) && s.Trim('"').Trim().Length > 0)
+                    .ToList();
             }
 
             return data.ToArray();

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -160,6 +160,7 @@ namespace DnsClientX {
 
             // Clean up empty strings and whitespace-only entries for TXT records
             if (Type == DnsRecordType.TXT) {
+                // Preserve a trailing empty TXT segment that may be significant
                 int count = data.Count;
                 bool keepLastEmpty = count > 0 && string.IsNullOrWhiteSpace(data[count - 1].Trim('"'));
                 data = data.Where((s, index) =>


### PR DESCRIPTION
## Summary
- ensure a trailing empty TXT segment is not removed

## Testing
- `dotnet test` *(fails: The argument /workspace/DnsClientX/DnsClientX.Tests/bin/Debug/net8.0/DnsClientX.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6867697779b0832ebd5355de738f46e4