### PR TITLE
Add timeout validation to Resolve-Dns cmdlet

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -145,6 +145,9 @@ namespace DnsClientX.PowerShell {
         /// </summary>
         /// <returns></returns>
         protected override async Task ProcessRecordAsync() {
+            if (TimeOut <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(TimeOut), "TimeOut must be greater than zero.");
+            }
             string names = string.Join(", ", Name);
             string types = string.Join(", ", Type);
             if (Server.Count > 0) {

--- a/Module/Tests/ResolveDns.Tests.ps1
+++ b/Module/Tests/ResolveDns.Tests.ps1
@@ -1,0 +1,7 @@
+Import-Module "$PSScriptRoot/../DnsClientX.psd1" -Force
+
+Describe 'Resolve-Dns cmdlet' {
+    It 'Fails when TimeOut is less than or equal to zero' {
+        { Resolve-Dns -Name 'example.com' -TimeOut 0 -ErrorAction Stop } | Should -Throw -ExceptionType System.ArgumentOutOfRangeException
+    }
+}


### PR DESCRIPTION
## Summary
- validate `TimeOut` parameter in `Resolve-Dns` cmdlet
- add Pester test for timeout validation

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: Network is unreachable)*
- `dotnet build DnsClientX.PowerShell/DnsClientX.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -Command "& { ./Module/DnsClientX.Tests.ps1 }"`

------
https://chatgpt.com/codex/tasks/task_e_686bac2f5858832ea6da57285c106a4d