### PR TITLE
Fix missing docs

### DIFF
--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -5,6 +5,9 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class implementing disposal logic.
+    /// </summary>
     public partial class ClientX : IDisposable, IAsyncDisposable {
         private bool _disposed;
         private readonly HashSet<HttpClient> _disposedClients = new();

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -6,6 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class containing core DNS query logic.
+    /// </summary>
     public partial class ClientX {
         /// <summary>
         /// Sends a DNS query for a specific record type to a DNS server.

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -9,6 +9,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class containing main resolve methods.
+    /// </summary>
     public partial class ClientX {
         /// <summary>
         /// Resolves a domain name using DNS over HTTPS. This method provides full control over the output.
@@ -83,31 +86,31 @@ namespace DnsClientX {
             try {
                 if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSON) {
                     response = await Client.ResolveJsonFormat(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps) {
-                response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
-                response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.ObliviousDnsOverHttps) {
-                response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2) {
-                response = await Client.ResolveWireFormatHttp2(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3) {
-                response = await Client.ResolveWireFormatHttp3(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {
-                response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, IgnoreCertificateErrors, cancellationToken).ConfigureAwait(false);
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverQuic) {
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps) {
+                    response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
+                    response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.ObliviousDnsOverHttps) {
+                    response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2) {
+                    response = await Client.ResolveWireFormatHttp2(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3) {
+                    response = await Client.ResolveWireFormatHttp3(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {
+                    response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, IgnoreCertificateErrors, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverQuic) {
 #if NET8_0_OR_GREATER
                 response = await DnsWireResolveQuic.ResolveWireFormatQuic(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
 #else
-                throw new DnsClientException("DNS over QUIC is not supported on this platform.");
+                    throw new DnsClientException("DNS over QUIC is not supported on this platform.");
 #endif
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTCP) {
-                response = await DnsWireResolveTcp.ResolveWireFormatTcp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-            } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverUDP) {
-                response = await DnsWireResolveUdp.ResolveWireFormatUdp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-            } else {
-                throw new DnsClientException($"Invalid RequestFormat: {EndpointConfiguration.RequestFormat}");
-            }
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTCP) {
+                    response = await DnsWireResolveTcp.ResolveWireFormatTcp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverUDP) {
+                    response = await DnsWireResolveUdp.ResolveWireFormatUdp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else {
+                    throw new DnsClientException($"Invalid RequestFormat: {EndpointConfiguration.RequestFormat}");
+                }
             } catch (Exception ex) {
                 if (auditEntry != null) {
                     auditEntry.Exception = ex;

--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -6,6 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class for resolving all matching records.
+    /// </summary>
     public partial class ClientX {
         /// <summary>
         /// Resolves a domain name using DNS over HTTPS and returns all answers of the provided type.

--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -6,6 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class with filtering resolve helpers.
+    /// </summary>
     public partial class ClientX {
         /// <summary>
         /// Resolves multiple domain names for a single DNS record type in parallel using DNS over HTTPS.

--- a/DnsClientX/DnsClientX.ResolveFirst.cs
+++ b/DnsClientX/DnsClientX.ResolveFirst.cs
@@ -6,6 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class with helpers for resolving first matching records.
+    /// </summary>
     public partial class ClientX {
         /// <summary>
         /// Resolves a domain name using DNS over HTTPS and returns the first answer of the provided type.

--- a/DnsClientX/DnsClientX.ResolveRoot.cs
+++ b/DnsClientX/DnsClientX.ResolveRoot.cs
@@ -3,6 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class implementing root server resolution logic.
+    /// </summary>
     public partial class ClientX {
         /// <summary>
         /// Resolves a domain name by iteratively querying root servers

--- a/DnsClientX/DnsClientX.ResolveStream.cs
+++ b/DnsClientX/DnsClientX.ResolveStream.cs
@@ -4,6 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class providing streaming DNS resolution helpers.
+    /// </summary>
     public partial class ClientX {
         /// <summary>
         /// Resolves multiple DNS record types for a single domain name and streams the responses.

--- a/DnsClientX/DnsClientX.ServiceDiscovery.cs
+++ b/DnsClientX/DnsClientX.ServiceDiscovery.cs
@@ -6,6 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class containing service discovery helpers.
+    /// </summary>
     public partial class ClientX {
         internal Func<string, DnsRecordType, CancellationToken, Task<DnsResponse>>? ResolverOverride;
 

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-using System.IO;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class providing zone transfer functionality.
+    /// </summary>
     public partial class ClientX {
         /// <summary>
         /// Performs a DNS zone transfer (AXFR) using TCP.

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -81,9 +81,25 @@ namespace DnsClientX {
 
         private static readonly DnsResponseCache _cache = new();
         private readonly bool _cacheEnabled;
+
+        /// <summary>
+        /// Gets a value indicating whether caching is enabled.
+        /// </summary>
         public bool CacheEnabled => _cacheEnabled;
+
+        /// <summary>
+        /// Gets or sets the default expiration time for cached entries.
+        /// </summary>
         public TimeSpan CacheExpiration { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Gets or sets the minimal TTL allowed for cached responses.
+        /// </summary>
         public TimeSpan MinCacheTtl { get; set; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Gets or sets the maximal TTL allowed for cached responses.
+        /// </summary>
         public TimeSpan MaxCacheTtl { get; set; } = TimeSpan.FromHours(1);
 
         /// <summary>

--- a/DnsClientX/DnsResponseCache.cs
+++ b/DnsClientX/DnsResponseCache.cs
@@ -2,19 +2,34 @@ using System;
 using System.Collections.Concurrent;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Simple in-memory cache for <see cref="DnsResponse"/> instances.
+    /// </summary>
     internal class DnsResponseCache {
         private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
 
+        /// <summary>
+        /// Wrapper class storing cached response together with its expiration timestamp.
+        /// </summary>
         private class CacheEntry {
             public CacheEntry(DnsResponse response, DateTimeOffset expiration) {
                 Response = response;
                 Expiration = expiration;
             }
 
+            /// <summary>Gets the cached DNS response.</summary>
             public DnsResponse Response { get; }
+
+            /// <summary>Gets the expiration time for the cached entry.</summary>
             public DateTimeOffset Expiration { get; }
         }
 
+        /// <summary>
+        /// Attempts to retrieve a cached response for a given key.
+        /// </summary>
+        /// <param name="key">Cache key.</param>
+        /// <param name="response">Retrieved response if found and not expired.</param>
+        /// <returns><c>true</c> if a valid entry was found; otherwise <c>false</c>.</returns>
         public bool TryGet(string key, out DnsResponse response) {
             if (_cache.TryGetValue(key, out var entry)) {
                 if (DateTimeOffset.UtcNow < entry.Expiration) {
@@ -27,6 +42,12 @@ namespace DnsClientX {
             return false;
         }
 
+        /// <summary>
+        /// Stores a response in the cache using the specified TTL value.
+        /// </summary>
+        /// <param name="key">Cache key.</param>
+        /// <param name="response">Response to cache.</param>
+        /// <param name="ttl">Time to keep the entry.</param>
         public void Set(string key, DnsResponse response, TimeSpan ttl) {
             var entry = new CacheEntry(response, DateTimeOffset.UtcNow.Add(ttl));
             _cache[key] = entry;

--- a/DnsClientX/RootServers.cs
+++ b/DnsClientX/RootServers.cs
@@ -1,5 +1,8 @@
 namespace DnsClientX {
     internal static class RootServers {
+        /// <summary>
+        /// List of well known DNS root servers used when performing iterative resolution.
+        /// </summary>
         public static readonly string[] Servers = {
             // IPv4
             "198.41.0.4",      // A.ROOT-SERVERS.NET


### PR DESCRIPTION
## Summary
- add missing XML documentation for partial classes
- document cache properties
- document root servers and caching helper

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686b663bc2a0832e9da3abdbcb3e832c