### PR TITLE
Add docs for missing public members

### DIFF
--- a/DnsClientX.Benchmarks/DomainBenchmark.cs
+++ b/DnsClientX.Benchmarks/DomainBenchmark.cs
@@ -3,11 +3,15 @@ using BenchmarkDotNet.Attributes;
 
 namespace DnsClientX.Benchmarks;
 
+/// <summary>
+/// Benchmark suite measuring query performance over different transports.
+/// </summary>
 [MemoryDiagnoser]
 public class DomainBenchmark {
     private readonly string[] _domains = ["google.com", "github.com", "cloudflare.com"];
 
     [Benchmark]
+    /// <summary>Benchmark querying over UDP.</summary>
     public async Task Udp() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverUDP);
@@ -15,6 +19,7 @@ public class DomainBenchmark {
     }
 
     [Benchmark]
+    /// <summary>Benchmark querying over TCP.</summary>
     public async Task Tcp() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverTCP);
@@ -22,6 +27,7 @@ public class DomainBenchmark {
     }
 
     [Benchmark]
+    /// <summary>Benchmark querying over TLS.</summary>
     public async Task Dot() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverTLS);
@@ -29,6 +35,7 @@ public class DomainBenchmark {
     }
 
     [Benchmark]
+    /// <summary>Benchmark querying over HTTPS.</summary>
     public async Task Doh() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverHttps);
@@ -36,6 +43,7 @@ public class DomainBenchmark {
     }
 
     [Benchmark]
+    /// <summary>Benchmark querying over QUIC.</summary>
     public async Task Doq() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverQuic);

--- a/DnsClientX.Benchmarks/Program.cs
+++ b/DnsClientX.Benchmarks/Program.cs
@@ -1,4 +1,11 @@
 using BenchmarkDotNet.Running;
 using DnsClientX.Benchmarks;
 
-BenchmarkRunner.Run<DomainBenchmark>();
+/// <summary>
+/// Entry point for running performance benchmarks.
+/// </summary>
+internal class Program {
+    private static void Main() {
+        BenchmarkRunner.Run<DomainBenchmark>();
+    }
+}

--- a/DnsClientX.Examples/DemoDnsAnswer.cs
+++ b/DnsClientX.Examples/DemoDnsAnswer.cs
@@ -7,7 +7,11 @@ using DnsClientX;
 
 namespace DnsClientX.Examples;
 
