### PR TITLE
Fix DeserializeDnsWireFormat null input handling

### DIFF
--- a/DnsClientX.Tests/DnsWireDeserializeTests.cs
+++ b/DnsClientX.Tests/DnsWireDeserializeTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireDeserializeTests {
+        [Fact]
+        public async Task DeserializeDnsWireFormat_NullInputs_ThrowsArgumentNullException() {
+            Type wireType = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWire")!;
+            MethodInfo method = wireType.GetMethod("DeserializeDnsWireFormat", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object?[] { null, false, null })!;
+            await Assert.ThrowsAsync<ArgumentNullException>(() => task);
+        }
+
+        [Fact]
+        public async Task DeserializeDnsWireFormat_BytesOnly_DoesNotThrow() {
+            Type wireType = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWire")!;
+            MethodInfo method = wireType.GetMethod("DeserializeDnsWireFormat", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var bytes = new byte[] { 0x00, 0x01, 0x81, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+            var task = (Task<DnsResponse>)method.Invoke(null, new object?[] { null, false, bytes })!;
+            DnsResponse response = await task;
+            Assert.NotNull(response);
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWire.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWire.cs
@@ -30,6 +30,7 @@ namespace DnsClientX {
         /// or
         /// </exception>
         internal static async Task<DnsResponse> DeserializeDnsWireFormat(this HttpResponseMessage res, bool debug = false, byte[] bytes = null) {
+            if (res == null && bytes == null) throw new ArgumentNullException(nameof(res));
             try {
                 byte[] dnsWireFormatBytes;
                 if (bytes != null) {


### PR DESCRIPTION
## Summary
- guard against both `res` and `bytes` being `null` in `DeserializeDnsWireFormat`
- add unit tests for the new validation logic

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release -v minimal` *(fails: Assert.True failures because tests rely on network)*

------
https://chatgpt.com/codex/tasks/task_e_686843329a18832e804edb89be954a33