### PR TITLE
Add using blocks in examples

### DIFF
--- a/DnsClientX.Examples/DemoByManualUrl.cs
+++ b/DnsClientX.Examples/DemoByManualUrl.cs
@@ -5,62 +5,69 @@ namespace DnsClientX.Examples {
     public class DemoByManualUrl {
         public static async Task Example() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, "1.1.1.1", dnsRequestFormat: DnsRequestFormat.DnsOverHttpsJSON);
-            using var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON);
-            var data = await client.Resolve("evotec.pl", DnsRecordType.A);
-            data.DisplayTable();
+            using (var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)) {
+                var data = await client.Resolve("evotec.pl", DnsRecordType.A);
+                data.DisplayTable();
+            }
         }
 
         public static async Task Example2() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
-            using var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON);
-            var data = await client.Resolve("evotec.pl", DnsRecordType.A);
-            data.DisplayTable();
+            using (var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsJSON)) {
+                var data = await client.Resolve("evotec.pl", DnsRecordType.A);
+                data.DisplayTable();
+            }
         }
 
         public static async Task ExampleGoogle() {
             HelpersSpectre.AddLine("Resolve", "evotec.pl", DnsRecordType.A, new Uri("https://8.8.8.8/resolve"), DnsRequestFormat.DnsOverHttpsJSON);
-            using var client = new ClientX(new Uri("https://8.8.8.8/resolve"), DnsRequestFormat.DnsOverHttpsJSON);
-            var data = await client.Resolve("evotec.pl", DnsRecordType.A);
-            data.DisplayTable();
+            using (var client = new ClientX(new Uri("https://8.8.8.8/resolve"), DnsRequestFormat.DnsOverHttpsJSON)) {
+                var data = await client.Resolve("evotec.pl", DnsRecordType.A);
+                data.DisplayTable();
+            }
         }
 
 
         public static async Task ExampleTesting() {
             HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverTLS);
-            using var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverTLS) {
-                Debug = false
-            };
-            var data = await client.Resolve("www.example.com", DnsRecordType.A);
-            data.DisplayTable();
+            using (var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverTLS) {
+                   Debug = false
+               }) {
+                var data = await client.Resolve("www.example.com", DnsRecordType.A);
+                data.DisplayTable();
+            }
         }
 
         public static async Task ExampleTestingHttpOverPost() {
             HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST);
-            using var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST) {
-                Debug = false
-            };
-            var data = await client.Resolve("www.example.com", DnsRecordType.A);
-            data.DisplayTable();
+            using (var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST) {
+                   Debug = false
+               }) {
+                var data = await client.Resolve("www.example.com", DnsRecordType.A);
+                data.DisplayTable();
+            }
         }
 
         public static async Task ExampleTestingUdp() {
             HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, "192.168.241.6", DnsRequestFormat.DnsOverUDP);
-            using var client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
-                Debug = false
-            };
-            var data = await client.Resolve("www.example.com", DnsRecordType.A);
-            //var data = await DnsWireResolveUdp.ResolveWireFormatUdp("www.example.com", DnsRecordType.A, false, false, true);
-            data.DisplayTable();
+            using (var client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
+                   Debug = false
+               }) {
+                var data = await client.Resolve("www.example.com", DnsRecordType.A);
+                //var data = await DnsWireResolveUdp.ResolveWireFormatUdp("www.example.com", DnsRecordType.A, false, false, true);
+                data.DisplayTable();
+            }
         }
 
         public static async Task ExampleTestingTcp() {
             HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, "192.168.241.5", DnsRequestFormat.DnsOverTCP);
-            using var client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
-                Debug = false
-            };
-            var data = await client.Resolve("www.example.com", DnsRecordType.A);
-            //var data = await DnsWireResolveUdp.ResolveWireFormatTcp("www.example.com", DnsRecordType.A, false, false, true);
-            data.DisplayTable();
+            using (var client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
+                   Debug = false
+               }) {
+                var data = await client.Resolve("www.example.com", DnsRecordType.A);
+                //var data = await DnsWireResolveUdp.ResolveWireFormatTcp("www.example.com", DnsRecordType.A, false, false, true);
+                data.DisplayTable();
+            }
         }
     }
 }

