### PR TITLE
Handle missing SOA in zone transfer

### DIFF
--- a/DnsClientX.Tests/ZoneTransferTests.cs
+++ b/DnsClientX.Tests/ZoneTransferTests.cs
@@ -149,5 +149,17 @@ namespace DnsClientX.Tests {
             await Assert.ThrowsAsync<DnsClientException>(() => client.ZoneTransferAsync("example.com"));
             await server;
         }
+
+        [Fact]
+        public async Task ZoneTransferAsync_FailsWithoutSoa() {
+            int port = GetFreePort();
+            byte[] m1 = BuildMessage("example.com", ("www.example.com", DnsRecordType.A, new byte[] { 1, 2, 3, 4 }));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var server = RunAxfrServerAsync(port, new[] { m1 }, cts.Token);
+
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = port } };
+            await Assert.ThrowsAsync<DnsClientException>(() => client.ZoneTransferAsync("example.com"));
+            await server;
+        }
     }
 }

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -43,6 +43,10 @@ namespace DnsClientX {
                 }
             }
 
+            if (soaCount == 0) {
+                throw new DnsClientException("SOA record not found during zone transfer.");
+            }
+
             var rrsets = new List<List<DnsAnswer>>();
             foreach (var rec in records) {
                 if (rrsets.Count == 0 || rrsets[rrsets.Count - 1][0].Name != rec.Name || rrsets[rrsets.Count - 1][0].Type != rec.Type) {


### PR DESCRIPTION
## Summary
- throw an exception when zone transfer responses never include an SOA record
- test for zone transfer with no SOA record

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~ZoneTransferTests --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686957c6a1c4832ebdefd0fe02783c10