### PR TITLE
Add concurrency resolve test

### DIFF
--- a/DnsClientX.Tests/ResolveConcurrencyTests.cs
+++ b/DnsClientX.Tests/ResolveConcurrencyTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveConcurrencyTests {
+        [Fact]
+        public async Task ShouldResolveConcurrentlyWithoutErrors() {
+            using var client = new ClientX(DnsEndpoint.System);
+            client.ResolverOverride = (name, type, ct) =>
+                Task.FromResult(new DnsResponse {
+                    Answers = new[] {
+                        new DnsAnswer {
+                            Name = "example.com",
+                            Type = DnsRecordType.A,
+                            DataRaw = "127.0.0.1"
+                        }
+                    }
+                });
+
+            var tasks = Enumerable.Range(0, 10)
+                .Select(_ => client.Resolve("example.com", DnsRecordType.A));
+
+            var results = await Task.WhenAll(tasks);
+
+            Assert.Equal(10, results.Length);
+            Assert.All(results, r => Assert.NotNull(r.Answers));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ResolveConcurrencyTests to ensure resolving concurrently works

## Testing
- `dotnet build --no-restore --verbosity quiet`
- `dotnet test --no-build --filter "FullyQualifiedName~ResolveConcurrencyTests" --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68696ddbedd0832ead92b93e0426ca9a