--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -163,38 +163,42 @@ namespace DnsClientX.Examples {
         public static async Task ExampleSPF() {
             var domains = new[] { "disneyplus.com" };
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, "1.1.1.1");
-            using var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
-                Debug = false
-            };
-            var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
-            Settings.Logger.WriteInformation(data.Answers[0].Data);
+            using (var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
+                   Debug = false
+               }) {
+                var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
+                Settings.Logger.WriteInformation(data.Answers[0].Data);
+            }
 
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, DnsEndpoint.Google);
-            using var client1 = new ClientX(DnsEndpoint.GoogleWireFormat, DnsSelectionStrategy.First) {
-                Debug = false
-            };
-            var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
-            Settings.Logger.WriteInformation(data1.Answers[0].Data);
+            using (var client1 = new ClientX(DnsEndpoint.GoogleWireFormat, DnsSelectionStrategy.First) {
+                   Debug = false
+               }) {
+                var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
+                Settings.Logger.WriteInformation(data1.Answers[0].Data);
+            }
         }
 
         public static async Task ExampleSPFQuad() {
             var domains = new[] { "disneyplus.com" };
             HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, "1.1.1.1");
-            using var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
-                Debug = false
-            };
-            var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
-            Settings.Logger.WriteInformation(data.Answers[0].Data);
+            using (var client = new ClientX(DnsEndpoint.Cloudflare, DnsSelectionStrategy.First) {
+                   Debug = false
+               }) {
+                var data = await client.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
+                Settings.Logger.WriteInformation(data.Answers[0].Data);
+            }
 
             foreach (DnsEndpoint endpoint in Enum.GetValues(typeof(DnsEndpoint))) {
                 HelpersSpectre.AddLine("QueryDns", "disneyplus.com", DnsRecordType.SPF, endpoint);
-                using var client1 = new ClientX(endpoint, DnsSelectionStrategy.First) {
-                    Debug = false
-                };
-                var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
-                Settings.Logger.WriteInformation(data1.Answers[0].Data);
-                Settings.Logger.WriteInformation(data1.Answers[0].DataStrings.Length.ToString());
-                Settings.Logger.WriteInformation(data1.Answers[0].DataStrings[0]);
+                using (var client1 = new ClientX(endpoint, DnsSelectionStrategy.First) {
+                       Debug = false
+                   }) {
+                    var data1 = await client1.ResolveFilter("disneyplus.com", DnsRecordType.TXT, "SPF1");
+                    Settings.Logger.WriteInformation(data1.Answers[0].Data);
+                    Settings.Logger.WriteInformation(data1.Answers[0].DataStrings.Length.ToString());
+                    Settings.Logger.WriteInformation(data1.Answers[0].DataStrings[0]);
+                }
             }
         }
     }

--- a/DnsClientX.Examples/DemoRecords.cs
+++ b/DnsClientX.Examples/DemoRecords.cs
@@ -9,10 +9,11 @@ namespace DnsClientX.Examples {
         /// <param name="recordType">The type.</param>
         /// <param name="endpoint">The endpoint.</param>
         public static async Task Demo(string domain, DnsRecordType recordType, DnsEndpoint endpoint) {
-            using var client = new ClientX(endpoint);
-            HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
-            var caaAnswer = await client.ResolveAll(domain, recordType);
-            caaAnswer.DisplayTable();
+            using (var client = new ClientX(endpoint)) {
+                HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
+                var caaAnswer = await client.ResolveAll(domain, recordType);
+                caaAnswer.DisplayTable();
+            }
         }
     }
 }

