### PR TITLE
Add async streaming for service discovery

### DIFF
--- a/DnsClientX.Examples/DemoServiceDiscovery.cs
+++ b/DnsClientX.Examples/DemoServiceDiscovery.cs
@@ -13,10 +13,9 @@ namespace DnsClientX.Examples {
         }
 
         public static async Task ExampleEnumerate() {
-            using (var client = new ClientX(DnsEndpoint.Cloudflare)) {
-                await foreach (var r in client.EnumerateServicesAsync("example.com")) {
-                    Console.WriteLine($"{r.ServiceName} -> {r.Target}:{r.Port}");
-                }
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            await foreach (var r in client.EnumerateServicesAsync("example.com")) {
+                Console.WriteLine($"{r.ServiceName} -> {r.Target}:{r.Port}");
             }
         }
     }

--- a/DnsClientX.Examples/DemoServiceDiscovery.cs
+++ b/DnsClientX.Examples/DemoServiceDiscovery.cs
@@ -11,5 +11,13 @@ namespace DnsClientX.Examples {
                 }
             }
         }
+
+        public static async Task ExampleEnumerate() {
+            using (var client = new ClientX(DnsEndpoint.Cloudflare)) {
+                await foreach (var r in client.EnumerateServicesAsync("example.com")) {
+                    Console.WriteLine($"{r.ServiceName} -> {r.Target}:{r.Port}");
+                }
+            }
+        }
     }
 }

--- a/DnsClientX.Examples/DemoServiceDiscovery.cs
+++ b/DnsClientX.Examples/DemoServiceDiscovery.cs
@@ -12,6 +12,10 @@ namespace DnsClientX.Examples {
             }
         }
 
