### PR TITLE
Fix UDP binding for tests

### DIFF
--- a/DnsClientX.Tests/DnsWireFallbackTests.cs
+++ b/DnsClientX.Tests/DnsWireFallbackTests.cs
@@ -29,7 +29,7 @@ namespace DnsClientX.Tests {
         }
 
         private static async Task RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
-            using var udp = new UdpClient(port);
+            using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
             UdpReceiveResult result = await udp.ReceiveAsync();
             await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
         }

--- a/DnsClientX.Tests/EcsOptionTests.cs
+++ b/DnsClientX.Tests/EcsOptionTests.cs
@@ -28,7 +28,7 @@ namespace DnsClientX.Tests {
         }
 
         private static async Task<byte[]> RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
-            using var udp = new UdpClient(port);
+            using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
             UdpReceiveResult result = await udp.ReceiveAsync();
             await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
             return result.Buffer;

--- a/DnsClientX.Tests/EdnsDoBitTests.cs
+++ b/DnsClientX.Tests/EdnsDoBitTests.cs
@@ -28,7 +28,7 @@ namespace DnsClientX.Tests {
         }
 
         private static async Task<byte[]> RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
-            using var udp = new UdpClient(port);
+            using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
             UdpReceiveResult result = await udp.ReceiveAsync();
             await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
             return result.Buffer;

--- a/DnsClientX.Tests/EdnsOptionsTests.cs
+++ b/DnsClientX.Tests/EdnsOptionsTests.cs
@@ -28,7 +28,7 @@ namespace DnsClientX.Tests {
         }
 
         private static async Task<byte[]> RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
-            using var udp = new UdpClient(port);
+            using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
             UdpReceiveResult result = await udp.ReceiveAsync();
             await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
             return result.Buffer;


### PR DESCRIPTION
## Summary
- bind UDP test servers to loopback to avoid Windows port conflicts

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build -v n --filter FullyQualifiedName~EcsOptionTests`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build -v n --filter FullyQualifiedName~EdnsOptionsTests`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build -v n --filter FullyQualifiedName~EdnsDoBitTests`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build -v n --filter FullyQualifiedName~DnsWireFallbackTests`


------
https://chatgpt.com/codex/tasks/task_e_686ae442ea68832eb98b1d02c21cadcc