+/// <summary>
+/// Example demonstrating DNS answer parsing helpers.
+/// </summary>
 internal class DemoDnsAnswer {
+    /// <summary>Runs the demo.</summary>
     public static async Task ExampleDnsAnswerParsing() {
         var dkimRecord = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
         var answer = new DnsAnswer {

--- a/DnsClientX.Examples/DemoResolve.cs
+++ b/DnsClientX.Examples/DemoResolve.cs
@@ -3,7 +3,11 @@ using System.Threading.Tasks;
 using Spectre.Console;
 
 namespace DnsClientX.Examples {
+    /// <summary>
+    /// Example illustrating how to resolve multiple record types from various DNS providers.
+    /// </summary>
     internal class DemoResolve {
+        /// <summary>Runs the demo.</summary>
         public static async Task Example() {
             var dnsEndpoints = new List<DnsEndpoint> {
                 DnsEndpoint.Cloudflare,

--- a/DnsClientX.Tests/ConfigurationOverrideTests.cs
+++ b/DnsClientX.Tests/ConfigurationOverrideTests.cs
@@ -4,6 +4,9 @@ using System.Reflection;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for overriding <see cref="Configuration"/> properties.
+    /// </summary>
     public class ConfigurationOverrideTests {
         [Fact]
         public void ShouldOverrideUserAgent() {

--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests ensuring proper disposal of internal resources.
+    /// </summary>
     public class DisposeTests {
         private class TrackingHandler : HttpClientHandler {
             public int DisposeCount { get; private set; }

--- a/DnsClientX.Tests/DnsKeyAlgorithmExtensionsTests.cs
+++ b/DnsClientX.Tests/DnsKeyAlgorithmExtensionsTests.cs
@@ -2,6 +2,9 @@ using System;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for <see cref="DnsKeyAlgorithmExtensions"/> utilities.
+    /// </summary>
     public class DnsKeyAlgorithmExtensionsTests {
         [Fact]
         public void FromValue_ReturnsEnum() {

--- a/DnsClientX.Tests/EcsOptionTests.cs
+++ b/DnsClientX.Tests/EcsOptionTests.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for EDNS Client Subnet option handling.
+    /// </summary>
     public class EcsOptionTests {
         private static byte[] CreateDnsHeader() {
             byte[] bytes = new byte[12];

--- a/DnsClientX.Tests/ParseBindFileTests.cs
+++ b/DnsClientX.Tests/ParseBindFileTests.cs
@@ -5,6 +5,9 @@ using System.Reflection;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Unit tests for <see cref="BindFileParser"/> helpers.
+    /// </summary>
     public class ParseBindFileTests {
         [Fact]
         public void MissingFile_ReturnsEmptyList() {

--- a/DnsClientX.Tests/ResolveFromRootTests.cs
+++ b/DnsClientX.Tests/ResolveFromRootTests.cs
@@ -2,6 +2,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests verifying resolution starting at DNS root servers.
+    /// </summary>
     public class ResolveFromRootTests {
         [Fact(Skip = "External dependency - requires root servers")] // network unreachable in CI
         public async Task ShouldResolveARecordFromRoot() {

--- a/DnsClientX.Tests/ResolveServiceAsyncTests.cs
+++ b/DnsClientX.Tests/ResolveServiceAsyncTests.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for <see cref="ClientX.ResolveServiceAsync"/> helper.
+    /// </summary>
     public class ResolveServiceAsyncTests {
         [Fact]
         public async Task ShouldOrderByPriorityAndWeight() {

--- a/DnsClientX/BindFileParser.cs
+++ b/DnsClientX/BindFileParser.cs
@@ -4,7 +4,16 @@ using System.IO;
 using System.Linq;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Helper class capable of parsing simplified BIND style zone files.
+    /// </summary>
     internal static class BindFileParser {
+        /// <summary>
+        /// Parses a BIND zone file and returns DNS answers found in the file.
+        /// </summary>
+        /// <param name="path">Path to the zone file on disk.</param>
+        /// <param name="debugPrint">Optional callback for debug information.</param>
+        /// <returns>List of parsed <see cref="DnsAnswer"/> objects.</returns>
         internal static List<DnsAnswer> ParseZoneFile(string path, Action<string>? debugPrint = null) {
             var records = new List<DnsAnswer>();
 

--- a/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
+++ b/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
@@ -5,7 +5,22 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Extension helpers for resolving DNS queries using HTTP/2 transport.
+    /// </summary>
     internal static class DnsWireResolveHttp2 {
+        /// <summary>
+        /// Performs a DNS-over-HTTP/2 query and deserializes the wire format response.
+        /// </summary>
+        /// <param name="client">HTTP client preconfigured for the DNS endpoint.</param>
+        /// <param name="name">Domain name to query.</param>
+        /// <param name="type">Record type to query.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="debug">Enable detailed logging.</param>
+        /// <param name="endpointConfiguration">Endpoint configuration details.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Parsed <see cref="DnsResponse"/> from the server.</returns>
         internal static async Task<DnsResponse> ResolveWireFormatHttp2(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -5,7 +5,22 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX {
+    /// <summary>
+    /// Extension helpers for performing DNS queries over HTTP/3.
+    /// </summary>
     internal static class DnsWireResolveHttp3 {
+        /// <summary>
+        /// Executes a DNS query using HTTP/3 transport and deserializes the result.
+        /// </summary>
+        /// <param name="client">HTTP client configured for the DNS endpoint.</param>
+        /// <param name="name">Domain name to query.</param>
+        /// <param name="type">Record type to query.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="debug">Enable detailed logging.</param>
+        /// <param name="endpointConfiguration">Endpoint configuration details.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Parsed <see cref="DnsResponse"/> instance.</returns>
         internal static async Task<DnsResponse> ResolveWireFormatHttp3(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -12,8 +12,25 @@ using System.Threading.Tasks;
 namespace DnsClientX {
 #if NET8_0_OR_GREATER
     #pragma warning disable CA2252
+    /// <summary>
+    /// Helper methods for resolving DNS queries over QUIC transport.
+    /// </summary>
     internal static class DnsWireResolveQuic {
+        /// <summary>Custom DNS host name resolution delegate used during tests.</summary>
         internal static Func<string, IPHostEntry>? HostEntryResolver;
+        /// <summary>
+        /// Executes a DNS-over-QUIC query and returns the parsed response.
+        /// </summary>
+        /// <param name="dnsServer">Target DNS server.</param>
+        /// <param name="port">QUIC port to use.</param>
+        /// <param name="name">Domain name to query.</param>
+        /// <param name="type">Record type to query.</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="debug">Enable detailed logging.</param>
+        /// <param name="endpointConfiguration">Endpoint configuration details.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Parsed <see cref="DnsResponse"/> from the server.</returns>
         internal static async Task<DnsResponse> ResolveWireFormatQuic(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 

--- a/DnsClientX/Security/RootTrustAnchors.cs
+++ b/DnsClientX/Security/RootTrustAnchors.cs
@@ -1,8 +1,15 @@
 namespace DnsClientX {
+    /// <summary>
+    /// Represents a DNSSEC DS record used as a trust anchor.
+    /// </summary>
     internal readonly struct RootDsRecord {
+        /// <summary>Key tag of the DNSKEY record.</summary>
         public ushort KeyTag { get; }
+        /// <summary>DNSKEY algorithm identifier.</summary>
         public DnsKeyAlgorithm Algorithm { get; }
+        /// <summary>Digest type as defined by RFC 4034.</summary>
         public byte DigestType { get; }
+        /// <summary>Hex-encoded digest value.</summary>
         public string Digest { get; }
 
         public RootDsRecord(ushort keyTag, DnsKeyAlgorithm algorithm, byte digestType, string digest) {
@@ -13,7 +20,11 @@ namespace DnsClientX {
         }
     }
 
+    /// <summary>
+    /// Collection of built-in root trust anchors for DNSSEC validation.
+    /// </summary>
     internal static class RootTrustAnchors {
+        /// <summary>Default DS records for the DNS root.</summary>
         internal static readonly RootDsRecord[] DsRecords = {
             new RootDsRecord(20326, DnsKeyAlgorithm.RSASHA256, 2, "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"),
             new RootDsRecord(38696, DnsKeyAlgorithm.RSASHA256, 2, "683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16")


### PR DESCRIPTION
## Summary
- document zone file parser helper
- add documentation to HTTP/2, HTTP/3 and QUIC resolvers
- document root trust anchors
- document benchmarks and example demos
- document several unit test classes

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686b98e36268832eb0e855d9643c81f5