### PR TITLE
Add ECS option support

### DIFF
--- a/DnsClientX.Tests/EcsOptionTests.cs
+++ b/DnsClientX.Tests/EcsOptionTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class EcsOptionTests {
+        private static byte[] CreateDnsHeader() {
+            byte[] bytes = new byte[12];
+            ushort id = 0x1234;
+            bytes[0] = (byte)(id >> 8);
+            bytes[1] = (byte)(id & 0xFF);
+            ushort flags = 0x8180;
+            bytes[2] = (byte)(flags >> 8);
+            bytes[3] = (byte)(flags & 0xFF);
+            return bytes;
+        }
+
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task<byte[]> RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
+            using var udp = new UdpClient(port);
+            UdpReceiveResult result = await udp.ReceiveAsync();
+            await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
+            return result.Buffer;
+        }
+
+        private static void AssertEcsOption(byte[] query, string name) {
+            int offset = 12;
+            foreach (var label in name.Split('.')) {
+                offset += 1 + label.Length;
+            }
+            offset += 1 + 2 + 2; // end of question
+
+            Assert.Equal(0, query[offset]);
+            offset += 1;
+            ushort type = (ushort)((query[offset] << 8) | query[offset + 1]);
+            Assert.Equal((ushort)DnsRecordType.OPT, type);
+            offset += 2 + 2 + 4; // udp size + ttl
+            ushort rdlen = (ushort)((query[offset] << 8) | query[offset + 1]);
+            Assert.True(rdlen > 0);
+            offset += 2;
+            ushort optionCode = (ushort)((query[offset] << 8) | query[offset + 1]);
+            Assert.Equal(8, optionCode); // ECS option
+        }
+
+        [Fact]
+        public async Task UdpRequest_ShouldIncludeEcsOption_WhenSubnetConfigured() {
+            int port = GetFreePort();
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var udpTask = RunUdpServerAsync(port, response, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) {
+                Port = port,
+                EnableEdns = true,
+                Subnet = "192.0.2.1/24"
+            };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            await task;
+            byte[] query = await udpTask;
+
+            AssertEcsOption(query, "example.com");
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -86,6 +86,13 @@ namespace DnsClientX {
         public bool EnableEdns { get; set; }
 
         /// <summary>
+        /// Gets or sets the EDNS Client Subnet (ECS) to include in DNS queries.
+        /// Specify as CIDR notation, for example <c>192.0.2.0/24</c>.
+        /// When configured, EDNS will be automatically enabled.
+        /// </summary>
+        public string? Subnet { get; set; }
+
+        /// <summary>
         /// Gets or sets the format of the DNS requests.
         /// </summary>
         public DnsRequestFormat RequestFormat { get; set; }

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
 
             EndpointConfiguration.SelectHostNameStrategy();
 
-            var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize);
+            var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize, null);
             var queryBytes = query.SerializeDnsWireFormat();
 
             var responses = await SendAxfrOverTcp(queryBytes, EndpointConfiguration.Hostname, EndpointConfiguration.Port, EndpointConfiguration.TimeOut, cancellationToken);

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -9,7 +9,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatHttp3(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -16,7 +16,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatQuic(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             var lengthPrefix = BitConverter.GetBytes((ushort)queryBytes.Length);

--- a/DnsClientX/ProtocolDnsWire/DnsMessage.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsMessage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers.Binary;
 using System.IO;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 
 namespace DnsClientX {
@@ -14,6 +15,7 @@ namespace DnsClientX {
         private readonly bool _requestDnsSec;
         private readonly bool _enableEdns;
         private readonly int _udpBufferSize;
+        private readonly string? _subnet;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DnsMessage"/> class.
@@ -22,15 +24,16 @@ namespace DnsClientX {
         /// <param name="type">The type.</param>
         /// <param name="requestDnsSec">if set to <c>true</c> [request DNS sec].</param>
         public DnsMessage(string name, DnsRecordType type, bool requestDnsSec)
-            : this(name, type, requestDnsSec, requestDnsSec, 4096) {
+            : this(name, type, requestDnsSec, requestDnsSec, 4096, null) {
         }
 
-        public DnsMessage(string name, DnsRecordType type, bool requestDnsSec, bool enableEdns, int udpBufferSize) {
+        public DnsMessage(string name, DnsRecordType type, bool requestDnsSec, bool enableEdns, int udpBufferSize, string? subnet) {
             _name = name;
             _type = type;
             _requestDnsSec = requestDnsSec;
-            _enableEdns = enableEdns || requestDnsSec;
+            _enableEdns = enableEdns || requestDnsSec || !string.IsNullOrEmpty(subnet);
             _udpBufferSize = udpBufferSize;
+            _subnet = subnet;
         }
 
         /// <summary>
@@ -94,6 +97,7 @@ namespace DnsClientX {
             stream.Write(buffer.ToArray(), 0, buffer.Length);
 
             if (_enableEdns) {
+                byte[] optionData = _subnet != null ? BuildEcsOption(_subnet) : Array.Empty<byte>();
                 stream.WriteByte(0);
                 BinaryPrimitives.WriteUInt16BigEndian(buffer, (ushort)DnsRecordType.OPT);
                 stream.Write(buffer.ToArray(), 0, buffer.Length);
@@ -102,8 +106,11 @@ namespace DnsClientX {
                 Span<byte> ttl = stackalloc byte[4];
                 BinaryPrimitives.WriteUInt32BigEndian(ttl, _requestDnsSec ? 0x00008000u : 0u);
                 stream.Write(ttl.ToArray(), 0, ttl.Length);
-                BinaryPrimitives.WriteUInt16BigEndian(buffer, 0);
+                BinaryPrimitives.WriteUInt16BigEndian(buffer, (ushort)optionData.Length);
                 stream.Write(buffer.ToArray(), 0, buffer.Length);
+                if (optionData.Length > 0) {
+                    stream.Write(optionData, 0, optionData.Length);
+                }
             }
 
             // Convert to base64url format
@@ -163,6 +170,7 @@ namespace DnsClientX {
 
                 if (_enableEdns)
                 {
+                    byte[] optionData = _subnet != null ? BuildEcsOption(_subnet) : Array.Empty<byte>();
                     ms.WriteByte(0);
                     bytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)DnsRecordType.OPT));
                     ms.Write(bytes, 0, bytes.Length);
@@ -170,12 +178,47 @@ namespace DnsClientX {
                     ms.Write(bytes, 0, bytes.Length);
                     bytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((int)(_requestDnsSec ? 0x00008000u : 0u)));
                     ms.Write(bytes, 0, bytes.Length);
-                    bytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)0));
+                    bytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)optionData.Length));
                     ms.Write(bytes, 0, bytes.Length);
+                    if (optionData.Length > 0)
+                    {
+                        ms.Write(optionData, 0, optionData.Length);
+                    }
                 }
 
                 return ms.ToArray();
             }
