### PR TITLE
Apply ConfigureAwait to async operations

### DIFF
--- a/DnsClientX.Cli/Program.cs
+++ b/DnsClientX.Cli/Program.cs
@@ -21,7 +21,7 @@ namespace DnsClientX.Cli {
                             Console.Error.WriteLine("Missing value for --type");
                             return 1;
                         }
-                        recordType = Enum.Parse<DnsRecordType>(args[++i], true);
+                        recordType = (DnsRecordType)Enum.Parse(typeof(DnsRecordType), args[++i], true);
                         break;
                     case "-e":
                     case "--endpoint":
@@ -29,7 +29,7 @@ namespace DnsClientX.Cli {
                             Console.Error.WriteLine("Missing value for --endpoint");
                             return 1;
                         }
-                        endpoint = Enum.Parse<DnsEndpoint>(args[++i], true);
+                        endpoint = (DnsEndpoint)Enum.Parse(typeof(DnsEndpoint), args[++i], true);
                         break;
                     default:
                         if (domain is null) {

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -22,15 +22,15 @@ namespace DnsClientX {
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse>(cancellationToken);
+                return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
             if (dnsEndpoint == DnsEndpoint.RootServer) {
                 using var client = new ClientX();
-                return await client.ResolveFromRoot(name, recordType, cancellationToken);
+                return await client.ResolveFromRoot(name, recordType, cancellationToken).ConfigureAwait(false);
             } else {
                 using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
                 client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
-                var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken);
+                var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return data;
             }
         }
@@ -67,21 +67,21 @@ namespace DnsClientX {
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken);
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
             if (dnsEndpoint == DnsEndpoint.RootServer) {
                 var tasks = name.Select(n => {
                     using var client = new ClientX();
                     return client.ResolveFromRoot(n, recordType, cancellationToken);
                 });
-                return await Task.WhenAll(tasks);
+                return await Task.WhenAll(tasks).ConfigureAwait(false);
             } else {
                 using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy) {
                     EndpointConfiguration = {
                         TimeOut = timeOutMilliseconds
                     }
                 };
-                var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken);
+                var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return data;
             }
         }
@@ -118,14 +118,14 @@ namespace DnsClientX {
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse>(cancellationToken);
+                return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
             using var client = new ClientX(dnsUri, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -160,14 +160,14 @@ namespace DnsClientX {
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken);
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
             using var client = new ClientX(dnsUri, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -202,14 +202,14 @@ namespace DnsClientX {
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse>(cancellationToken);
+                return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -244,14 +244,14 @@ namespace DnsClientX {
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken);
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -269,14 +269,14 @@ namespace DnsClientX {
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken);
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -309,14 +309,14 @@ namespace DnsClientX {
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken);
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
             using var client = new ClientX(endpoint: dnsEndpoint) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken);
+            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 

--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -27,8 +27,8 @@ namespace DnsClientX {
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,
                         retryDelayMs,
-                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null)
-                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken);
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null).ConfigureAwait(false)
+                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken).ConfigureAwait(false);
             } catch (DnsClientException ex) {
                 res = ex.Response;
             }
@@ -60,8 +60,8 @@ namespace DnsClientX {
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,
                         retryDelayMs,
-                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null)
-                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken);
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null).ConfigureAwait(false)
+                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken).ConfigureAwait(false);
             } catch (DnsClientException ex) {
                 res = ex.Response;
             }
@@ -95,8 +95,8 @@ namespace DnsClientX {
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,
                         retryDelayMs,
-                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null)
-                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken);
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null).ConfigureAwait(false)
+                    : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken).ConfigureAwait(false);
             } catch (DnsClientException ex) {
                 res = ex.Response;
             }

