### PR TITLE
Add configurable custom DNS endpoint

### DIFF
--- a/DnsClientX.Tests/ConfigurationOverrideTests.cs
+++ b/DnsClientX.Tests/ConfigurationOverrideTests.cs
@@ -32,5 +32,16 @@ namespace DnsClientX.Tests {
             using var client = new ClientX(DnsEndpoint.Cloudflare, useTcpFallback: false);
             Assert.False(client.EndpointConfiguration.UseTcpFallback);
         }
+
+        [Fact]
+        public void CustomEndpoint_ShouldAllowOverrides() {
+            using var client = new ClientX(DnsEndpoint.Custom);
+            client.EndpointConfiguration.Hostname = "1.1.1.1";
+            client.EndpointConfiguration.RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+            client.EndpointConfiguration.BaseUri = new Uri($"https://{client.EndpointConfiguration.Hostname}/dns-query");
+
+            Assert.Equal("1.1.1.1", client.EndpointConfiguration.Hostname);
+            Assert.Equal(new Uri("https://1.1.1.1/dns-query"), client.EndpointConfiguration.BaseUri);
+        }
     }
 }

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -31,12 +31,12 @@ namespace DnsClientX {
         /// <summary>
         /// Gets the hostname of the DNS-over-HTTPS resolver.
         /// </summary>
-        public string Hostname { get; private set; }
+        public string? Hostname { get; set; }
 
         /// <summary>
         /// Gets the base URI to send DNS requests to.
         /// </summary>
-        public Uri BaseUri { get; private set; }
+        public Uri? BaseUri { get; set; }
 
         /// <summary>
         /// The preferred HTTP request version to use by default.
@@ -256,6 +256,11 @@ namespace DnsClientX {
                     RequestFormat = DnsRequestFormat.ObliviousDnsOverHttps;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
+                case DnsEndpoint.Custom:
+                    hostnames = [];
+                    RequestFormat = DnsRequestFormat.DnsOverHttps;
+                    baseUriFormat = null;
+                    break;
                 case DnsEndpoint.Google:
                     hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };
                     RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
@@ -352,7 +357,9 @@ namespace DnsClientX {
                 Port = 443;
             }
 
-            BaseUri = new Uri(string.Format(baseUriFormat, Hostname));
+            if (baseUriFormat != null && !string.IsNullOrEmpty(Hostname)) {
+                BaseUri = new Uri(string.Format(baseUriFormat, Hostname));
+            }
         }
     }
 }

--- a/DnsClientX/Definitions/DnsEndpoint.cs
+++ b/DnsClientX/Definitions/DnsEndpoint.cs
@@ -106,6 +106,11 @@ namespace DnsClientX {
         /// <summary>
         /// Cloudflare's Oblivious DNS-over-HTTPS endpoint.
         /// </summary>
-        CloudflareOdoh
+        CloudflareOdoh,
+        /// <summary>
+        /// Custom DNS endpoint configured via <see cref="Configuration"/>
+        /// overrides.
+        /// </summary>
+        Custom
     }
 }

--- a/README.md
+++ b/README.md
@@ -363,6 +363,15 @@ using var client = new ClientX(DnsEndpoint.Cloudflare, userAgent: "MyApp/1.0", h
 ```
 You can also modify `client.EndpointConfiguration.UserAgent` and `client.EndpointConfiguration.HttpVersion` after construction.
 
+### Using a custom endpoint
+
+```csharp
+using var client = new ClientX(DnsEndpoint.Custom);
+client.EndpointConfiguration.Hostname = "1.1.1.1";
+client.EndpointConfiguration.RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+client.EndpointConfiguration.BaseUri = new Uri($"https://{client.EndpointConfiguration.Hostname}/dns-query");
+```
+
 ### Querying DNS over QUIC via Cloudflare
 
 ```csharp


### PR DESCRIPTION
## Summary
- support a `Custom` value in `DnsEndpoint`
- allow editing `Hostname` and `BaseUri` after construction
- handle the new endpoint in `Configuration`
- show example of using custom endpoint in README
- test custom endpoint overrides

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867699fe234832eab86fb7d25f210ba