+        }
+
+        private static byte[] BuildEcsOption(string subnet) {
+            string[] parts = subnet.Split('/');
+            if (!IPAddress.TryParse(parts[0], out var ip)) {
+                throw new ArgumentException("Invalid subnet", nameof(subnet));
+            }
+            int prefixLength = parts.Length > 1 ? int.Parse(parts[1]) : (ip.AddressFamily == AddressFamily.InterNetwork ? 32 : 128);
+
+            ushort family = ip.AddressFamily == AddressFamily.InterNetwork ? (ushort)1 : (ushort)2;
+            byte[] addressBytes = ip.GetAddressBytes();
+            int addressBits = prefixLength;
+            int addressBytesLen = (addressBits + 7) / 8;
+            if (addressBytesLen > addressBytes.Length) addressBytesLen = addressBytes.Length;
+            byte[] truncated = new byte[addressBytesLen];
+            Array.Copy(addressBytes, truncated, addressBytesLen);
+            int unusedBits = addressBytesLen * 8 - addressBits;
+            if (unusedBits > 0 && addressBytesLen > 0) {
+                truncated[addressBytesLen - 1] &= (byte)(0xFF << unusedBits);
+            }
+
+            using var ms = new MemoryStream();
+            void WriteUInt16(ushort value) => ms.Write(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)value)), 0, 2);
+
+            WriteUInt16(8); // OPTION-CODE for ECS
+            WriteUInt16((ushort)(4 + truncated.Length)); // OPTION-LENGTH
+            WriteUInt16(family);
+            ms.WriteByte((byte)prefixLength);
+            ms.WriteByte(0); // scope prefix length
+            ms.Write(truncated, 0, truncated.Length);
+            return ms.ToArray();
         }
     }
 }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
             // For OpenDNS, we need to create a DNS message and base64url encode it
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -31,7 +31,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatDoT(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, bool ignoreCertificateErrors, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             // Calculate the length prefix for the query

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatPost(this HttpClient client, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatTcp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatUdp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize);
+            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {


### PR DESCRIPTION
## Summary
- support specifying EDNS Client Subnet in Configuration
- include ECS when serializing wire format DNS messages
- adapt protocol resolvers to pass subnet option
- add unit test verifying ECS option added for UDP queries

## Testing
- `dotnet test` *(fails: The argument /workspace/DnsClientX/DnsClientX.Tests/bin/Debug/net8.0/DnsClientX.Tests.dll is invalid...)*


------
https://chatgpt.com/codex/tasks/task_e_68676a13fd84832e9cae8295b3eb3b24