### PR TITLE
Increase unit test coverage

### DIFF
--- a/DnsClientX.Tests/BindFileParserTests.cs
+++ b/DnsClientX.Tests/BindFileParserTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class BindFileParserTests {
+        [Fact]
+        public void ParseZoneFile_ReadsRecordsAndAppliesDefaults() {
+            string file = Path.GetTempFileName();
+            File.WriteAllLines(file, new[] {
+                "$TTL 1800",
+                "example.com. IN A 1.1.1.1",
+                "www 60 IN CNAME example.com.",
+                "badttl -1 IN A 1.1.1.1"
+            });
+
+            var records = BindFileParser.ParseZoneFile(file);
+
+            Assert.Equal(2, records.Count);
+            Assert.Equal("example.com", records[0].Name);
+            Assert.Equal(1800, records[0].TTL);
+            Assert.Equal(DnsRecordType.A, records[0].Type);
+            Assert.Equal("1.1.1.1", records[0].DataRaw);
+            Assert.Equal("www", records[1].Name);
+            Assert.Equal(60, records[1].TTL);
+            Assert.Equal(DnsRecordType.CNAME, records[1].Type);
+            Assert.Equal("example.com.", records[1].DataRaw);
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsQuestionTests.cs
+++ b/DnsClientX.Tests/DnsQuestionTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsQuestionTests {
+        [Fact]
+        public void SettingNameStripsTrailingDotButKeepsOriginal() {
+            var q = new DnsQuestion { Name = "example.com." };
+            Assert.Equal("example.com", q.Name);
+            Assert.Equal("example.com.", q.OriginalName);
+        }
+
+        [Fact]
+        public void SettingNameWithoutDotUnchanged() {
+            var q = new DnsQuestion { Name = "example.com" };
+            Assert.Equal("example.com", q.Name);
+            Assert.Equal("example.com", q.OriginalName);
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsResponseTests.cs
+++ b/DnsClientX.Tests/DnsResponseTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsResponseTests {
+        [Fact]
+        public void AddServerDetailsPopulatesFields() {
+            var response = new DnsResponse {
+                Questions = new[] { new DnsQuestion { Name = "example.com", Type = DnsRecordType.A } },
+                Answers = new[] { new DnsAnswer { Name = "example.com", Type = DnsRecordType.A, TTL = 60, DataRaw = "1.1.1.1" } }
+            };
+            var config = new Configuration("8.8.8.8", DnsRequestFormat.DnsOverHttps);
+
+            response.AddServerDetails(config);
+
+            Assert.Equal(config.Hostname, response.Questions[0].HostName);
+            Assert.Equal(config.BaseUri, response.Questions[0].BaseUri);
+            Assert.Equal(config.RequestFormat, response.Questions[0].RequestFormat);
+            Assert.Equal(config.Port, response.Questions[0].Port);
+            Assert.Single(response.AnswersMinimal);
+            Assert.Equal(config.Port, response.AnswersMinimal[0].Port);
+        }
+
+        [Fact]
+        public void CommentConverterReadsArray() {
+            var json = "[\"a\",\"b\"]";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new CommentConverter());
+            string result = JsonSerializer.Deserialize<string>(json, options)!;
+            Assert.Equal("a; b", result);
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsServiceDiscoveryTests.cs
+++ b/DnsClientX.Tests/DnsServiceDiscoveryTests.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsServiceDiscoveryTests {
+        [Fact]
+        public void PropertiesStoreValues() {
+            var discovery = new DnsServiceDiscovery {
+                ServiceName = "_http._tcp.example.com",
+                Target = "host.example.com",
+                Port = 8080,
+                Priority = 1,
+                Weight = 2,
+                Metadata = new Dictionary<string, string> { { "k", "v" } }
+            };
+
+            Assert.Equal("_http._tcp.example.com", discovery.ServiceName);
+            Assert.Equal("host.example.com", discovery.Target);
+            Assert.Equal(8080, discovery.Port);
+            Assert.Equal(1, discovery.Priority);
+            Assert.Equal(2, discovery.Weight);
+            Assert.Equal("v", discovery.Metadata!["k"]);
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsSrvRecordTests.cs
+++ b/DnsClientX.Tests/DnsSrvRecordTests.cs
@@ -1,0 +1,23 @@
+using System.Net;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsSrvRecordTests {
+        [Fact]
+        public void PropertiesStoreValues() {
+            var record = new DnsSrvRecord {
+                Target = "host.example.com",
+                Port = 443,
+                Priority = 1,
+                Weight = 5,
+                Addresses = new[] { IPAddress.Parse("1.1.1.1") }
+            };
+
+            Assert.Equal("host.example.com", record.Target);
+            Assert.Equal(443, record.Port);
+            Assert.Equal(1, record.Priority);
+            Assert.Equal(5, record.Weight);
+            Assert.Single(record.Addresses!, IPAddress.Parse("1.1.1.1"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for BindFileParser
- test DnsQuestion trimming behaviour
- cover DnsServiceDiscovery and DnsSrvRecord
- add DnsResponse AddServerDetails and CommentConverter tests
- run existing unit tests

## Testing
- `dotnet test --filter "FullyQualifiedName~BindFileParserTests"`
- `dotnet test --filter "FullyQualifiedName~DnsQuestionTests"`
- `dotnet test --filter "FullyQualifiedName~DnsServiceDiscoveryTests"`
- `dotnet test --filter "FullyQualifiedName~DnsSrvRecordTests"`
- `dotnet test --filter "FullyQualifiedName~DnsResponseTests"`
- `dotnet test --filter "$FILTER" --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_686b702cb218832e9da4fec721d22bb3