### PR TITLE
Fix QUIC resolver host resolution

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveQuicTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveQuicTests.cs
@@ -1,0 +1,24 @@
+#if NET8_0_OR_GREATER
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireResolveQuicTests {
+        [Fact]
+        public async Task ResolveWireFormatQuic_ReturnsServerFailure_WhenHostHasNoAddresses() {
+            var previous = DnsWireResolveQuic.HostEntryResolver;
+            try {
+                DnsWireResolveQuic.HostEntryResolver = _ => new IPHostEntry { AddressList = Array.Empty<IPAddress>() };
+                var config = new Configuration("dummy", DnsRequestFormat.DnsOverQuic);
+                var response = await DnsWireResolveQuic.ResolveWireFormatQuic("dummy", 853, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None);
+                Assert.Equal(DnsResponseCode.ServerFailure, response.Status);
+            } finally {
+                DnsWireResolveQuic.HostEntryResolver = previous;
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- guard DOQ resolver against hostnames with no addresses
- allow test injection of host entry for DOQ
- add unit test for missing host addresses

## Testing
- `dotnet test` *(fails: Failed: 140, Passed: 241, Skipped: 15)*

------
https://chatgpt.com/codex/tasks/task_e_6868433a4800832eabe64fb0bff6fe21