### PR TITLE
Add ClientXBuilder

### DIFF
--- a/DnsClientX/ClientXBuilder.cs
+++ b/DnsClientX/ClientXBuilder.cs
@@ -1,0 +1,46 @@
+using System.Net;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Builder class for creating configured <see cref="ClientX"/> instances.
+    /// </summary>
+    public class ClientXBuilder {
+        private DnsEndpoint _endpoint = DnsEndpoint.Cloudflare;
+        private int _timeout = Configuration.DefaultTimeout;
+        private IWebProxy? _proxy;
+
+        /// <summary>
+        /// Sets the DNS endpoint to use.
+        /// </summary>
+        /// <param name="endpoint">Predefined DNS endpoint.</param>
+        public ClientXBuilder WithEndpoint(DnsEndpoint endpoint) {
+            _endpoint = endpoint;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the DNS query timeout in milliseconds.
+        /// </summary>
+        /// <param name="timeout">Timeout in milliseconds.</param>
+        public ClientXBuilder WithTimeout(int timeout) {
+            _timeout = timeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets an optional web proxy for HTTP requests.
+        /// </summary>
+        /// <param name="proxy">The web proxy to use.</param>
+        public ClientXBuilder WithProxy(IWebProxy proxy) {
+            _proxy = proxy;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds and returns a configured <see cref="ClientX"/> instance.
+        /// </summary>
+        public ClientX Build() {
+            return new ClientX(_endpoint, DnsSelectionStrategy.First, _timeout, webProxy: _proxy);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -386,6 +386,16 @@ using var client = new ClientX(DnsEndpoint.Cloudflare, userAgent: "MyApp/1.0", h
 ```
 You can also modify `client.EndpointConfiguration.UserAgent` and `client.EndpointConfiguration.HttpVersion` after construction.
 
+
+### Building a client with `ClientXBuilder`
+
+```csharp
+using var client = new ClientXBuilder()
+    .WithEndpoint(DnsEndpoint.Cloudflare)
+    .WithTimeout(2000)
+    .Build();
+```
+
 ### Using a custom endpoint
 
 ```csharp


### PR DESCRIPTION
## Summary
- add `ClientXBuilder` for simplified ClientX creation
- document ClientXBuilder usage in README

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release -f net8.0 --no-build --verbosity quiet`
- `dotnet build DnsClientX.sln -c Release --nologo`


------
https://chatgpt.com/codex/tasks/task_e_68694dd0eba4832ebf2004e85803f4e2