### PR TITLE
Pass cancellation token to retry delays

### DIFF
--- a/DnsClientX.Tests/FailoverStrategyTests.cs
+++ b/DnsClientX.Tests/FailoverStrategyTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -29,7 +30,7 @@ namespace DnsClientX.Tests {
             var advance = (Action)Delegate.CreateDelegate(typeof(Action), config, "AdvanceToNextHostname", false)!;
             await Assert.ThrowsAsync<DnsClientException>(async () =>
             {
-                await (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, advance, false })!;
+                await (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, advance, false, CancellationToken.None })!;
             });
 
             config.SelectHostNameStrategy();

--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -27,7 +27,9 @@ namespace DnsClientX {
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,
                         retryDelayMs,
-                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null).ConfigureAwait(false)
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null,
+                        true,
+                        cancellationToken).ConfigureAwait(false)
                     : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken).ConfigureAwait(false);
             } catch (DnsClientException ex) {
                 res = ex.Response;
@@ -60,7 +62,9 @@ namespace DnsClientX {
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,
                         retryDelayMs,
-                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null).ConfigureAwait(false)
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null,
+                        true,
+                        cancellationToken).ConfigureAwait(false)
                     : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken).ConfigureAwait(false);
             } catch (DnsClientException ex) {
                 res = ex.Response;
@@ -95,7 +99,9 @@ namespace DnsClientX {
                         () => Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken),
                         maxRetries,
                         retryDelayMs,
-                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null).ConfigureAwait(false)
+                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null,
+                        true,
+                        cancellationToken).ConfigureAwait(false)
                     : await Resolve(name, type, requestDnsSec, validateDnsSec, false, false, 1, 0, cancellationToken).ConfigureAwait(false);
             } catch (DnsClientException ex) {
                 res = ex.Response;


### PR DESCRIPTION
## Summary
- allow `RetryAsync` to accept a `CancellationToken`
- propagate the token so `Task.Delay` can be cancelled
- adjust `Resolve` and `ResolveAll` to pass the token
- update unit tests and add a new test for cancelling during retry

## Testing
- `dotnet test` *(fails: Failed: 140, Passed: 253, Skipped: 15)*

------
https://chatgpt.com/codex/tasks/task_e_686957bd81a0832e9e2a167120fbf026