### PR TITLE
Add basic tests for uncovered utilities

### DIFF
--- a/DnsClientX.Tests/AuditEntryTests.cs
+++ b/DnsClientX.Tests/AuditEntryTests.cs
@@ -1,0 +1,20 @@
+using System;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class AuditEntryTests {
+        [Fact]
+        public void Constructor_SetsProperties() {
+            var entry = new AuditEntry("example.com", DnsRecordType.A);
+            var response = new DnsResponse { Status = DnsResponseCode.NoError };
+            var ex = new InvalidOperationException();
+            entry.Response = response;
+            entry.Exception = ex;
+
+            Assert.Equal("example.com", entry.Name);
+            Assert.Equal(DnsRecordType.A, entry.RecordType);
+            Assert.Same(response, entry.Response);
+            Assert.Same(ex, entry.Exception);
+        }
+    }
+}

--- a/DnsClientX.Tests/DebuggingHelpersTests.cs
+++ b/DnsClientX.Tests/DebuggingHelpersTests.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DebuggingHelpersTests {
+        private class CapturingLogger : InternalLogger {
+            public string? LastMessage { get; private set; }
+            public CapturingLogger() => OnDebugMessage += (_, e) => LastMessage = e.FullMessage;
+        }
+
+        private static void SetLogger(InternalLogger logger) {
+            FieldInfo field = typeof(Settings).GetField("_logger", BindingFlags.NonPublic | BindingFlags.Static)!;
+            field.SetValue(null, logger);
+        }
+
+        [Fact]
+        public void TroubleshootingDnsWire2_ReadsValueAndLogs() {
+            var logger = new CapturingLogger();
+            SetLogger(logger);
+            using var ms = new MemoryStream(new byte[] { 0x01, 0x02 });
+            using var reader = new BinaryReader(ms);
+            ushort result = DebuggingHelpers.TroubleshootingDnsWire2(reader, "test");
+            Assert.Equal(0x0102, result);
+            Assert.Contains("01-02", logger.LastMessage);
+        }
+
+        [Fact]
+        public void TroubleshootingDnsWire4_ReadsValueAndLogs() {
+            var logger = new CapturingLogger();
+            SetLogger(logger);
+            using var ms = new MemoryStream(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+            using var reader = new BinaryReader(ms);
+            uint result = DebuggingHelpers.TroubleshootingDnsWire4(reader, "test");
+            Assert.Equal(0x01020304u, result);
+            Assert.Contains("01-02-03-04", logger.LastMessage);
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsKeyAlgorithmExtensionsTests.cs
+++ b/DnsClientX.Tests/DnsKeyAlgorithmExtensionsTests.cs
@@ -1,0 +1,17 @@
+using System;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsKeyAlgorithmExtensionsTests {
+        [Fact]
+        public void FromValue_ReturnsEnum() {
+            var result = DnsKeyAlgorithmExtensions.FromValue(8);
+            Assert.Equal(DnsKeyAlgorithm.RSASHA256, result);
+        }
+
+        [Fact]
+        public void FromValue_Invalid_Throws() {
+            Assert.Throws<ArgumentException>(() => DnsKeyAlgorithmExtensions.FromValue(999));
+        }
+    }
+}

--- a/DnsClientX.Tests/IsValidDnsAddressTests.cs
+++ b/DnsClientX.Tests/IsValidDnsAddressTests.cs
@@ -1,0 +1,23 @@
+using System.Net;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class IsValidDnsAddressTests {
+        private static bool InvokeIsValid(string ip) {
+            MethodInfo method = typeof(SystemInformation).GetMethod("IsValidDnsAddress", BindingFlags.NonPublic | BindingFlags.Static)!;
+            return (bool)method.Invoke(null, new object[] { IPAddress.Parse(ip) })!;
+        }
+
+        [Theory]
+        [InlineData("1.1.1.1", true)]
+        [InlineData("169.254.0.1", false)]
+        [InlineData("127.0.0.1", false)]
+        [InlineData("2001:db8::1", true)]
+        [InlineData("fe80::1", false)]
+        public void ValidatesAddresses(string ip, bool expected) {
+            bool result = InvokeIsValid(ip);
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/DnsClientX.Tests/TaskExtensionsTests.cs
+++ b/DnsClientX.Tests/TaskExtensionsTests.cs
@@ -1,0 +1,35 @@
+using System;
+using DnsClientX;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class TaskExtensionsTests {
+        [Fact]
+        public void RunSync_TaskOfT_ReturnsResult() {
+            var task = Task.FromResult(5);
+            int result = task.RunSync();
+            Assert.Equal(5, result);
+        }
+
+        [Fact]
+        public void RunSync_Task_WaitsForCompletion() {
+            bool ran = false;
+            Task task = Task.Run(() => ran = true);
+            task.RunSync();
+            Assert.True(ran);
+        }
+
+        [Fact]
+        public void RunSync_FuncOfT_ReturnsResult() {
+            int result = ((Func<Task<int>>)(() => Task.FromResult(7))).RunSync();
+            Assert.Equal(7, result);
+        }
+        [Fact]
+        public void RunSync_Func_WaitsForCompletion() {
+            bool ran = false;
+            ((Func<Task>)(() => { ran = true; return Task.CompletedTask; })).RunSync();
+            Assert.True(ran);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add missing tests for `AuditEntry`
- cover `TaskExtensions` utilities
- check `DnsKeyAlgorithmExtensions.FromValue`
- verify logger output via `DebuggingHelpers`
- validate `SystemInformation.IsValidDnsAddress`

## Testing
- `dotnet build --no-restore`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter FullyQualifiedName~AuditEntryTests`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter FullyQualifiedName~TaskExtensionsTests`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter FullyQualifiedName~DnsKeyAlgorithmExtensionsTests`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter FullyQualifiedName~DebuggingHelpersTests`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter FullyQualifiedName~IsValidDnsAddressTests`


------
https://chatgpt.com/codex/tasks/task_e_686b6c07d260832eb8e0cc2c9407beb1