### PR TITLE
Add EDNS options support in builder

### DIFF
--- a/DnsClientX.Tests/ClientXBuilderTests.cs
+++ b/DnsClientX.Tests/ClientXBuilderTests.cs
@@ -21,6 +21,17 @@ namespace DnsClientX.Tests {
             var field = typeof(ClientX).GetField("_webProxy", BindingFlags.NonPublic | BindingFlags.Instance)!;
             Assert.Same(proxy, field.GetValue(client));
         }
+
+        [Fact]
+        public void BuildShouldApplyEdnsOptions() {
+            var options = new EdnsOptions { EnableEdns = true, UdpBufferSize = 2048, Subnet = "192.0.2.0/24" };
+
+            using var client = new ClientXBuilder()
+                .WithEdnsOptions(options)
+                .Build();
+
+            Assert.Same(options, client.EndpointConfiguration.EdnsOptions);
+        }
     }
 }
 

--- a/DnsClientX/ClientXBuilder.cs
+++ b/DnsClientX/ClientXBuilder.cs
@@ -8,6 +8,7 @@ namespace DnsClientX {
         private DnsEndpoint _endpoint = DnsEndpoint.Cloudflare;
         private int _timeout = Configuration.DefaultTimeout;
         private IWebProxy? _proxy;
+        private EdnsOptions? _ednsOptions;
 
         /// <summary>
         /// Sets the DNS endpoint to use.
@@ -37,10 +38,23 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Configures EDNS options for DNS queries.
+        /// </summary>
+        /// <param name="options">The EDNS options to apply.</param>
+        public ClientXBuilder WithEdnsOptions(EdnsOptions options) {
+            _ednsOptions = options;
+            return this;
+        }
+
+        /// <summary>
         /// Builds and returns a configured <see cref="ClientX"/> instance.
         /// </summary>
         public ClientX Build() {
-            return new ClientX(_endpoint, DnsSelectionStrategy.First, _timeout, webProxy: _proxy);
+            var client = new ClientX(_endpoint, DnsSelectionStrategy.First, _timeout, webProxy: _proxy);
+            if (_ednsOptions != null) {
+                client.EndpointConfiguration.EdnsOptions = _ednsOptions;
+            }
+            return client;
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the `ClientXBuilder` with `WithEdnsOptions` method
- allow `Build()` to apply EDNS options
- add unit test verifying EDNS options handling

## Testing
- `dotnet test -v minimal` *(fails: `Failed:   140, Passed:   300, Skipped:    15, Total:   455`)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1d15064832e99e32016ebb7b927