--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -23,7 +23,7 @@ namespace DnsClientX {
         public async Task<DnsResponse[]> ResolveFilter(string[] names, DnsRecordType type, string filter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             var tasks = names.Select(name => Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken)).ToList();
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             var responses = tasks.Select(task => task.Result).ToList();
 
@@ -54,7 +54,7 @@ namespace DnsClientX {
         public async Task<DnsResponse[]> ResolveFilter(string[] names, DnsRecordType type, Regex regexFilter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             var tasks = names.Select(name => Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken)).ToList();
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             var responses = tasks.Select(task => task.Result).ToList();
 
@@ -84,7 +84,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response that matches the filter.</returns>
         public async Task<DnsResponse> ResolveFilter(string name, DnsRecordType type, string filter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
-            var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken);
+            var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(filter) && response.Answers != null) {
                 response.Answers = FilterAnswers(response.Answers, filter, type);
@@ -107,7 +107,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response that matches the filter.</returns>
         public async Task<DnsResponse> ResolveFilter(string name, DnsRecordType type, Regex regexFilter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
-            var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken);
+            var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false);
 
             if (response.Answers != null) {
                 response.Answers = FilterAnswersRegex(response.Answers, regexFilter, type);

--- a/DnsClientX/DnsClientX.ResolveFirst.cs
+++ b/DnsClientX/DnsClientX.ResolveFirst.cs
@@ -30,7 +30,7 @@ namespace DnsClientX {
                 retryOnTransient: retryOnTransient,
                 maxRetries: maxRetries,
                 retryDelayMs: retryDelayMs,
-                cancellationToken: cancellationToken);
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return res.Answers?.FirstOrDefault(x => x.Type == type);
         }

--- a/DnsClientX/DnsClientX.ResolveRoot.cs
+++ b/DnsClientX/DnsClientX.ResolveRoot.cs
@@ -15,7 +15,7 @@ namespace DnsClientX {
                 foreach (var server in servers) {
                     var host = server.TrimEnd('.');
                     var cfg = new Configuration(host, DnsRequestFormat.DnsOverUDP) { UseTcpFallback = true };
-                    lastResponse = await DnsWireResolveUdp.ResolveWireFormatUdp(host, cfg.Port, name, type, false, false, Debug, cfg, cancellationToken);
+                    lastResponse = await DnsWireResolveUdp.ResolveWireFormatUdp(host, cfg.Port, name, type, false, false, Debug, cfg, cancellationToken).ConfigureAwait(false);
                     if (lastResponse.Answers?.Any(a => a.Type == type) == true) {
                         return lastResponse;
                     }
@@ -36,7 +36,7 @@ namespace DnsClientX {
                 if (ns == null) {
                     return lastResponse;
                 }
-                var nsResponse = await ResolveFromRoot(ns, DnsRecordType.A, cancellationToken);
+                var nsResponse = await ResolveFromRoot(ns, DnsRecordType.A, cancellationToken).ConfigureAwait(false);
                 servers = nsResponse.Answers?.Select(a => a.Data.TrimEnd('.')).ToArray() ?? RootServers.Servers;
             }
             return lastResponse;

--- a/DnsClientX/DnsClientX.ServiceDiscovery.cs
+++ b/DnsClientX/DnsClientX.ServiceDiscovery.cs
@@ -33,14 +33,14 @@ namespace DnsClientX {
         public async Task<DnsServiceDiscovery[]> DiscoverServices(string domain, CancellationToken cancellationToken = default) {
             if (string.IsNullOrWhiteSpace(domain)) throw new ArgumentNullException(nameof(domain));
             string ptrQuery = $"_services._dns-sd._udp.{domain}";
-            var ptrResponse = await ResolveForSd(ptrQuery, DnsRecordType.PTR, cancellationToken);
+            var ptrResponse = await ResolveForSd(ptrQuery, DnsRecordType.PTR, cancellationToken).ConfigureAwait(false);
             if (ptrResponse.Answers == null) return Array.Empty<DnsServiceDiscovery>();
 
             var results = new List<DnsServiceDiscovery>();
             foreach (var ptr in ptrResponse.Answers.Where(a => a.Type == DnsRecordType.PTR)) {
                 string serviceDomain = ptr.Data.TrimEnd('.');
-                var srvResponse = await ResolveForSd(serviceDomain, DnsRecordType.SRV, cancellationToken);
-                var txtResponse = await ResolveForSd(serviceDomain, DnsRecordType.TXT, cancellationToken);
+                var srvResponse = await ResolveForSd(serviceDomain, DnsRecordType.SRV, cancellationToken).ConfigureAwait(false);
+                var txtResponse = await ResolveForSd(serviceDomain, DnsRecordType.TXT, cancellationToken).ConfigureAwait(false);
 
                 var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var txt in txtResponse.Answers?.Where(a => a.Type == DnsRecordType.TXT) ?? Array.Empty<DnsAnswer>()) {
@@ -102,7 +102,7 @@ namespace DnsClientX {
             if (!protocol.StartsWith("_", StringComparison.Ordinal)) protocol = "_" + protocol;
 
             string query = $"{service}.{protocol}.{domain}";
-            var response = await ResolveForSd(query, DnsRecordType.SRV, cancellationToken);
+            var response = await ResolveForSd(query, DnsRecordType.SRV, cancellationToken).ConfigureAwait(false);
             if (response.Answers == null) return Array.Empty<DnsSrvRecord>();
 
             var records = new List<DnsSrvRecord>();
@@ -116,12 +116,12 @@ namespace DnsClientX {
                     IPAddress[]? addresses = null;
                     if (resolveHosts) {
                         var addr = new List<IPAddress>();
-                        var aRes = await ResolveForSd(target, DnsRecordType.A, cancellationToken);
+                        var aRes = await ResolveForSd(target, DnsRecordType.A, cancellationToken).ConfigureAwait(false);
                         if (aRes.Answers != null) {
                             addr.AddRange(aRes.Answers.Where(a => a.Type == DnsRecordType.A)
                                 .Select(a => IPAddress.Parse(a.Data)));
                         }
-                        var aaaaRes = await ResolveForSd(target, DnsRecordType.AAAA, cancellationToken);
+                        var aaaaRes = await ResolveForSd(target, DnsRecordType.AAAA, cancellationToken).ConfigureAwait(false);
                         if (aaaaRes.Answers != null) {
                             addr.AddRange(aaaaRes.Answers.Where(a => a.Type == DnsRecordType.AAAA)
                                 .Select(a => IPAddress.Parse(a.Data)));

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -26,12 +26,12 @@ namespace DnsClientX {
             var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize, null);
             var queryBytes = query.SerializeDnsWireFormat();
 
-            var responses = await SendAxfrOverTcp(queryBytes, EndpointConfiguration.Hostname, EndpointConfiguration.Port, EndpointConfiguration.TimeOut, cancellationToken);
+            var responses = await SendAxfrOverTcp(queryBytes, EndpointConfiguration.Hostname, EndpointConfiguration.Port, EndpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
 
             var records = new List<DnsAnswer>();
             int soaCount = 0;
             foreach (var buffer in responses) {
-                var res = await DnsWire.DeserializeDnsWireFormat(null, Debug, buffer);
+                var res = await DnsWire.DeserializeDnsWireFormat(null, Debug, buffer).ConfigureAwait(false);
                 res.AddServerDetails(EndpointConfiguration);
                 if (res.Status != DnsResponseCode.NoError) {
                     throw new DnsClientException($"Zone transfer failed with {res.Status}", res);
@@ -67,7 +67,7 @@ namespace DnsClientX {
 
         private static async Task<List<byte[]>> SendAxfrOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             using var tcpClient = new TcpClient();
-            await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken);
+            await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
             using var stream = tcpClient.GetStream();
 
             var lengthBytes = BitConverter.GetBytes((ushort)query.Length);
@@ -75,30 +75,30 @@ namespace DnsClientX {
 
             var writeTask = stream.WriteAsync(lengthBytes, 0, lengthBytes.Length, cancellationToken);
             var timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
-            if (await Task.WhenAny(writeTask, timeoutTask) == timeoutTask) {
+            if (await Task.WhenAny(writeTask, timeoutTask).ConfigureAwait(false) == timeoutTask) {
                 throw new TimeoutException($"Writing length to {dnsServer}:{port} timed out after {timeoutMilliseconds} milliseconds.");
             }
-            await writeTask;
+            await writeTask.ConfigureAwait(false);
 
             writeTask = stream.WriteAsync(query, 0, query.Length, cancellationToken);
             timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
-            if (await Task.WhenAny(writeTask, timeoutTask) == timeoutTask) {
+            if (await Task.WhenAny(writeTask, timeoutTask).ConfigureAwait(false) == timeoutTask) {
                 throw new TimeoutException($"Writing query to {dnsServer}:{port} timed out after {timeoutMilliseconds} milliseconds.");
             }
-            await writeTask;
+            await writeTask.ConfigureAwait(false);
 
             var responses = new List<byte[]>();
             var lenBuf = new byte[2];
             while (true) {
                 try {
-                    await ReadExactWithTimeoutAsync(stream, lenBuf, 0, 2, timeoutMilliseconds, cancellationToken);
+                    await ReadExactWithTimeoutAsync(stream, lenBuf, 0, 2, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
                 } catch (EndOfStreamException) {
                     break;
                 }
                 if (BitConverter.IsLittleEndian) Array.Reverse(lenBuf);
                 int length = BitConverter.ToUInt16(lenBuf, 0);
                 var responseBuffer = new byte[length];
-                await ReadExactWithTimeoutAsync(stream, responseBuffer, 0, length, timeoutMilliseconds, cancellationToken);
+                await ReadExactWithTimeoutAsync(stream, responseBuffer, 0, length, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
                 responses.Add(responseBuffer);
             }
             return responses;
@@ -118,7 +118,7 @@ namespace DnsClientX {
             linkedCts.CancelAfter(timeoutMilliseconds);
 #if NET5_0_OR_GREATER
             try {
-                await tcpClient.ConnectAsync(host, port, linkedCts.Token);
+                await tcpClient.ConnectAsync(host, port, linkedCts.Token).ConfigureAwait(false);
             } catch (OperationCanceledException) {
                 tcpClient.Close();
                 cancellationToken.ThrowIfCancellationRequested();
@@ -127,13 +127,13 @@ namespace DnsClientX {
 #else
             var connectTask = tcpClient.ConnectAsync(host, port);
             var delayTask = Task.Delay(Timeout.Infinite, linkedCts.Token);
-            var completed = await Task.WhenAny(connectTask, delayTask);
+            var completed = await Task.WhenAny(connectTask, delayTask).ConfigureAwait(false);
             if (completed != connectTask) {
                 tcpClient.Close();
                 cancellationToken.ThrowIfCancellationRequested();
                 throw new TimeoutException($"Connection to {host}:{port} timed out after {timeoutMilliseconds} milliseconds.");
             }
-            await connectTask;
+            await connectTask.ConfigureAwait(false);
 #endif
         }
     }

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -107,10 +107,10 @@ namespace DnsClientX {
         private static async Task ReadExactWithTimeoutAsync(NetworkStream stream, byte[] buffer, int offset, int count, int timeoutMilliseconds, CancellationToken cancellationToken) {
             var readTask = DnsWire.ReadExactAsync(stream, buffer, offset, count, cancellationToken);
             var timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
-            if (await Task.WhenAny(readTask, timeoutTask) == timeoutTask) {
+            if (await Task.WhenAny(readTask, timeoutTask).ConfigureAwait(false) == timeoutTask) {
                 throw new TimeoutException($"Reading from stream timed out after {timeoutMilliseconds} milliseconds.");
             }
-            await readTask;
+            await readTask.ConfigureAwait(false);
         }
 
         private static async Task ConnectAsync(TcpClient tcpClient, string host, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -25,8 +25,8 @@ namespace DnsClientX {
             }
 
             try {
-                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken);
-                DnsResponse response = await res.DeserializeDnsWireFormat(debug);
+                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken).ConfigureAwait(false);
+                DnsResponse response = await res.DeserializeDnsWireFormat(debug).ConfigureAwait(false);
                 response.AddServerDetails(endpointConfiguration);
                 if (res.StatusCode != HttpStatusCode.OK || !string.IsNullOrEmpty(response.Error)) {
                     string message = string.Concat(

--- a/DnsClientX/ProtocolDnsJson/DnsJson.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJson.cs
@@ -24,13 +24,13 @@ namespace DnsClientX {
         /// <param name="response">The HTTP response message with JSON as a body.</param>
         /// <param name="debug">Whether to print the JSON data to the console.</param>
         internal static async Task<T> Deserialize<T>(this HttpResponseMessage response, bool debug = false) {
-            using Stream stream = await response.Content.ReadAsStreamAsync();
+            using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             if (stream.Length == 0) throw new DnsClientException("Response content is empty, can't parse as JSON.");
             try {
                 if (debug) {
                     // Read the stream as a string
                     using StreamReader reader = new StreamReader(stream);
-                    string json = await reader.ReadToEndAsync();
+                    string json = await reader.ReadToEndAsync().ConfigureAwait(false);
                     // Write the JSON data using logger
                     Settings.Logger.WriteDebug(json);
                     // Deserialize the JSON data

--- a/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
@@ -28,9 +28,9 @@ namespace DnsClientX {
 
             using HttpRequestMessage req = new(HttpMethod.Get, url);
             try {
-                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken);
+                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken).ConfigureAwait(false);
 
-                DnsResponse response = await res.Deserialize<DnsResponse>(debug);
+                DnsResponse response = await res.Deserialize<DnsResponse>(debug).ConfigureAwait(false);
                 response.AddServerDetails(configuration);
                 return response;
             } catch (Exception ex) {

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -61,24 +61,24 @@ namespace DnsClientX {
                 }
             };
 
-            await using var connection = await QuicConnection.ConnectAsync(options, cancellationToken);
-            await using var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken);
+            await using var connection = await QuicConnection.ConnectAsync(options, cancellationToken).ConfigureAwait(false);
+            await using var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken).ConfigureAwait(false);
 
             try {
 
-                await stream.WriteAsync(payload, cancellationToken);
+                await stream.WriteAsync(payload, cancellationToken).ConfigureAwait(false);
                 stream.CompleteWrites();
 
                 var lengthBuffer = new byte[2];
-                await DnsWire.ReadExactAsync(stream, lengthBuffer, 0, 2, cancellationToken);
+                await DnsWire.ReadExactAsync(stream, lengthBuffer, 0, 2, cancellationToken).ConfigureAwait(false);
                 if (BitConverter.IsLittleEndian) {
                     Array.Reverse(lengthBuffer);
                 }
                 int responseLength = BitConverter.ToUInt16(lengthBuffer, 0);
                 var responseBuffer = new byte[responseLength];
-                await DnsWire.ReadExactAsync(stream, responseBuffer, 0, responseLength, cancellationToken);
+                await DnsWire.ReadExactAsync(stream, responseBuffer, 0, responseLength, cancellationToken).ConfigureAwait(false);
 
-                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer);
+                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
                 response.AddServerDetails(endpointConfiguration);
                 return response;
             } catch (PlatformNotSupportedException ex) {

--- a/DnsClientX/ProtocolDnsWire/DnsWire.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWire.cs
@@ -35,13 +35,13 @@ namespace DnsClientX {
                 if (bytes != null) {
                     dnsWireFormatBytes = bytes;
                 } else {
-                    using Stream stream = await res.Content.ReadAsStreamAsync();
+                    using Stream stream = await res.Content.ReadAsStreamAsync().ConfigureAwait(false);
                     if (stream.Length == 0) throw new DnsClientException("Response content is empty, can't parse as DNS wire format.");
                     // Ensure the stream's position is at the start
                     stream.Position = 0;
 
                     dnsWireFormatBytes = new byte[stream.Length];
-                    await ReadExactAsync(stream, dnsWireFormatBytes, 0, dnsWireFormatBytes.Length, CancellationToken.None);
+                    await ReadExactAsync(stream, dnsWireFormatBytes, 0, dnsWireFormatBytes.Length, CancellationToken.None).ConfigureAwait(false);
                 }
 
                 if (debug) {
@@ -499,7 +499,7 @@ namespace DnsClientX {
         /// </summary>
         internal static async Task ReadExactAsync(Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
             int read;
-            while (count > 0 && (read = await stream.ReadAsync(buffer, offset, count, cancellationToken)) > 0) {
+            while (count > 0 && (read = await stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false)) > 0) {
                 offset += read;
                 count -= read;
             }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -36,8 +36,8 @@ namespace DnsClientX {
             }
 
             try {
-                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken);
-                DnsResponse response = await res.DeserializeDnsWireFormat(debug);
+                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken).ConfigureAwait(false);
+                DnsResponse response = await res.DeserializeDnsWireFormat(debug).ConfigureAwait(false);
                 response.AddServerDetails(endpointConfiguration);
                 if (res.StatusCode != HttpStatusCode.OK || !string.IsNullOrEmpty(response.Error)) {
                     string message = string.Concat(

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -35,8 +35,8 @@ namespace DnsClientX {
             using ByteArrayContent content = new(queryBytes);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/dns-message");
 
-            using HttpResponseMessage postAsync = await client.PostAsync(client.BaseAddress, content, cancellationToken);
-            var response = await postAsync.DeserializeDnsWireFormat(debug);
+            using HttpResponseMessage postAsync = await client.PostAsync(client.BaseAddress, content, cancellationToken).ConfigureAwait(false);
+            var response = await postAsync.DeserializeDnsWireFormat(debug).ConfigureAwait(false);
             response.AddServerDetails(endpointConfiguration);
             return response;
         }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -168,7 +168,7 @@ namespace DnsClientX {
             linkedCts.CancelAfter(timeoutMilliseconds);
 #if NET5_0_OR_GREATER
             try {
-                await tcpClient.ConnectAsync(host, port, linkedCts.Token);
+                await tcpClient.ConnectAsync(host, port, linkedCts.Token).ConfigureAwait(false);
             } catch (OperationCanceledException) {
                 tcpClient.Close();
                 cancellationToken.ThrowIfCancellationRequested();
@@ -178,14 +178,14 @@ namespace DnsClientX {
             var connectTask = tcpClient.ConnectAsync(host, port);
             var delayTask = Task.Delay(Timeout.Infinite, linkedCts.Token);
 
-            var completed = await Task.WhenAny(connectTask, delayTask);
+            var completed = await Task.WhenAny(connectTask, delayTask).ConfigureAwait(false);
             if (completed != connectTask) {
                 tcpClient.Close();
                 cancellationToken.ThrowIfCancellationRequested();
                 throw new TimeoutException($"Connection to {host}:{port} timed out after {timeoutMilliseconds} milliseconds.");
             }
 
-            await connectTask; // propagate possible exceptions
+            await connectTask.ConfigureAwait(false); // propagate possible exceptions
 #endif
         }
     }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -44,14 +44,14 @@ namespace DnsClientX {
 
             try {
                 // Send the DNS query over UDP and receive the response
-                var responseBuffer = await SendQueryOverUdp(queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken);
+                var responseBuffer = await SendQueryOverUdp(queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
 
                 // Deserialize the response from DNS wire format
-                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer);
+                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
                 if (response.IsTruncated && endpointConfiguration.UseTcpFallback) {
                     // If the response is truncated and fallback is enabled, retry the query over TCP
                     response = await DnsWireResolveTcp.ResolveWireFormatTcp(dnsServer, port, name, type, requestDnsSec,
-                        validateDnsSec, debug, endpointConfiguration, cancellationToken);
+                        validateDnsSec, debug, endpointConfiguration, cancellationToken).ConfigureAwait(false);
                 }
                 response.AddServerDetails(endpointConfiguration);
                 return response;
@@ -99,9 +99,9 @@ namespace DnsClientX {
 
                 // Send the query
 #if NET5_0_OR_GREATER
-                await udpClient.SendAsync(query, serverEndpoint, cancellationToken);
+                await udpClient.SendAsync(query, serverEndpoint, cancellationToken).ConfigureAwait(false);
 #else
-                await udpClient.SendAsync(query, query.Length, serverEndpoint);
+                await udpClient.SendAsync(query, query.Length, serverEndpoint).ConfigureAwait(false);
 #endif
 
                 // Set up the cancellation token for the timeout
@@ -114,7 +114,7 @@ namespace DnsClientX {
 #else
                         var responseTask = udpClient.ReceiveAsync();
 #endif
-                        var completedTask = await Task.WhenAny(responseTask, Task.Delay(timeoutMilliseconds, cts.Token));
+                        var completedTask = await Task.WhenAny(responseTask, Task.Delay(timeoutMilliseconds, cts.Token)).ConfigureAwait(false);
 
                         if (completedTask == responseTask) {
                             // If the response task completed, return the response buffer


### PR DESCRIPTION
## Summary
- add `ConfigureAwait(false)` for library async calls to avoid capturing sync context

## Testing
- `dotnet build DnsClientX.sln -v minimal`
- `dotnet test DnsClientX.sln --no-build --verbosity minimal` *(fails: Failed:   140, Passed:   240, Skipped:    15, Total:   395)*

------
https://chatgpt.com/codex/tasks/task_e_686843555bf4832eb417f1ffe8f81f9d