### PR TITLE
Fix PTR parsing for malformed strings

### DIFF
--- a/DnsClientX.Tests/ConvertSpecialFormatToDottedTests.cs
+++ b/DnsClientX.Tests/ConvertSpecialFormatToDottedTests.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ConvertSpecialFormatToDottedTests {
+        private static string Invoke(string data) {
+            var answer = new DnsAnswer();
+            MethodInfo method = typeof(DnsAnswer).GetMethod("ConvertSpecialFormatToDotted", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            return (string)method.Invoke(answer, new object[] { data })!;
+        }
+
+        [Fact]
+        public void MalformedInputReturnsOriginal() {
+            string malformed = $"{(char)7}examp"; // length byte larger than remaining data
+            Assert.Equal(malformed, Invoke(malformed));
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -520,15 +520,15 @@ namespace DnsClientX {
                 // Move to the next character
                 i++;
 
-                // Read the label
-                if (i + length <= data.Length) {
-                    result.Append(data.Substring(i, length));
-                    result.Append('.');
-                    i += length;
-                } else {
-                    // If the length byte is invalid, break the loop
-                    break;
+                // Validate available length before slicing the string
+                if (i + length > data.Length) {
+                    return data;
                 }
+
+                // Read the label
+                result.Append(data.Substring(i, length));
+                result.Append('.');
+                i += length;
             }
 
             // Remove the trailing dot and return the result


### PR DESCRIPTION
## Summary
- validate length before slicing PTR strings
- add test for malformed PTR input

## Testing
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6868437dd534832ea62331d4addae763