--- a/DnsClientX.Examples/DemoResolve.cs
+++ b/DnsClientX.Examples/DemoResolve.cs
@@ -48,15 +48,15 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
-                    Debug = false
-                };
-
-                foreach (var domain in domains) {
-                    foreach (var recordType in recordTypes) {
-                        HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
-                        DnsResponse? response = await client.Resolve(domain, recordType);
-                        response?.DisplayTable();
+                using (var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
+                       Debug = false
+                   }) {
+                    foreach (var domain in domains) {
+                        foreach (var recordType in recordTypes) {
+                            HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
+                            DnsResponse? response = await client.Resolve(domain, recordType);
+                            response?.DisplayTable();
+                        }
                     }
                 }
             }

--- a/DnsClientX.Examples/DemoResolveAll.cs
+++ b/DnsClientX.Examples/DemoResolveAll.cs
@@ -48,15 +48,15 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using var client = new ClientX(endpoint) {
-                    Debug = false
-                };
-
-                foreach (var domain in domains) {
-                    foreach (var recordType in recordTypes) {
-                        HelpersSpectre.AddLine("ResolveAll", domain, recordType, endpoint);
-                        var response = await client.ResolveAll(domain, recordType);
-                        response.DisplayToConsole();
+                using (var client = new ClientX(endpoint) {
+                       Debug = false
+                   }) {
+                    foreach (var domain in domains) {
+                        foreach (var recordType in recordTypes) {
+                            HelpersSpectre.AddLine("ResolveAll", domain, recordType, endpoint);
+                            var response = await client.ResolveAll(domain, recordType);
+                            response.DisplayToConsole();
+                        }
                     }
                 }
             }
@@ -94,15 +94,15 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using var client = new ClientX(endpoint) {
-                    Debug = false
-                };
-
-                foreach (var domain in domains) {
-                    foreach (var recordType in recordTypes) {
-                        HelpersSpectre.AddLine("ResolveAll", domain, recordType, endpoint);
-                        var response = await client.ResolveAll(domain, recordType);
-                        response.DisplayToConsole();
+                using (var client = new ClientX(endpoint) {
+                       Debug = false
+                   }) {
+                    foreach (var domain in domains) {
+                        foreach (var recordType in recordTypes) {
+                            HelpersSpectre.AddLine("ResolveAll", domain, recordType, endpoint);
+                            var response = await client.ResolveAll(domain, recordType);
+                            response.DisplayToConsole();
+                        }
                     }
                 }
             }

--- a/DnsClientX.Examples/DemoResolveFirst.cs
+++ b/DnsClientX.Examples/DemoResolveFirst.cs
@@ -47,15 +47,15 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using var client = new ClientX(endpoint) {
-                    Debug = false
-                };
-
-                foreach (var domain in domains) {
-                    foreach (var recordType in recordTypes) {
-                        HelpersSpectre.AddLine("ResolveFirst", domain, recordType, endpoint);
-                        var response = await client.ResolveFirst(domain);
-                        response?.DisplayTable();
+                using (var client = new ClientX(endpoint) {
+                       Debug = false
+                   }) {
+                    foreach (var domain in domains) {
+                        foreach (var recordType in recordTypes) {
+                            HelpersSpectre.AddLine("ResolveFirst", domain, recordType, endpoint);
+                            var response = await client.ResolveFirst(domain);
+                            response?.DisplayTable();
+                        }
                     }
                 }
             }

--- a/DnsClientX.Examples/DemoResolveParallel.cs
+++ b/DnsClientX.Examples/DemoResolveParallel.cs
@@ -49,14 +49,14 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using var client = new ClientX(endpoint) {
-                    Debug = false
-                };
-
-                foreach (var domain in domains) {
-                    HelpersSpectre.AddLine("Resolve (Parallel)", domain, string.Join(",", recordTypes), endpoint);
-                    var responses = await client.Resolve(domain, recordTypes.ToArray());
-                    responses?.DisplayTable();
+                using (var client = new ClientX(endpoint) {
+                       Debug = false
+                   }) {
+                    foreach (var domain in domains) {
+                        HelpersSpectre.AddLine("Resolve (Parallel)", domain, string.Join(",", recordTypes), endpoint);
+                        var responses = await client.Resolve(domain, recordTypes.ToArray());
+                        responses?.DisplayTable();
+                    }
                 }
             }
         }

--- a/DnsClientX.Examples/DemoResolveParallelDNSBL.cs
+++ b/DnsClientX.Examples/DemoResolveParallelDNSBL.cs
@@ -142,15 +142,15 @@ namespace DnsClientX.Examples {
             // Start the stopwatch before the operation
             stopwatch.Start();
 
-            using var client = new ClientX(endpoint) {
-                Debug = false
-            };
-
-            HelpersSpectre.AddLine("Resolve (Parallel)", $"{ipAddress} => {queries.Count} queries", DnsRecordType.A, endpoint);
-            var responses = await client.Resolve(queries.ToArray(), DnsRecordType.A);
-            stopwatch.Stop();
-            HelpersSpectre.AddLine($"Time to resolve {stopwatch.ElapsedMilliseconds} ms", $"{ipAddress} => {queries.Count} queries", DnsRecordType.A, endpoint);
-            responses.DisplayTable();
+            using (var client = new ClientX(endpoint) {
+                   Debug = false
+               }) {
+                HelpersSpectre.AddLine("Resolve (Parallel)", $"{ipAddress} => {queries.Count} queries", DnsRecordType.A, endpoint);
+                var responses = await client.Resolve(queries.ToArray(), DnsRecordType.A);
+                stopwatch.Stop();
+                HelpersSpectre.AddLine($"Time to resolve {stopwatch.ElapsedMilliseconds} ms", $"{ipAddress} => {queries.Count} queries", DnsRecordType.A, endpoint);
+                responses.DisplayTable();
+            }
         }
     }
 }

