### PR TITLE
Fix hostname selection randomness

### DIFF
--- a/DnsClientX.Tests/SelectHostNameStrategyConcurrencyTests.cs
+++ b/DnsClientX.Tests/SelectHostNameStrategyConcurrencyTests.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class SelectHostNameStrategyConcurrencyTests {
+        [Fact]
+        public async Task ShouldHandleConcurrentHostSelection() {
+            var config = new Configuration(DnsEndpoint.Cloudflare, DnsSelectionStrategy.Random);
+
+            var tasks = Enumerable.Range(0, 20)
+                .Select(_ => Task.Run(() => {
+                    for (int i = 0; i < 50; i++) {
+                        config.SelectHostNameStrategy();
+                        Assert.Contains(config.Hostname, new[] { "1.1.1.1", "1.0.0.1" });
+                    }
+                }));
+
+            await Task.WhenAll(tasks);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use `Random.Shared` in Configuration.SelectHostNameStrategy
- allow older frameworks to keep thread-safety with locked `Random`
- test concurrent hostname selection

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --filter FullyQualifiedName~SelectHostNameStrategyConcurrencyTests --verbosity minimal`
- ❌ `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -f net472 --filter FullyQualifiedName~SelectHostNameStrategyConcurrencyTests --verbosity minimal` *(fails: reference assemblies for .NETFramework not found)*


------
https://chatgpt.com/codex/tasks/task_e_686bac08fd0c832ea05a0ec96ee8bfc7