+        /// <summary>
+        /// Demonstrates streaming discovery where results are printed as soon as
+        /// they are available.
+        /// </summary>
         public static async Task ExampleEnumerate() {
             using var client = new ClientX(DnsEndpoint.Cloudflare);
             await foreach (var r in client.EnumerateServicesAsync("example.com")) {

--- a/DnsClientX.Examples/Program.cs
+++ b/DnsClientX.Examples/Program.cs
@@ -16,6 +16,7 @@ namespace DnsClientX.Examples {
 
             await DemoDnsAnswer.ExampleDnsAnswerParsing();
             await DemoServiceDiscovery.Example();
+            await DemoServiceDiscovery.ExampleEnumerate();
 
             //await DemoQuery.ExampleTXTAll();
             //await DemoQuery.ExampleTXT();

--- a/DnsClientX.Tests/EnumerateServicesAsyncTests.cs
+++ b/DnsClientX.Tests/EnumerateServicesAsyncTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class EnumerateServicesAsyncTests {
+        [Fact]
+        public async Task ShouldStreamServices() {
+            var ptrResponse = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer { Name = "_services._dns-sd._udp.example.com", Type = DnsRecordType.PTR, DataRaw = "_http._tcp.example.com." }
+                }
+            };
+            var srvResponse = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer { Name = "_http._tcp.example.com", Type = DnsRecordType.SRV, DataRaw = "0 0 80 host.example.com." }
+                }
+            };
+            var txtResponse = new DnsResponse {
+                Answers = new[] {
+                    new DnsAnswer { Name = "_http._tcp.example.com", Type = DnsRecordType.TXT, DataRaw = "path=/" }
+                }
+            };
+
+            using var client = new ClientX(DnsEndpoint.System);
+            client.ResolverOverride = (name, type, ct) => {
+                if (name == "_services._dns-sd._udp.example.com" && type == DnsRecordType.PTR) return Task.FromResult(ptrResponse);
+                if (name == "_http._tcp.example.com" && type == DnsRecordType.SRV) return Task.FromResult(srvResponse);
+                if (name == "_http._tcp.example.com" && type == DnsRecordType.TXT) return Task.FromResult(txtResponse);
+                return Task.FromResult(new DnsResponse { Answers = Array.Empty<DnsAnswer>() });
+            };
+
+            var results = new List<DnsServiceDiscovery>();
+            await foreach (var r in client.EnumerateServicesAsync("example.com", CancellationToken.None)) {
+                results.Add(r);
+            }
+
+            Assert.Single(results);
+            var service = results[0];
+            Assert.Equal("_http._tcp.example.com", service.ServiceName);
+            Assert.Equal("host.example.com", service.Target);
+            Assert.Equal(80, service.Port);
+            Assert.True(service.Metadata != null && service.Metadata["path"] == "/");
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.ServiceDiscovery.cs
+++ b/DnsClientX/DnsClientX.ServiceDiscovery.cs
@@ -87,7 +87,10 @@ namespace DnsClientX {
         /// </summary>
         /// <param name="domain">Domain name to look up for advertised services.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
-        /// <returns>An asynchronous enumeration of discovered services.</returns>
+        /// <returns>
+        /// An asynchronous enumeration of <see cref="DnsServiceDiscovery"/> instances
+        /// returned as soon as each service record is processed.
+        /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="domain"/> is null or whitespace.</exception>
         public async IAsyncEnumerable<DnsServiceDiscovery> EnumerateServicesAsync(
             string domain,

--- a/DnsClientX/DnsClientX.ServiceDiscovery.cs
+++ b/DnsClientX/DnsClientX.ServiceDiscovery.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -79,6 +80,60 @@ namespace DnsClientX {
             }
 
             return results.ToArray();
+        }
+
+        /// <summary>
+        /// Streams DNS-SD services discovered under the specified domain.
+        /// </summary>
+        /// <param name="domain">Domain name to look up for advertised services.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>An asynchronous enumeration of discovered services.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="domain"/> is null or whitespace.</exception>
+        public async IAsyncEnumerable<DnsServiceDiscovery> EnumerateServicesAsync(
+            string domain,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(domain)) throw new ArgumentNullException(nameof(domain));
+            string ptrQuery = $"_services._dns-sd._udp.{domain}";
+            var ptrResponse = await ResolveForSd(ptrQuery, DnsRecordType.PTR, cancellationToken).ConfigureAwait(false);
+            if (ptrResponse.Answers == null) yield break;
+
+            foreach (var ptr in ptrResponse.Answers.Where(a => a.Type == DnsRecordType.PTR)) {
+                string serviceDomain = ptr.Data.TrimEnd('.');
+                var srvResponse = await ResolveForSd(serviceDomain, DnsRecordType.SRV, cancellationToken).ConfigureAwait(false);
+                var txtResponse = await ResolveForSd(serviceDomain, DnsRecordType.TXT, cancellationToken).ConfigureAwait(false);
+
+                var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var txt in txtResponse.Answers?.Where(a => a.Type == DnsRecordType.TXT) ?? Array.Empty<DnsAnswer>()) {
+                    foreach (string part in txt.DataStringsEscaped) {
+                        var idx = part.IndexOf('=');
+                        if (idx > 0) {
+                            string key = part.Substring(0, idx);
+                            string val = part.Substring(idx + 1);
+                            metadata[key] = val;
+                        } else {
+                            metadata[part] = string.Empty;
+                        }
+                    }
+                }
+
+                foreach (var srv in srvResponse.Answers?.Where(a => a.Type == DnsRecordType.SRV) ?? Array.Empty<DnsAnswer>()) {
+                    var bits = srv.Data.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (bits.Length == 4 &&
+                        int.TryParse(bits[0], out int priority) &&
+                        int.TryParse(bits[1], out int weight) &&
+                        int.TryParse(bits[2], out int port)) {
+                        string target = bits[3].TrimEnd('.');
+                        yield return new DnsServiceDiscovery {
+                            ServiceName = serviceDomain,
+                            Target = target,
+                            Port = port,
+                            Priority = priority,
+                            Weight = weight,
+                            Metadata = metadata.Count > 0 ? new Dictionary<string, string>(metadata) : null
+                        };
+                    }
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add `EnumerateServicesAsync` for streaming DNS‑SD results
- demonstrate streaming service discovery in examples
- test streaming service discovery

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `dotnet test` *(fails: HttpConnectionPool.ConnectToTcpHostAsync errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bb19b01f4832e8bf8c762901c9d35