--- a/DnsClientX.Examples/DemoResolveReturn.cs
+++ b/DnsClientX.Examples/DemoResolveReturn.cs
@@ -57,15 +57,15 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using var client = new ClientX(endpoint) {
-                    Debug = false
-                };
-
-                foreach (var domain in domains) {
-                    foreach (var recordType in recordTypes) {
-                        HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
-                        DnsResponse? response = await client.Resolve(domain, recordType, requestDnsSec: true, validateDnsSec: true, returnAllTypes: true);
-                        response?.DisplayTable();
+                using (var client = new ClientX(endpoint) {
+                       Debug = false
+                   }) {
+                    foreach (var domain in domains) {
+                        foreach (var recordType in recordTypes) {
+                            HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
+                            DnsResponse? response = await client.Resolve(domain, recordType, requestDnsSec: true, validateDnsSec: true, returnAllTypes: true);
+                            response?.DisplayTable();
+                        }
                     }
                 }
             }

--- a/DnsClientX.Examples/DemoResolveUdpTcp.cs
+++ b/DnsClientX.Examples/DemoResolveUdpTcp.cs
@@ -4,38 +4,42 @@ namespace DnsClientX.Examples {
     internal class DemoResolveUdpTcp {
         public static async Task ExampleTestingUdp() {
             HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.TXT, "192.168.241.6", DnsRequestFormat.DnsOverUDP);
-            using var client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
-                Debug = true
-            };
-            var data = await client.Resolve("github.com", DnsRecordType.TXT);
-            data.DisplayTable();
+            using (var client = new ClientX("192.168.241.6", DnsRequestFormat.DnsOverUDP) {
+                   Debug = true
+               }) {
+                var data = await client.Resolve("github.com", DnsRecordType.TXT);
+                data.DisplayTable();
+            }
         }
 
         public static async Task ExampleTestingTcp() {
             HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.TXT, "192.168.241.5", DnsRequestFormat.DnsOverTCP);
-            using var client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
-                Debug = true
-            };
-            var data = await client.Resolve("github.com", DnsRecordType.TXT);
-            data.DisplayTable();
+            using (var client = new ClientX("192.168.241.5", DnsRequestFormat.DnsOverTCP) {
+                   Debug = true
+               }) {
+                var data = await client.Resolve("github.com", DnsRecordType.TXT);
+                data.DisplayTable();
+            }
         }
 
         public static async Task ExampleTestingUdpWrongServer() {
             HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.TXT, "8.8.1.1", DnsRequestFormat.DnsOverUDP);
