### PR TITLE
Skip retry when maxRetries is 1

### DIFF
--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace DnsClientX.Tests {
     public class ResolveAll {
         [Theory]
@@ -120,6 +122,17 @@ namespace DnsClientX.Tests {
                 Assert.True(answer.Name == "evotec.pl");
                 Assert.True((bool)(answer.Type == DnsRecordType.A));
             }
+        }
+
+        [Fact]
+        public async Task ShouldNotDelayWhenMaxRetriesIsOne() {
+            using var Client = new ClientX(DnsEndpoint.Cloudflare);
+            var sw = Stopwatch.StartNew();
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => Client.ResolveAll(string.Empty, DnsRecordType.A, retryOnTransient: true, maxRetries: 1, retryDelayMs: 200));
+            sw.Stop();
+
+            Assert.InRange(sw.ElapsedMilliseconds, 0, 100);
         }
     }
 }

--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -22,7 +22,7 @@ namespace DnsClientX {
         public async Task<DnsAnswer[]> ResolveAll(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             DnsResponse res;
             try {
-                res = retryOnTransient
+                res = retryOnTransient && maxRetries > 1
                     ? await RetryAsync(
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,
@@ -55,7 +55,7 @@ namespace DnsClientX {
         public async Task<DnsAnswer[]> ResolveAll(string name, string filter, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             DnsResponse res;
             try {
-                res = retryOnTransient
+                res = retryOnTransient && maxRetries > 1
                     ? await RetryAsync(
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,
@@ -90,7 +90,7 @@ namespace DnsClientX {
         public async Task<DnsAnswer[]> ResolveAll(string name, Regex regexPattern, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             DnsResponse res;
             try {
-                res = retryOnTransient
+                res = retryOnTransient && maxRetries > 1
                     ? await RetryAsync(
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,


### PR DESCRIPTION
## Summary
- check `maxRetries` before using `RetryAsync`
- ensure delay-free resolve path when no retries are needed
- test that `ResolveAll` doesn't wait when `maxRetries` is one

## Testing
- `dotnet test` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686843e99d90832eb9bb6d66c936ff9f