### PR TITLE
Add job timeouts

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -22,6 +22,7 @@ jobs:
     test-windows:
         name: 'Windows'
         runs-on: windows-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -64,6 +65,7 @@ jobs:
     test-ubuntu:
         name: 'Ubuntu'
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -106,6 +108,7 @@ jobs:
     test-macos:
         name: 'macOS'
         runs-on: macos-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -22,6 +22,7 @@ jobs:
     refresh-psd1:
         name: 'Refresh PSD1'
         runs-on: windows-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -48,6 +49,7 @@ jobs:
         needs: refresh-psd1
         name: 'Windows PowerShell 5.1'
         runs-on: windows-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -83,6 +85,7 @@ jobs:
         needs: refresh-psd1
         name: 'Windows PowerShell 7'
         runs-on: windows-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -118,6 +121,7 @@ jobs:
         needs: refresh-psd1
         name: 'Ubuntu PowerShell 7'
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -160,6 +164,7 @@ jobs:
         needs: refresh-psd1
         name: 'macOS PowerShell 7'
         runs-on: macos-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add 10-minute timeout to each CI job

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686a1f72dd6c832eacd61f6b4645dbda