### PR TITLE
Add ResolveAsyncEnumerable method

### DIFF
--- a/DnsClientX.Examples/DemoResolveAsyncEnumerable.cs
+++ b/DnsClientX.Examples/DemoResolveAsyncEnumerable.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates resolving DNS queries concurrently using <see cref="ClientX.ResolveAsyncEnumerable"/>.
+    /// </summary>
+    internal class DemoResolveAsyncEnumerable {
+        /// <summary>Runs the demo.</summary>
+        public static async Task Example() {
+            var names = new[] { "github.com", "microsoft.com" };
+            var types = new[] { DnsRecordType.A, DnsRecordType.MX };
+
+            using var client = new ClientX(DnsEndpoint.System);
+
+            await foreach (var response in client.ResolveAsyncEnumerable(names, types, retryOnTransient: false)) {
+                response.DisplayToConsole();
+            }
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolveAsyncEnumerableTests.cs
+++ b/DnsClientX.Tests/ResolveAsyncEnumerableTests.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveAsyncEnumerableTests {
+        [Fact]
+        public async Task ResolveAsyncEnumerable_MultipleResponses() {
+            using var client = new ClientX(DnsEndpoint.System);
+            var names = new[] { "github.com", "microsoft.com" };
+            var types = new[] { DnsRecordType.A, DnsRecordType.MX };
+            int count = 0;
+
+            await foreach (var response in client.ResolveAsyncEnumerable(names, types, retryOnTransient: false)) {
+                Assert.NotNull(response);
+                Assert.NotNull(response.Answers);
+                count++;
+            }
+
+            Assert.Equal(names.Length * types.Length, count);
+        }
+
+        [Fact]
+        public async Task ResolveAsyncEnumerable_EmptyNames_YieldsNothing() {
+            using var client = new ClientX(DnsEndpoint.System);
+            var results = new List<DnsResponse>();
+
+            await foreach (var response in client.ResolveAsyncEnumerable(System.Array.Empty<string>(), new[] { DnsRecordType.A }, retryOnTransient: false)) {
+                results.Add(response);
+            }
+
+            Assert.Empty(results);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.ResolveAsyncEnumerable.cs
+++ b/DnsClientX/DnsClientX.ResolveAsyncEnumerable.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class providing concurrent resolve helpers.
+    /// </summary>
+    public partial class ClientX {
+        /// <summary>
+        /// Resolves multiple DNS record types for a single domain name concurrently and yields responses as they complete.
+        /// </summary>
+        public async IAsyncEnumerable<DnsResponse> ResolveAsyncEnumerable(
+            string name,
+            DnsRecordType[] types,
+            bool requestDnsSec = false,
+            bool validateDnsSec = false,
+            bool returnAllTypes = false,
+            bool retryOnTransient = true,
+            int maxRetries = 3,
+            int retryDelayMs = 200,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            var tasks = new List<Task<DnsResponse>>();
+
+            foreach (DnsRecordType type in types) {
+                tasks.Add(Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, cancellationToken));
+            }
+
+            while (tasks.Count > 0) {
+                Task<DnsResponse> finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+                tasks.Remove(finished);
+                yield return await finished.ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Resolves multiple domain names and DNS record types concurrently and yields responses as they complete.
+        /// </summary>
+        public async IAsyncEnumerable<DnsResponse> ResolveAsyncEnumerable(
+            string[] names,
+            DnsRecordType[] types,
+            bool requestDnsSec = false,
+            bool validateDnsSec = false,
+            bool returnAllTypes = false,
+            bool retryOnTransient = true,
+            int maxRetries = 3,
+            int retryDelayMs = 200,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            var tasks = new List<Task<DnsResponse>>();
+
+            foreach (string n in names) {
+                foreach (DnsRecordType type in types) {
+                    tasks.Add(Resolve(n, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, cancellationToken));
+                }
+            }
+
+            while (tasks.Count > 0) {
+                Task<DnsResponse> finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+                tasks.Remove(finished);
+                yield return await finished.ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Resolves multiple domain names for a single DNS record type concurrently and yields responses as they complete.
+        /// </summary>
+        public async IAsyncEnumerable<DnsResponse> ResolveAsyncEnumerable(
+            string[] names,
+            DnsRecordType type,
+            bool requestDnsSec = false,
+            bool validateDnsSec = false,
+            bool returnAllTypes = false,
+            bool retryOnTransient = true,
+            int maxRetries = 3,
+            int retryDelayMs = 200,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            var tasks = new List<Task<DnsResponse>>();
+
+            foreach (string n in names) {
+                tasks.Add(Resolve(n, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, cancellationToken));
+            }
+
+            while (tasks.Count > 0) {
+                Task<DnsResponse> finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+                tasks.Remove(finished);
+                yield return await finished.ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -503,6 +503,10 @@ foreach (var endpoint in dnsEndpoints) {
     await foreach (var response in client.ResolveStream(domains.ToArray(), recordTypes.ToArray())) {
         response.DisplayToConsole();
     }
+
+    await foreach (var response in client.ResolveAsyncEnumerable(domains.ToArray(), recordTypes.ToArray())) {
+        response.DisplayToConsole();
+    }
 }
 ```
 


### PR DESCRIPTION
## Summary
- add concurrent `ResolveAsyncEnumerable` to stream DNS responses
- demonstrate usage in examples and README
- test `ResolveAsyncEnumerable` enumerations

## Testing
- `dotnet test -c Release --verbosity minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1c5b61c832e80188761a0f72483