### PR TITLE
Fix XML doc warnings

### DIFF
--- a/DnsClientX/Definitions/DnsAnswer.cs
+++ b/DnsClientX/Definitions/DnsAnswer.cs
@@ -121,7 +121,7 @@ namespace DnsClientX {
         /// Some records (mainly TXT) can be split into multiple strings and maximum length of a string is 255 characters.
         /// This method tries to preserve the original format of the data in case user needs to check for that format.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Array of strings representing record data.</returns>
         private string[] ConvertToMultiString() {
             // If we have filtered data, use that instead of the raw data
             string dataToProcess = _filteredData is null ? DataRaw : _filteredData;
@@ -169,7 +169,7 @@ namespace DnsClientX {
         /// <summary>
         /// Converts the data to a string trying to unify the format of the data between different providers
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Record data converted to a unified string format.</returns>
         private string ConvertData() {
             if (DataRaw is null) {
                 return string.Empty;

--- a/DnsClientX/Definitions/DnsAnswerMinimal.cs
+++ b/DnsClientX/Definitions/DnsAnswerMinimal.cs
@@ -75,7 +75,7 @@ namespace DnsClientX {
         /// Converts from DnsAnswer[] to DnsAnswerMinimal[].
         /// </summary>
         /// <param name="dnsAnswers">The DNS answers.</param>
-        /// <returns></returns>
+        /// <returns>Array of minimal DNS answers.</returns>
         public static DnsAnswerMinimal[] ConvertFromDnsAnswer(this DnsAnswer[] dnsAnswers) {
             return dnsAnswers.Select(answer => new DnsAnswerMinimal {
                 Name = answer.Name,

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -115,7 +115,7 @@ namespace DnsClientX {
         /// <summary>
         /// Adds the server details to the DNS questions for output purposes.
         /// </summary>
-        /// <param name="configuration"></param>
+        /// <param name="configuration">Client configuration used when querying.</param>
         internal void AddServerDetails(Configuration configuration) {
             if (Questions == null) {
                 Questions = Array.Empty<DnsQuestion>();

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -22,6 +22,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (dnsEndpoint == DnsEndpoint.RootServer) {
@@ -53,6 +54,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
@@ -70,6 +72,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             if (dnsEndpoint == DnsEndpoint.RootServer) {
@@ -107,6 +110,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
@@ -124,6 +128,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             using var client = new ClientX(dnsUri, requestFormat) {
@@ -150,6 +155,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
@@ -166,6 +172,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             using var client = new ClientX(dnsUri, requestFormat) {
@@ -191,6 +198,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
@@ -208,6 +216,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat) {
@@ -234,6 +243,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
@@ -250,6 +260,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat) {
@@ -275,6 +286,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat) {
@@ -300,6 +312,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
@@ -315,6 +328,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             using var client = new ClientX(endpoint: dnsEndpoint) {
@@ -340,6 +354,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return QueryDns(name, recordType, dnsEndpoint, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();

--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -21,6 +21,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public async Task<DnsAnswer[]> ResolveAll(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             DnsResponse res;
@@ -56,6 +57,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public async Task<DnsAnswer[]> ResolveAll(string name, string filter, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             DnsResponse res;
@@ -93,6 +95,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public async Task<DnsAnswer[]> ResolveAll(string name, Regex regexPattern, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             DnsResponse res;

--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -85,6 +85,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response that matches the filter.</returns>
         public async Task<DnsResponse> ResolveFilter(string name, DnsRecordType type, string filter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false);
@@ -108,6 +109,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response that matches the filter.</returns>
         public async Task<DnsResponse> ResolveFilter(string name, DnsRecordType type, Regex regexFilter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             var response = await Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false);

--- a/DnsClientX/DnsClientX.ResolveFirst.cs
+++ b/DnsClientX/DnsClientX.ResolveFirst.cs
@@ -22,6 +22,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the first DNS answer of the provided type, or null if no such answer exists.</returns>
         public async Task<DnsAnswer?> ResolveFirst(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             DnsResponse res = await Resolve(
@@ -48,6 +49,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The first DNS answer of the provided type, or null if no such answer exists.</returns>
         public DnsAnswer? ResolveFirstSync(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             return ResolveFirst(name, type, requestDnsSec, validateDnsSec, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();

--- a/DnsClientX/DnsClientX.ResolveRoot.cs
+++ b/DnsClientX/DnsClientX.ResolveRoot.cs
@@ -11,6 +11,9 @@ namespace DnsClientX {
         /// Resolves a domain name by iteratively querying root servers
         /// and following NS referrals until an answer is obtained.
         /// </summary>
+        /// <param name="name">Domain name to resolve.</param>
+        /// <param name="type">Record type to resolve.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async Task<DnsResponse> ResolveFromRoot(string name, DnsRecordType type = DnsRecordType.A, CancellationToken cancellationToken = default) {
             var servers = RootServers.Servers.ToArray();
             DnsResponse lastResponse = new();

--- a/DnsClientX/DnsClientX.ResolveStream.cs
+++ b/DnsClientX/DnsClientX.ResolveStream.cs
@@ -11,6 +11,15 @@ namespace DnsClientX {
         /// <summary>
         /// Resolves multiple DNS record types for a single domain name and streams the responses.
         /// </summary>
+        /// <param name="name">Domain name to resolve.</param>
+        /// <param name="types">Record types to resolve.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="returnAllTypes">Whether to return all record types.</param>
+        /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
+        /// <param name="maxRetries">Maximum number of retries.</param>
+        /// <param name="retryDelayMs">Delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async IAsyncEnumerable<DnsResponse> ResolveStream(
             string name,
             DnsRecordType[] types,
@@ -29,6 +38,15 @@ namespace DnsClientX {
         /// <summary>
         /// Resolves multiple domain names for multiple DNS record types and streams the responses.
         /// </summary>
+        /// <param name="names">Domain names to resolve.</param>
+        /// <param name="types">Record types to resolve.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="returnAllTypes">Whether to return all record types.</param>
+        /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
+        /// <param name="maxRetries">Maximum number of retries.</param>
+        /// <param name="retryDelayMs">Delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async IAsyncEnumerable<DnsResponse> ResolveStream(
             string[] names,
             DnsRecordType[] types,
@@ -49,6 +67,15 @@ namespace DnsClientX {
         /// <summary>
         /// Resolves multiple domain names for a single DNS record type and streams the responses.
         /// </summary>
+        /// <param name="names">Domain names to resolve.</param>
+        /// <param name="type">Record type to resolve.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="returnAllTypes">Whether to return all record types.</param>
+        /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
+        /// <param name="maxRetries">Maximum number of retries.</param>
+        /// <param name="retryDelayMs">Delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async IAsyncEnumerable<DnsResponse> ResolveStream(
             string[] names,
             DnsRecordType type,

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -141,6 +141,7 @@ namespace DnsClientX {
         /// <param name="httpVersion">Optional HTTP protocol version.</param>
         /// <param name="ignoreCertificateErrors">Ignore certificate validation errors.</param>
         /// <param name="enableCache">Enable in-memory caching of responses.</param>
+        /// <param name="useTcpFallback">Falls back to TCP when UDP responses are truncated.</param>
         /// <param name="webProxy">Optional HTTP proxy.</param>
         public ClientX(
             DnsEndpoint endpoint = DnsEndpoint.Cloudflare,
@@ -178,6 +179,7 @@ namespace DnsClientX {
         /// <param name="httpVersion">Optional HTTP protocol version.</param>
         /// <param name="ignoreCertificateErrors">Ignore certificate validation errors.</param>
         /// <param name="enableCache">Enable in-memory caching of responses.</param>
+        /// <param name="useTcpFallback">Falls back to TCP when UDP responses are truncated.</param>
         /// <param name="webProxy">Optional HTTP proxy.</param>
         public ClientX(
             string hostname,
@@ -215,6 +217,7 @@ namespace DnsClientX {
         /// <param name="httpVersion">Optional HTTP protocol version.</param>
         /// <param name="ignoreCertificateErrors">Ignore certificate validation errors.</param>
         /// <param name="enableCache">Enable in-memory caching of responses.</param>
+        /// <param name="useTcpFallback">Falls back to TCP when UDP responses are truncated.</param>
         /// <param name="webProxy">Optional HTTP proxy.</param>
         public ClientX(
             Uri baseUri,

--- a/DnsClientX/DnsResponseCache.cs
+++ b/DnsClientX/DnsResponseCache.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 namespace DnsClientX {
     /// <summary>
     /// Simple in-memory cache for <see cref="DnsResponse"/> instances.
+    /// Stores responses together with their expiration times.
     /// </summary>
     internal class DnsResponseCache {
         private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
@@ -53,6 +54,7 @@ namespace DnsClientX {
         /// <param name="key">Cache key.</param>
         /// <param name="response">Response to cache.</param>
         /// <param name="ttl">Time to keep the entry.</param>
+        /// <returns>None.</returns>
         public void Set(string key, DnsResponse response, TimeSpan ttl) {
             var entry = new CacheEntry(response, DateTimeOffset.UtcNow.Add(ttl));
             _cache[key] = entry;

--- a/DnsClientX/Extensions/TaskExtensions.cs
+++ b/DnsClientX/Extensions/TaskExtensions.cs
@@ -38,6 +38,7 @@ namespace DnsClientX {
         /// Executes the provided asynchronous delegate synchronously.
         /// </summary>
         /// <param name="func">Asynchronous delegate to invoke.</param>
+        /// <returns>A task representing the completion of <paramref name="func"/>.</returns>
         public static void RunSync(this Func<Task> func) {
             Task.Run(func).GetAwaiter().GetResult();
         }

--- a/DnsClientX/Logging/InternalLogger.cs
+++ b/DnsClientX/Logging/InternalLogger.cs
@@ -3,7 +3,7 @@ using System;
 namespace DnsClientX;
 
 /// <summary>
-/// Internal logger that allows to write to console, error or wherever else is needed
+/// Internal logger that allows writing diagnostic information to various sinks.
 /// </summary>
 public class InternalLogger {
     private readonly object _lock = new object();

--- a/DnsClientX/Security/RootTrustAnchors.cs
+++ b/DnsClientX/Security/RootTrustAnchors.cs
@@ -1,4 +1,7 @@
 namespace DnsClientX {
+    /// <summary>
+    /// Represents a DNSSEC DS record used as a trust anchor.
+    /// </summary>
     internal readonly struct RootDsRecord {
         public ushort KeyTag { get; }
         public DnsKeyAlgorithm Algorithm { get; }
@@ -13,6 +16,9 @@ namespace DnsClientX {
         }
     }
 
+    /// <summary>
+    /// Provides built-in DNSSEC trust anchors for the root zone.
+    /// </summary>
     internal static class RootTrustAnchors {
         internal static readonly RootDsRecord[] DsRecords = {
             new RootDsRecord(20326, DnsKeyAlgorithm.RSASHA256, 2, "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"),


### PR DESCRIPTION
## Summary
- document optional TCP fallback parameter
- add missing cancellation token param docs
- clarify streaming helpers and internal logger
- improve DNS answer helper docs
- expand DNSSEC trust anchor documentation

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686b95c452d4832eb444cda99dae6c8a