### PR TITLE
Add extra resolver tests

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveHttp3Tests.cs
+++ b/DnsClientX.Tests/DnsWireResolveHttp3Tests.cs
@@ -1,0 +1,34 @@
+#if NET8_0_OR_GREATER
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireResolveHttp3Tests {
+        private class Http3Handler : HttpMessageHandler {
+            public HttpRequestMessage? Request { get; private set; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                Request = request;
+                byte[] responseBytes = { 0x00, 0x01, 0x81, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(responseBytes) };
+                response.Version = HttpVersion.Version30;
+                return Task.FromResult(response);
+            }
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatHttp3_UsesHttp3() {
+            var handler = new Http3Handler();
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/dns-query") };
+            var config = new Configuration(new Uri("https://example.com/dns-query"), DnsRequestFormat.DnsOverHttp3);
+            var response = await DnsWireResolveHttp3.ResolveWireFormatHttp3(client, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None);
+
+            Assert.Equal(HttpVersion.Version30, handler.Request?.Version);
+            Assert.Equal(DnsResponseCode.NoError, response.Status);
+        }
+    }
+}
+#endif

--- a/DnsClientX.Tests/QueryDnsCancellationTests.cs
+++ b/DnsClientX.Tests/QueryDnsCancellationTests.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class QueryDnsCancellationTests {
+        [Fact]
+        public async Task QueryDns_RootServer_CancelledTask() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                () => ClientX.QueryDns("example.com", DnsRecordType.A, DnsEndpoint.RootServer, cancellationToken: cts.Token));
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolveEdgeCaseTests.cs
+++ b/DnsClientX.Tests/ResolveEdgeCaseTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveEdgeCaseTests {
+        [Fact]
+        public void ResolveAllSync_InvalidName_Throws() {
+            using var client = new ClientX();
+            Assert.Throws<ArgumentNullException>(() => client.ResolveAllSync(string.Empty));
+        }
+
+        [Fact]
+        public async Task ResolveFilter_InvalidName_Throws() {
+            using var client = new ClientX();
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => client.ResolveFilter(string.Empty, DnsRecordType.A, "filter", retryOnTransient: false));
+        }
+
+        [Fact]
+        public async Task ResolveFilterRegex_InvalidName_Throws() {
+            using var client = new ClientX();
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => client.ResolveFilter(string.Empty, DnsRecordType.A, new Regex("test"), retryOnTransient: false));
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolveFilterLineTests.cs
+++ b/DnsClientX.Tests/ResolveFilterLineTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveFilterLineTests {
+        private static DnsAnswer CreateTxt(string data) => new() { Name = "example.com", Type = DnsRecordType.TXT, TTL = 300, DataRaw = data };
+
+        [Fact]
+        public void FilterAnswers_ReturnsMatchingLine() {
+            var client = new ClientX();
+            var method = typeof(ClientX).GetMethod("FilterAnswers", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] { CreateTxt("line1\nline2") };
+            var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, "line2", DnsRecordType.TXT })!;
+            Assert.Single(result);
+            Assert.Equal("line2", result[0].Data);
+        }
+
+        [Fact]
+        public void FilterAnswersRegex_ReturnsMatchingLine() {
+            var client = new ClientX();
+            var method = typeof(ClientX).GetMethod("FilterAnswersRegex", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] { CreateTxt("line1\nline2") };
+            var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, new Regex("line2$"), DnsRecordType.TXT })!;
+            Assert.Single(result);
+            Assert.Equal("line2", result[0].Data);
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolveRootCancellationTests.cs
+++ b/DnsClientX.Tests/ResolveRootCancellationTests.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveRootCancellationTests {
+        [Fact]
+        public async Task ResolveFromRoot_CancelsEarly() {
+            using var client = new ClientX();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var response = await client.ResolveFromRoot("example.com", cancellationToken: cts.Token);
+            Assert.NotEqual(DnsResponseCode.NoError, response.Status);
+            Assert.NotNull(response.Error);
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolveStreamEmptyTests.cs
+++ b/DnsClientX.Tests/ResolveStreamEmptyTests.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveStreamEmptyTests {
+        [Fact]
+        public async Task ResolveStream_NoNames_YieldsNoResults() {
+            using var client = new ClientX(DnsEndpoint.System);
+            var results = new List<DnsResponse>();
+            await foreach (var response in client.ResolveStream(System.Array.Empty<string>(), new[] { DnsRecordType.A }, retryOnTransient: false)) {
+                results.Add(response);
+            }
+            Assert.Empty(results);
+        }
+    }
+}

--- a/DnsClientX.Tests/RootServersTests.cs
+++ b/DnsClientX.Tests/RootServersTests.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class RootServersTests {
+        [Fact]
+        public void RootServersList_HasExpectedCounts() {
+            var servers = RootServers.Servers;
+            Assert.Equal(26, servers.Length);
+            Assert.Equal(13, servers.Count(s => !s.Contains(':')));
+            Assert.Equal(13, servers.Count(s => s.Contains(':')));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test query cancellation for root servers
- validate root server list
- cover invalid inputs for ResolveAll and ResolveFilter
- ensure ResolveStream handles empty names
- verify filtered TXT records and HTTP/3 resolver

## Testing
- `dotnet test --filter FullyQualifiedName~ResolveRootCancellationTests`
- `dotnet test --filter FullyQualifiedName~RootServersTests`
- `dotnet test --filter FullyQualifiedName~ResolveEdgeCaseTests`
- `dotnet test --filter FullyQualifiedName~ResolveStreamEmptyTests`
- `dotnet test --filter FullyQualifiedName~QueryDnsCancellationTests`
- `dotnet test --filter FullyQualifiedName~ResolveFilterLineTests`
- `dotnet test --filter FullyQualifiedName~DnsWireResolveHttp3Tests`
- `dotnet test --filter "FullyQualifiedName~ResolveRootCancellationTests|FullyQualifiedName~RootServersTests|FullyQualifiedName~ResolveEdgeCaseTests|FullyQualifiedName~ResolveStreamEmptyTests|FullyQualifiedName~QueryDnsCancellationTests|FullyQualifiedName~ResolveFilterLineTests|FullyQualifiedName~DnsWireResolveHttp3Tests"`

------
https://chatgpt.com/codex/tasks/task_e_686b76f4fa30832ebfe866f5b42eb88c