### PR TITLE
Ensure ClientX disposal on canceled queries

### DIFF
--- a/DnsClientX.Tests/CancellationTests.cs
+++ b/DnsClientX.Tests/CancellationTests.cs
@@ -39,5 +39,16 @@ namespace DnsClientX.Tests {
             cts.Cancel();
             await Assert.ThrowsAsync<TaskCanceledException>(() => ClientX.QueryDns("example.com", DnsRecordType.A, cancellationToken: cts.Token));
         }
+
+        [Fact]
+        public async Task QueryDns_ShouldDisposeClient_WhenCancelled() {
+            ClientX.DisposalCount = 0;
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => ClientX.QueryDns("example.com", DnsRecordType.A, cancellationToken: cts.Token));
+
+            Assert.Equal(1, ClientX.DisposalCount);
+        }
     }
 }

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -8,6 +8,7 @@ namespace DnsClientX {
     public partial class ClientX : IDisposable, IAsyncDisposable {
         private bool _disposed;
         private readonly HashSet<HttpClient> _disposedClients = new();
+        internal static int DisposalCount;
 
         private bool TryAddDisposedClient(HttpClient client) {
             lock (_lock) {
@@ -56,6 +57,7 @@ namespace DnsClientX {
                 }
 
                 _disposed = true;
+                System.Threading.Interlocked.Increment(ref DisposalCount);
             }
         }
 
@@ -125,6 +127,7 @@ namespace DnsClientX {
                 }
 
                 _disposed = true;
+                System.Threading.Interlocked.Increment(ref DisposalCount);
             }
         }
 

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -21,15 +21,18 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
-            }
             if (dnsEndpoint == DnsEndpoint.RootServer) {
                 using var client = new ClientX();
+                if (cancellationToken.IsCancellationRequested) {
+                    return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
+                }
                 return await client.ResolveFromRoot(name, recordType, cancellationToken).ConfigureAwait(false);
             } else {
                 using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
                 client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
+                if (cancellationToken.IsCancellationRequested) {
+                    return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
+                }
                 var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return data;
             }
@@ -66,12 +69,12 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
-            }
             if (dnsEndpoint == DnsEndpoint.RootServer) {
                 var tasks = name.Select(n => {
                     using var client = new ClientX();
+                    if (cancellationToken.IsCancellationRequested) {
+                        return Task.FromCanceled<DnsResponse>(cancellationToken);
+                    }
                     return client.ResolveFromRoot(n, recordType, cancellationToken);
                 });
                 return await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -81,6 +84,9 @@ namespace DnsClientX {
                         TimeOut = timeOutMilliseconds
                     }
                 };
+                if (cancellationToken.IsCancellationRequested) {
+                    return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
+                }
                 var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return data;
             }
@@ -117,14 +123,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
-            }
             using var client = new ClientX(dnsUri, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
+            if (cancellationToken.IsCancellationRequested) {
+                return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
+            }
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
@@ -159,14 +165,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
-            }
             using var client = new ClientX(dnsUri, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
+            if (cancellationToken.IsCancellationRequested) {
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
+            }
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
@@ -201,14 +207,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
-            }
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
+            if (cancellationToken.IsCancellationRequested) {
+                return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
+            }
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
@@ -243,14 +249,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
-            }
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
+            if (cancellationToken.IsCancellationRequested) {
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
+            }
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
@@ -268,14 +274,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
-            }
             using var client = new ClientX(hostName, requestFormat) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
+            if (cancellationToken.IsCancellationRequested) {
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
+            }
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
@@ -308,14 +314,14 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            if (cancellationToken.IsCancellationRequested) {
-                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
-            }
             using var client = new ClientX(endpoint: dnsEndpoint) {
                 EndpointConfiguration = {
                     TimeOut = timeOutMilliseconds
                 }
             };
+            if (cancellationToken.IsCancellationRequested) {
+                return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
+            }
             var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }


### PR DESCRIPTION
## Summary
- dispose `ClientX` even if cancellation is already requested
- track disposal count in `ClientX`
- test that queries with a canceled token dispose the client

## Testing
- `dotnet test` *(fails: Failed: 140, Passed: 249, Skipped: 15)*

------
https://chatgpt.com/codex/tasks/task_e_68693ed193b0832ea5ea7244dc200e1f