### PR TITLE
Add additional unit tests for builder and answer helpers

### DIFF
--- a/DnsClientX.Tests/ClientXBuilderTests.cs
+++ b/DnsClientX.Tests/ClientXBuilderTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ClientXBuilderTests {
+        [Fact]
+        public void BuildShouldApplySettings() {
+            var proxy = new WebProxy("http://localhost:8080");
+
+            using var client = new ClientXBuilder()
+                .WithEndpoint(DnsEndpoint.GoogleWireFormatPost)
+                .WithTimeout(2000)
+                .WithProxy(proxy)
+                .Build();
+
+            Assert.Equal(2000, client.EndpointConfiguration.TimeOut);
+            Assert.NotNull(client.EndpointConfiguration.BaseUri);
+            Assert.StartsWith("https://8.8.8.8", client.EndpointConfiguration.BaseUri!.ToString());
+
+            var field = typeof(ClientX).GetField("_webProxy", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            Assert.Same(proxy, field.GetValue(client));
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsAnswerMinimalTests.cs
+++ b/DnsClientX.Tests/DnsAnswerMinimalTests.cs
@@ -1,0 +1,39 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsAnswerMinimalTests {
+        [Fact]
+        public void ExplicitConversionCopiesFields() {
+            var answer = new DnsAnswer {
+                Name = "example.com",
+                Type = DnsRecordType.A,
+                TTL = 3600,
+                DataRaw = "1.1.1.1"
+            };
+
+            DnsAnswerMinimal minimal = (DnsAnswerMinimal)answer;
+
+            Assert.Equal("example.com", minimal.Name);
+            Assert.Equal(DnsRecordType.A, minimal.Type);
+            Assert.Equal(3600, minimal.TTL);
+            Assert.Equal("1.1.1.1", minimal.Data);
+        }
+
+        [Fact]
+        public void ConvertFromDnsAnswerArrayConvertsAll() {
+            var answers = new[] {
+                new DnsAnswer { Name = "a.com", Type = DnsRecordType.A, TTL = 60, DataRaw = "1.1.1.1" },
+                new DnsAnswer { Name = "b.com", Type = DnsRecordType.AAAA, TTL = 60, DataRaw = "::1" }
+            };
+
+            var result = answers.ConvertFromDnsAnswer();
+
+            Assert.Equal(2, result.Length);
+            Assert.Equal("a.com", result[0].Name);
+            Assert.Equal("1.1.1.1", result[0].Data);
+            Assert.Equal(DnsRecordType.AAAA, result[1].Type);
+            Assert.Equal("::1", result[1].Data);
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsAnswerParsingTests.cs
+++ b/DnsClientX.Tests/DnsAnswerParsingTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsAnswerParsingTests {
+        private static byte[] PtrBytes => new byte[] {
+            3, (byte)'w', (byte)'w', (byte)'w',
+            6, (byte)'g', (byte)'o', (byte)'o', (byte)'g', (byte)'l', (byte)'e',
+            3, (byte)'c', (byte)'o', (byte)'m',
+            0
+        };
+
+        [Fact]
+        public void PtrDataFromSpecialFormatIsConverted() {
+            var answer = new DnsAnswer { Type = DnsRecordType.PTR, DataRaw = Encoding.UTF8.GetString(PtrBytes) };
+            Assert.Equal("www.google.com", answer.Data);
+        }
+
+        [Fact]
+        public void PtrDataFromBase64IsConverted() {
+            var base64 = Convert.ToBase64String(PtrBytes);
+            var answer = new DnsAnswer { Type = DnsRecordType.PTR, DataRaw = base64 };
+            Assert.Equal("www.google.com", answer.Data);
+        }
+
+        [Fact]
+        public void NaptrDataFromBase64IsParsed() {
+            byte[] rdata = {
+                0x00, 0x01, // order = 1
+                0x00, 0x02, // preference = 2
+                0x01, (byte)'u', // flags "u"
+                0x03, (byte)'s', (byte)'i', (byte)'p', // service "sip"
+                0x00, // regexp length 0
+                0x07, (byte)'e', (byte)'x', (byte)'a', (byte)'m', (byte)'p', (byte)'l', (byte)'e',
+                0x03, (byte)'c', (byte)'o', (byte)'m',
+                0x00 // terminator
+            };
+            var base64 = Convert.ToBase64String(rdata);
+            var answer = new DnsAnswer { Type = DnsRecordType.NAPTR, DataRaw = base64 };
+
+            Assert.Equal("1 2 \"u\" \"sip\" \"\" example.com", answer.Data);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests for `ClientXBuilder` verifying builder configuration
- add tests for `DnsAnswerMinimal` conversion utilities
- add tests for PTR/NAPTR parsing in `DnsAnswer`

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --filter FullyQualifiedName~ClientXBuilderTests --no-build`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --filter FullyQualifiedName~DnsAnswerMinimalTests --no-build`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --filter FullyQualifiedName~DnsAnswerParsingTests --no-build`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -f net472 --filter FullyQualifiedName~DnsAnswerParsingTests` *(fails: reference assemblies for net472 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686958085fb8832eaac8076d4827ff15