### PR TITLE
Add async disposal support

### DIFF
--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -34,6 +34,22 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        public async Task Client_DisposeAsync_ShouldNotDisposeHttpClientTwice() {
+            var handler = new TrackingHandler();
+            var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
+            await using var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(clientX)!;
+            clients[clientX.EndpointConfiguration.SelectionStrategy] = customClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(clientX, customClient);
+
+            await clientX.DisposeAsync();
+
+            Assert.Equal(1, handler.DisposeCount);
+        }
+
+        [Fact]
         public async Task Client_Dispose_CalledConcurrently_ShouldOnlyDisposeOnce() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -47,6 +63,26 @@ namespace DnsClientX.Tests {
             var tasks = new List<Task>();
             for (int i = 0; i < 5; i++) {
                 tasks.Add(Task.Run(() => clientX.Dispose()));
+            }
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(1, handler.DisposeCount);
+        }
+
+        [Fact]
+        public async Task Client_DisposeAsync_CalledConcurrently_ShouldOnlyDisposeOnce() {
+            var handler = new TrackingHandler();
+            var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
+            var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(clientX)!;
+            clients[clientX.EndpointConfiguration.SelectionStrategy] = customClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(clientX, customClient);
+
+            var tasks = new List<Task>();
+            for (int i = 0; i < 5; i++) {
+                tasks.Add(Task.Run(() => clientX.DisposeAsync().AsTask()));
             }
             await Task.WhenAll(tasks);
 

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 
+using System.Threading.Tasks;
+
 namespace DnsClientX {
-    public partial class ClientX : IDisposable {
+    public partial class ClientX : IDisposable, IAsyncDisposable {
         private bool _disposed;
         private readonly HashSet<HttpClient> _disposedClients = new();
 
@@ -51,6 +53,75 @@ namespace DnsClientX {
                     }
 
                     handlerLocal?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync() {
+            await DisposeAsyncCore().ConfigureAwait(false);
+            Dispose(disposing: false);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes managed resources asynchronously when possible.
+        /// </summary>
+        /// <returns>A task representing the asynchronous disposal.</returns>
+        protected virtual async ValueTask DisposeAsyncCore() {
+            if (!_disposed) {
+                HttpClientHandler? handlerLocal;
+                List<HttpClient> clients;
+                HttpClient? mainClient;
+
+                lock (_lock) {
+                    clients = new List<HttpClient>(_clients.Values);
+                    _clients.Clear();
+
+                    mainClient = Client;
+                    handlerLocal = handler;
+                    Client = null;
+                    handler = null;
+                }
+
+                foreach (HttpClient client in clients) {
+                    if (TryAddDisposedClient(client)) {
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                        if (client is IAsyncDisposable asyncClient) {
+                            await asyncClient.DisposeAsync().ConfigureAwait(false);
+                        } else {
+                            client.Dispose();
+                        }
+#else
+                        client.Dispose();
+#endif
+                    }
+                }
+
+                if (mainClient != null && TryAddDisposedClient(mainClient)) {
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    if (mainClient is IAsyncDisposable asyncClient) {
+                        await asyncClient.DisposeAsync().ConfigureAwait(false);
+                    } else {
+                        mainClient.Dispose();
+                    }
+#else
+                    mainClient.Dispose();
+#endif
+                }
+
+                if (handlerLocal != null) {
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    if (handlerLocal is IAsyncDisposable asyncHandler) {
+                        await asyncHandler.DisposeAsync().ConfigureAwait(false);
+                    } else {
+                        handlerLocal.Dispose();
+                    }
+#else
+                    handlerLocal.Dispose();
+#endif
                 }
 
                 _disposed = true;


### PR DESCRIPTION
## Summary
- add IAsyncDisposable implementation to `ClientX`
- dispose `HttpClient` and handler asynchronously when possible
- add async disposal tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6868439c1298832e9a53b81e89e2671a