### PR TITLE
Fix missing XML doc param tags

### DIFF
--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -132,6 +132,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public DnsAnswer[] ResolveAllSync(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return ResolveAll(name, type, requestDnsSec, validateDnsSec, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
@@ -149,6 +150,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public DnsAnswer[] ResolveAllSync(string name, string filter, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return ResolveAll(name, filter, type, requestDnsSec, validateDnsSec, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
@@ -166,6 +168,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of all DNS answers of the provided type.</returns>
         public DnsAnswer[] ResolveAllSync(string name, Regex regexPattern, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
             return ResolveAll(name, regexPattern, type, requestDnsSec, validateDnsSec, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();

--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -22,6 +22,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS responses that match the filter.</returns>
         public async Task<DnsResponse[]> ResolveFilter(string[] names, DnsRecordType type, string filter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             var tasks = names.Select(name => Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken)).ToList();
@@ -53,6 +54,7 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS responses that match the filter.</returns>
         public async Task<DnsResponse[]> ResolveFilter(string[] names, DnsRecordType type, Regex regexFilter, bool requestDnsSec = false, bool validateDnsSec = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             var tasks = names.Select(name => Resolve(name, type, requestDnsSec, validateDnsSec, false, retryOnTransient, maxRetries, retryDelayMs, cancellationToken)).ToList();

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -20,6 +20,7 @@ namespace DnsClientX {
         /// <param name="validateDnsSec">if set to <c>true</c> [validate DNS sec].</param>
         /// <param name="debug">if set to <c>true</c> [debug].</param>
         /// <param name="endpointConfiguration">Configuration used for server details.</param>
+        /// <param name="ignoreCertificateErrors">Ignore certificate validation errors.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         /// <exception cref="System.ArgumentNullException">name - Name is null or empty.</exception>


### PR DESCRIPTION
## Summary
- add missing `<param>` tags for `cancellationToken` in `ResolveAllSync` overloads
- add missing `<param>` tags in `ResolveFilter` helper
- document `ignoreCertificateErrors` in `DnsWireResolveDot`

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686b9b18245c832eb0631a2e22765b9a