### PR TITLE
Handle empty custom hostnames

### DIFF
--- a/DnsClientX.Tests/ConfigurationOverrideTests.cs
+++ b/DnsClientX.Tests/ConfigurationOverrideTests.cs
@@ -37,14 +37,8 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
-        public void CustomEndpoint_ShouldAllowOverrides() {
-            using var client = new ClientX(DnsEndpoint.Custom);
-            client.EndpointConfiguration.Hostname = "1.1.1.1";
-            client.EndpointConfiguration.RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
-            client.EndpointConfiguration.BaseUri = new Uri($"https://{client.EndpointConfiguration.Hostname}/dns-query");
-
-            Assert.Equal("1.1.1.1", client.EndpointConfiguration.Hostname);
-            Assert.Equal(new Uri("https://1.1.1.1/dns-query"), client.EndpointConfiguration.BaseUri);
+        public void CustomEndpoint_ShouldThrowWhenNoHostnameProvided() {
+            Assert.Throws<ArgumentException>(() => new Configuration(DnsEndpoint.Custom));
         }
     }
 }

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -353,6 +353,10 @@ namespace DnsClientX {
                 default:
                     throw new ArgumentException("Invalid endpoint", nameof(endpoint));
             }
+
+            if (endpoint == DnsEndpoint.Custom && hostnames.Count == 0) {
+                throw new ArgumentException("At least one hostname must be specified for a custom endpoint.", nameof(endpoint));
+            }
             // Select a hostname based on the selection strategy
             this.hostnames = hostnames;
             this.baseUriFormat = baseUriFormat;


### PR DESCRIPTION
## Summary
- validate custom endpoint hostnames during configuration
- test that using `DnsEndpoint.Custom` without a hostname throws

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bac0f6b28832e9c4698d42b80e133