### PR TITLE
Fix nullable warnings

### DIFF
--- a/DnsClientX.Examples/DemoDnsAnswer.cs
+++ b/DnsClientX.Examples/DemoDnsAnswer.cs
@@ -13,6 +13,7 @@ namespace DnsClientX.Examples;
 internal class DemoDnsAnswer {
     /// <summary>Runs the demo.</summary>
     public static async Task ExampleDnsAnswerParsing() {
+        await Task.CompletedTask;
         var dkimRecord = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
         var answer = new DnsAnswer {
             DataRaw = dkimRecord,

--- a/DnsClientX.Examples/DnsClientX.Examples.csproj
+++ b/DnsClientX.Examples/DnsClientX.Examples.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net8.0</TargetFrameworks>
         <LangVersion>Latest</LangVersion>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DnsClientX.Examples/Program.cs
+++ b/DnsClientX.Examples/Program.cs
@@ -18,35 +18,35 @@ namespace DnsClientX.Examples {
             await DemoServiceDiscovery.Example();
 
             //await DemoQuery.ExampleTXTAll();
-            return;
-            await DemoQuery.ExampleTXT();
-            await DemoQuery.ExampleSPF();
-            await DemoQuery.ExampleTXTQuad();
-            await DemoQuery.ExampleSPFQuad();
+            //await DemoQuery.ExampleTXT();
+            //await DemoQuery.ExampleSPF();
+            //await DemoQuery.ExampleTXTQuad();
+            //await DemoQuery.ExampleSPFQuad();
             return;
 
+            // The lines below are retained for reference and intentionally
+            // disabled to avoid unreachable code warnings.
             // await ConvertToDnsClient.ExampleConvertToDnsClientFromX();
             // await ConvertToDnsClient.ExampleConvertFromDnsClientToX();
-            //await DemoQuery.ExampleTesting();
-            //await DemoByManualUrl.ExampleTesting();
-            //await DemoByManualUrl.ExampleTestingHttpOverPost();
-            //await DemoByManualUrl.ExampleTestingUdp();
-            //await DemoByManualUrl.ExampleTestingTcp();
-            //await DemoByManualUrl.ExampleGoogle();
+            // await DemoQuery.ExampleTesting();
+            // await DemoByManualUrl.ExampleTesting();
+            // await DemoByManualUrl.ExampleTestingHttpOverPost();
+            // await DemoByManualUrl.ExampleTestingUdp();
+            // await DemoByManualUrl.ExampleTestingTcp();
+            // await DemoByManualUrl.ExampleGoogle();
 
-            //await GetSystemDns.Example1();
-            //await DemoQuery.Example0();
-            //await DemoQuery.ExampleTLSA();
+            // await GetSystemDns.Example1();
+            // await DemoQuery.Example0();
+            // await DemoQuery.ExampleTLSA();
 
-            await DemoResolveUdpTcp.ExampleTestingUdpWrongServer();
-            await DemoResolveUdpTcp.ExampleTestingUdpWrongServer1();
+            // await DemoResolveUdpTcp.ExampleTestingUdpWrongServer();
+            // await DemoResolveUdpTcp.ExampleTestingUdpWrongServer1();
 
-            return;
-            await DemoQuery.Example1();
-            await DemoQuery.ExampleGoogleOverWire();
-            await DemoQuery.ExampleGoogleOverWirePost();
-            await DemoQuery.ExampleCloudflareSelection();
-            //await DemoQuery.ExampleSystemDns();
+            // await DemoQuery.Example1();
+            // await DemoQuery.ExampleGoogleOverWire();
+            // await DemoQuery.ExampleGoogleOverWirePost();
+            // await DemoQuery.ExampleCloudflareSelection();
+            // await DemoQuery.ExampleSystemDns();
 
 
 

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -75,7 +75,12 @@ namespace DnsClientX {
         /// Disposes managed resources asynchronously when possible.
         /// </summary>
         /// <returns>A task representing the asynchronous disposal.</returns>
+#if !(NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER)
         protected virtual async ValueTask DisposeAsyncCore() {
+            await Task.CompletedTask;
+#else
+        protected virtual async ValueTask DisposeAsyncCore() {
+#endif
             if (!_disposed) {
                 HttpClientHandler? handlerLocal;
                 List<HttpClient> clients;
@@ -134,6 +139,9 @@ namespace DnsClientX {
             }
         }
 
+        /// <summary>
+        /// Finalizer to ensure unmanaged resources are released.
+        /// </summary>
         ~ClientX() {
             Dispose(disposing: false);
         }

--- a/DnsClientX/DnsClientX.ResolveFirst.cs
+++ b/DnsClientX/DnsClientX.ResolveFirst.cs
@@ -13,7 +13,7 @@ namespace DnsClientX {
         /// <summary>
         /// Resolves a domain name using DNS over HTTPS and returns the first answer of the provided type.
         /// This helper method is useful when you only need the first answer of a specific type.
-        /// Alternatively, <see cref="Resolve(string, DnsRecordType, bool, bool, bool, bool, int, int)"/> may be used to get full control over the response.
+        /// Alternatively, <see cref="Resolve(string, DnsRecordType, bool, bool, bool, bool, int, int, CancellationToken)"/> may be used to get full control over the response.
         /// </summary>
         /// <param name="name">The fully qualified domain name (FQDN) to resolve. Example: <c>foo.bar.example.com</c></param>
         /// <param name="type">The DNS resource type to resolve. By default, this is the <c>A</c> record.</param>

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -25,6 +25,7 @@
         <Authors>Przemyslaw Klys</Authors>
 
         <LangVersion>Latest</LangVersion>
+        <Nullable>enable</Nullable>
 
         <PackageId>DnsClientX</PackageId>
         <PackageIcon>DnsClientX.png</PackageIcon>


### PR DESCRIPTION
## Summary
- enable nullable reference types in main library and examples
- update async disposal to avoid CS1998
- add destructor documentation
- fix cref comment in `ResolveFirst`
- cleanup example `Program` to avoid unreachable code warnings
- silence analyzer warning in example `DemoDnsAnswer`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: DNS tests cannot reach servers)*

------
https://chatgpt.com/codex/tasks/task_e_686b9d4857cc832ea0da2fcbad989df2