### PR TITLE
Fix comment detection in Bind zone parser

### DIFF
--- a/DnsClientX.Tests/ParseBindFileTests.cs
+++ b/DnsClientX.Tests/ParseBindFileTests.cs
@@ -37,5 +37,16 @@ namespace DnsClientX.Tests {
             File.Delete(tempPath);
             Assert.Empty(result);
         }
+
+        [Fact]
+        public void SemicolonInQuotedText_IsNotComment() {
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
+            File.WriteAllText(tempPath, "test IN TXT \"text;not comment\"\n");
+            MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            File.Delete(tempPath);
+            Assert.Single(result);
+            Assert.Equal("text;not comment", result[0].DataRaw);
+        }
     }
 }

--- a/DnsClientX/BindFileParser.cs
+++ b/DnsClientX/BindFileParser.cs
@@ -105,7 +105,7 @@ namespace DnsClientX {
                 }
 
                 string data = string.Join(" ", tokens.Skip(index));
-                if (type == DnsRecordType.TXT && data.Length > 1 && data.StartsWith('"') && data.EndsWith('"')) {
+                if (type == DnsRecordType.TXT && data.Length > 1 && data.StartsWith("\"") && data.EndsWith("\"")) {
                     data = data.Substring(1, data.Length - 2);
                 }
 

--- a/DnsClientX/BindFileParser.cs
+++ b/DnsClientX/BindFileParser.cs
@@ -21,7 +21,32 @@ namespace DnsClientX {
                     continue;
                 }
 
-                int commentIndex = line.IndexOf(';');
+                int commentIndex = -1;
+                bool inQuotes = false;
+                bool escape = false;
+                for (int i = 0; i < line.Length; i++) {
+                    char c = line[i];
+                    if (escape) {
+                        escape = false;
+                        continue;
+                    }
+
+                    if (c == '\\') {
+                        escape = true;
+                        continue;
+                    }
+
+                    if (c == '"') {
+                        inQuotes = !inQuotes;
+                        continue;
+                    }
+
+                    if (c == ';' && !inQuotes) {
+                        commentIndex = i;
+                        break;
+                    }
+                }
+
                 if (commentIndex >= 0) {
                     line = line.Substring(0, commentIndex).Trim();
                 }

--- a/DnsClientX/BindFileParser.cs
+++ b/DnsClientX/BindFileParser.cs
@@ -95,6 +95,7 @@ namespace DnsClientX {
                     if (!Enum.TryParse(typeToken, true, out type)) {
                         continue;
                     }
+                    index++;
                 } else {
                     index++;
                 }
@@ -104,6 +105,9 @@ namespace DnsClientX {
                 }
 
                 string data = string.Join(" ", tokens.Skip(index));
+                if (type == DnsRecordType.TXT && data.Length > 1 && data.StartsWith('"') && data.EndsWith('"')) {
+                    data = data.Substring(1, data.Length - 2);
+                }
 
                 records.Add(new DnsAnswer {
                     Name = name,


### PR DESCRIPTION
## Summary
- handle quoted semicolons in `BindFileParser`
- add regression test for quoted semicolon TXT record

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release -f net8.0 --no-build` *(fails: AuditTrailTests.ShouldRecordResponseWhenEnabled, DnssecTests.QueryDnskey_WithDnssec ...)*

------
https://chatgpt.com/codex/tasks/task_e_686957cc0dcc832eab7bb6f16c7318ae