-            using var client = new ClientX("8.8.1.1", DnsRequestFormat.DnsOverUDP) {
-                Debug = true
-            };
-            var data = await client.Resolve("github.com", DnsRecordType.TXT);
-            data.DisplayTable();
+            using (var client = new ClientX("8.8.1.1", DnsRequestFormat.DnsOverUDP) {
+                   Debug = true
+               }) {
+                var data = await client.Resolve("github.com", DnsRecordType.TXT);
+                data.DisplayTable();
+            }
         }
 
         public static async Task ExampleTestingUdpWrongServer1() {
             HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.TXT, "a1-226.akam.net", DnsRequestFormat.DnsOverUDP);
-            using var client = new ClientX("a1akam1.net", DnsRequestFormat.DnsOverUDP) {
-                Debug = true
-            };
-            var data = await client.Resolve("github.com", DnsRecordType.TXT);
-            data.DisplayTable();
+            using (var client = new ClientX("a1akam1.net", DnsRequestFormat.DnsOverUDP) {
+                   Debug = true
+               }) {
+                var data = await client.Resolve("github.com", DnsRecordType.TXT);
+                data.DisplayTable();
+            }
         }
     }
 }

--- a/DnsClientX.Examples/DemoResolveWithFilter.cs
+++ b/DnsClientX.Examples/DemoResolveWithFilter.cs
@@ -45,15 +45,15 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
-                    Debug = false
-                };
-
-                foreach (var domain in domains) {
-                    foreach (var recordType in recordTypes) {
-                        HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
-                        DnsResponse? response = await client.ResolveFilter(domain, recordType, filter);
-                        response?.DisplayTable();
+                using (var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
+                       Debug = false
+                   }) {
+                    foreach (var domain in domains) {
+                        foreach (var recordType in recordTypes) {
+                            HelpersSpectre.AddLine("Resolve", domain, recordType, endpoint);
+                            DnsResponse? response = await client.ResolveFilter(domain, recordType, filter);
+                            response?.DisplayTable();
+                        }
                     }
                 }
             }
@@ -97,15 +97,13 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
-                    Debug = false
-                };
-
-
-
-                HelpersSpectre.AddLine("Resolve", "Multiple Domains", recordType, endpoint);
-                var response = await client.ResolveFilter(domains, recordType, filter);
-                response?.DisplayTable();
+                using (var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
+                       Debug = false
+                   }) {
+                    HelpersSpectre.AddLine("Resolve", "Multiple Domains", recordType, endpoint);
+                    var response = await client.ResolveFilter(domains, recordType, filter);
+                    response?.DisplayTable();
+                }
             }
         }
     }

--- a/DnsClientX.Examples/DemoServiceDiscovery.cs
+++ b/DnsClientX.Examples/DemoServiceDiscovery.cs
@@ -4,10 +4,11 @@ using System.Threading.Tasks;
 namespace DnsClientX.Examples {
     internal class DemoServiceDiscovery {
         public static async Task Example() {
-            using var client = new ClientX(DnsEndpoint.Cloudflare);
-            var results = await client.DiscoverServices("example.com");
-            foreach (var r in results) {
-                Console.WriteLine($"{r.ServiceName} -> {r.Target}:{r.Port}");
+            using (var client = new ClientX(DnsEndpoint.Cloudflare)) {
+                var results = await client.DiscoverServices("example.com");
+                foreach (var r in results) {
+                    Console.WriteLine($"{r.ServiceName} -> {r.Target}:{r.Port}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- wrap `ClientX` instances in `using` blocks across example files

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68684390d22c832e9ca921677270c39e