### PR TITLE
Fix TXT splitting for DMARC records

### DIFF
--- a/DnsClientX.Tests/DmarcTxtRecordTests.cs
+++ b/DnsClientX.Tests/DmarcTxtRecordTests.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DmarcTxtRecordTests {
+        [Fact]
+        public void DmarcRecord_IsNotSplitIntoMultipleLines() {
+            string record = "v=DMARC1; p=reject; rua=mailto:report@dmarc-reports.example.net; adkim=s; aspf=s";
+            var answer = new DnsAnswer {
+                Name = "_dmarc.example.com",
+                Type = DnsRecordType.TXT,
+                TTL = 60,
+                DataRaw = record
+            };
+
+            Assert.Equal(record, answer.Data);
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -545,15 +545,15 @@ namespace DnsClientX {
 
             // Common patterns that indicate concatenated records
             var patterns = new[] {
-                "=", // Most TXT records are key=value pairs
+                // Detect common TXT records that may be concatenated by some providers
                 "v=spf1", // SPF records
                 "google-site-verification=",
                 "facebook-domain-verification=",
                 "apple-domain-verification=",
                 "MS=ms",
                 "_domainkey",
-                "dmarc",
-                "adsp"
+                "dmarc=",
+                "adsp="
             };
 
             int patternMatches = 0;


### PR DESCRIPTION
## Summary
- refine TXT concatenation detection logic
- add regression test for DMARC TXT record

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --verbosity minimal` *(fails: Network is unreachable)*
- `dotnet build DnsClientX.sln`

------
https://chatgpt.com/codex/tasks/task_e_686ad4c3a748832ea404a9203ac55af9