### PR TITLE
Add DNS over HTTP/2 support

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveHttp2Tests.cs
+++ b/DnsClientX.Tests/DnsWireResolveHttp2Tests.cs
@@ -1,0 +1,34 @@
+#if NET8_0_OR_GREATER
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireResolveHttp2Tests {
+        private class Http2Handler : HttpMessageHandler {
+            public HttpRequestMessage? Request { get; private set; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                Request = request;
+                byte[] responseBytes = { 0x00, 0x01, 0x81, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(responseBytes) };
+                response.Version = HttpVersion.Version20;
+                return Task.FromResult(response);
+            }
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatHttp2_UsesHttp2() {
+            var handler = new Http2Handler();
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/dns-query") };
+            var config = new Configuration(new Uri("https://example.com/dns-query"), DnsRequestFormat.DnsOverHttp2);
+            var response = await DnsWireResolveHttp2.ResolveWireFormatHttp2(client, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None);
+
+            Assert.Equal(HttpVersion.Version20, handler.Request?.Version);
+            Assert.Equal(DnsResponseCode.NoError, response.Status);
+        }
+    }
+}
+#endif

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -34,6 +34,10 @@ namespace DnsClientX {
         /// </summary>
         DnsOverQuic,
         /// <summary>
+        /// DNS over HTTP/2 using wire format.
+        /// </summary>
+        DnsOverHttp2,
+        /// <summary>
         /// DNS over HTTP/3 using wire format.
         /// </summary>
         DnsOverHttp3,

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -87,6 +87,8 @@ namespace DnsClientX {
                 response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.ObliviousDnsOverHttps) {
                 response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2) {
+                response = await Client.ResolveWireFormatHttp2(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3) {
                 response = await Client.ResolveWireFormatHttp3(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
             } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -276,6 +276,7 @@ namespace DnsClientX {
             // Set the accept header based on the request format, which is required for proper processing
             if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||
+                EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2 ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3 ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.ObliviousDnsOverHttps) {
                 client.DefaultRequestHeaders.Accept.Add(

--- a/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
+++ b/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    internal static class DnsWireResolveHttp2 {
+        internal static async Task<DnsResponse> ResolveWireFormatHttp2(this HttpClient client, string name,
+            DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
+            Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var base64UrlDnsMessage = dnsMessage.ToBase64Url();
+            string url = $"?dns={base64UrlDnsMessage}";
+
+            using HttpRequestMessage req = new(HttpMethod.Get, url);
+#if NET8_0_OR_GREATER
+            req.Version = HttpVersion.Version20;
+#else
+            req.Version = new Version(2, 0);
+#endif
+            if (debug) {
+                Settings.Logger.WriteDebug("Query Name: " + name + " type: " + type + " url: " + req.RequestUri);
+                Settings.Logger.WriteDebug("Query DnsWireFormatBytes: " + base64UrlDnsMessage);
+            }
+
+            try {
+                using HttpResponseMessage res = await client.SendAsync(req, cancellationToken).ConfigureAwait(false);
+                DnsResponse response = await res.DeserializeDnsWireFormat(debug).ConfigureAwait(false);
+                response.AddServerDetails(endpointConfiguration);
+                if (res.StatusCode != HttpStatusCode.OK || !string.IsNullOrEmpty(response.Error)) {
+                    string message = string.Concat(
+                        $"Failed to query type {type} of \"{name}\", received HTTP status code {res.StatusCode}.",
+                        string.IsNullOrEmpty(response.Error) ? string.Empty : $"\nError: {response.Error}",
+                        response.Comments is null ? string.Empty : $"\nComments: {string.Join(", ", response.Comments)}");
+                    throw new DnsClientException(message, response);
+                }
+
+                return response;
+            } catch (HttpRequestException ex) {
+                DnsResponseCode responseCode;
+                if (ex.InnerException is TaskCanceledException || ex.InnerException is TimeoutException) {
+                    responseCode = DnsResponseCode.ServerFailure;
+                } else if (ex.InnerException is WebException webEx) {
+                    switch (webEx.Status) {
+                        case WebExceptionStatus.Timeout:
+                            responseCode = DnsResponseCode.ServerFailure;
+                            break;
+                        case WebExceptionStatus.ConnectFailure:
+                            responseCode = DnsResponseCode.Refused;
+                            break;
+                        case WebExceptionStatus.NameResolutionFailure:
+                            responseCode = DnsResponseCode.ServerFailure;
+                            break;
+                        case WebExceptionStatus.TrustFailure:
+                        case WebExceptionStatus.SecureChannelFailure:
+                            responseCode = DnsResponseCode.Refused;
+                            break;
+                        default:
+                            responseCode = DnsResponseCode.ServerFailure;
+                            break;
+                    }
+                } else {
+                    var error = (ex.InnerException?.Message ?? string.Empty).ToLowerInvariant();
+                    if (error.Contains("ssl") || error.Contains("certificate") || error.Contains("handshake")) {
+                        responseCode = DnsResponseCode.Refused;
+                    } else if (error.Contains("timeout")) {
+                        responseCode = DnsResponseCode.ServerFailure;
+                    } else {
+                        responseCode = DnsResponseCode.ServerFailure;
+                    }
+                }
+
+                DnsResponse response = new DnsResponse {
+                    Questions = [
+                        new DnsQuestion {
+                            Name = name,
+                            RequestFormat = DnsRequestFormat.DnsOverHttp2,
+                            HostName = client.BaseAddress.Host,
+                            Port = client.BaseAddress.Port,
+                            Type = type,
+                            OriginalName = name
+                        }
+                    ],
+                    Status = responseCode
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" =>{ex.Message} {ex.InnerException?.Message}";                
+                return response;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `DnsWireResolveHttp2` for HTTP/2 wire format queries
- support new `DnsOverHttp2` format in `DnsRequestFormat`
- route requests through the HTTP/2 resolver
- adjust Accept header logic
- add unit test with a mock HTTP/2 handler

## Testing
- `dotnet test` *(fails: The argument ... invalid)*
- `dotnet build DnsClientX.sln`

------
https://chatgpt.com/codex/tasks/task_e_68694deefe78832e94e6ef80ed6607ad