### PR TITLE
Add EDNS options support

### DIFF
--- a/DnsClientX.Tests/EdnsDoBitTests.cs
+++ b/DnsClientX.Tests/EdnsDoBitTests.cs
@@ -162,6 +162,26 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        public async Task UdpRequest_ShouldUseBufferSize_FromEdnsOptions() {
+            int port = GetFreePort();
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var udpTask = RunUdpServerAsync(port, response, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) {
+                Port = port,
+                EdnsOptions = new EdnsOptions { EnableEdns = true, UdpBufferSize = 1234 }
+            };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            await task;
+            byte[] query = await udpTask;
+
+            AssertBufferSize(query, "example.com", 1234);
+        }
+
+        [Fact]
         public async Task UdpRequest_ShouldNotSetDoBit_WhenDnssecNotRequested() {
             int port = GetFreePort();
             var response = CreateDnsHeader();

--- a/DnsClientX.Tests/EdnsOptionsTests.cs
+++ b/DnsClientX.Tests/EdnsOptionsTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class EdnsOptionsTests {
+        private static byte[] CreateDnsHeader() {
+            byte[] bytes = new byte[12];
+            ushort id = 0x1234;
+            bytes[0] = (byte)(id >> 8);
+            bytes[1] = (byte)(id & 0xFF);
+            ushort flags = 0x8180;
+            bytes[2] = (byte)(flags >> 8);
+            bytes[3] = (byte)(flags & 0xFF);
+            return bytes;
+        }
+
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task<byte[]> RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
+            using var udp = new UdpClient(port);
+            UdpReceiveResult result = await udp.ReceiveAsync();
+            await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
+            return result.Buffer;
+        }
+
+        private static void AssertEcsOption(byte[] query, string name) {
+            int offset = 12;
+            foreach (var label in name.Split('.')) {
+                offset += 1 + label.Length;
+            }
+            offset += 1 + 2 + 2;
+
+            Assert.Equal(0, query[offset]);
+            offset += 1;
+            ushort type = (ushort)((query[offset] << 8) | query[offset + 1]);
+            Assert.Equal((ushort)DnsRecordType.OPT, type);
+            offset += 2 + 2 + 4;
+            ushort rdlen = (ushort)((query[offset] << 8) | query[offset + 1]);
+            Assert.True(rdlen > 0);
+            offset += 2;
+            ushort optionCode = (ushort)((query[offset] << 8) | query[offset + 1]);
+            Assert.Equal(8, optionCode);
+        }
+
+        [Fact]
+        public async Task UdpRequest_ShouldIncludeEcsOption_WhenOptionsConfigured() {
+            int port = GetFreePort();
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var udpTask = RunUdpServerAsync(port, response, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) {
+                Port = port,
+                EdnsOptions = new EdnsOptions { EnableEdns = true, Subnet = "192.0.2.1/24" }
+            };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            await task;
+            byte[] query = await udpTask;
+
+            AssertEcsOption(query, "example.com");
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -93,6 +93,13 @@ namespace DnsClientX {
         public string? Subnet { get; set; }
 
         /// <summary>
+        /// Gets or sets additional EDNS options. When configured, these values
+        /// override <see cref="EnableEdns"/>, <see cref="UdpBufferSize"/> and
+        /// <see cref="Subnet"/>.
+        /// </summary>
+        public EdnsOptions? EdnsOptions { get; set; }
+
+        /// <summary>
         /// Gets or sets the format of the DNS requests.
         /// </summary>
         public DnsRequestFormat RequestFormat { get; set; }

--- a/DnsClientX/EdnsOptions.cs
+++ b/DnsClientX/EdnsOptions.cs
@@ -1,0 +1,21 @@
+namespace DnsClientX {
+    /// <summary>
+    /// Represents EDNS options used when sending DNS queries.
+    /// </summary>
+    public class EdnsOptions {
+        /// <summary>
+        /// Gets or sets a value indicating whether EDNS should be enabled.
+        /// </summary>
+        public bool EnableEdns { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the UDP buffer size used for EDNS queries.
+        /// </summary>
+        public int UdpBufferSize { get; set; } = 4096;
+
+        /// <summary>
+        /// Gets or sets the EDNS Client Subnet (ECS) in CIDR notation.
+        /// </summary>
+        public string? Subnet { get; set; }
+    }
+}

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -9,7 +9,11 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatHttp3(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
+            int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
+            string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -17,7 +17,11 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatQuic(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
+            int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
+            string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             var lengthPrefix = BitConverter.GetBytes((ushort)queryBytes.Length);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -23,7 +23,11 @@ namespace DnsClientX {
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
             // For OpenDNS, we need to create a DNS message and base64url encode it
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
+            int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
+            string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -31,7 +31,11 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatDoT(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, bool ignoreCertificateErrors, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
+            int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
+            string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             // Calculate the length prefix for the query

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -23,7 +23,11 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatPost(this HttpClient client, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
+            int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
+            string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -23,7 +23,11 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatTcp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
+            int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
+            string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -23,7 +23,11 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatUdp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var query = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
+            int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
+            string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {


### PR DESCRIPTION
## Summary
- add `EdnsOptions` class for configuring EDNS
- expose `EdnsOptions` on `Configuration`
- include EDNS options in DNS message creation
- test EDNS options through new unit tests

## Testing
- `dotnet test` *(fails: Failed: 141, Passed: 250, Skipped: 15)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68694dfb81f0832e99ad44afd6b4c58a