### PR TITLE
Add TTL validation to BindFileParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,4 @@ build/*
 /Module/Artefacts/*
 /Module/Lib/*dotnet-install.sh
 packages-microsoft-prod.deb
+dotnet-install.sh

--- a/DnsClientX.Tests/ParseBindFileTests.cs
+++ b/DnsClientX.Tests/ParseBindFileTests.cs
@@ -27,5 +27,15 @@ namespace DnsClientX.Tests {
             Assert.Equal(DnsRecordType.A, result[2].Type);
             Assert.Equal(600, result[2].TTL);
         }
+
+        [Fact]
+        public void NegativeTtl_SkipsRecord() {
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
+            File.WriteAllText(tempPath, "www -60 IN A 203.0.113.10\n");
+            MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            File.Delete(tempPath);
+            Assert.Empty(result);
+        }
     }
 }

--- a/DnsClientX/BindFileParser.cs
+++ b/DnsClientX/BindFileParser.cs
@@ -29,7 +29,11 @@ namespace DnsClientX {
                 if (line.StartsWith("$TTL", StringComparison.OrdinalIgnoreCase)) {
                     var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                     if (parts.Length > 1 && int.TryParse(parts[1], out int ttlDirective)) {
-                        defaultTtl = ttlDirective;
+                        if (ttlDirective >= 0) {
+                            defaultTtl = ttlDirective;
+                        } else {
+                            debugPrint?.Invoke($"Skipping invalid TTL directive: {line}");
+                        }
                     }
                     continue;
                 }
@@ -48,6 +52,10 @@ namespace DnsClientX {
                 int ttl = defaultTtl;
 
                 if (int.TryParse(tokens[index], out int ttlVal)) {
+                    if (ttlVal < 0) {
+                        debugPrint?.Invoke($"Skipping record with negative TTL: {line}");
+                        continue;
+                    }
                     ttl = ttlVal;
                     index++;
                 }


### PR DESCRIPTION
## Summary
- skip invalid negative `$TTL` directives
- skip records with negative TTL values
- ignore dotnet-install.sh script
- test BindFileParser with negative TTL input

## Testing
- `dotnet test` *(fails: HttpConnectionPool.ConnectAsync)*

------
https://chatgpt.com/codex/tasks/task_e_68684377a3f8832eb20c052a707e7dbe