### PR TITLE
Add NextDNS endpoint

### DIFF
--- a/DnsClientX.Examples/DemoResolve.cs
+++ b/DnsClientX.Examples/DemoResolve.cs
@@ -20,7 +20,8 @@ namespace DnsClientX.Examples {
                 DnsEndpoint.Quad9ECS,
                 DnsEndpoint.Quad9Unsecure,
                 DnsEndpoint.OpenDNS,
-                DnsEndpoint.OpenDNSFamily
+                DnsEndpoint.OpenDNSFamily,
+                DnsEndpoint.NextDNS
             };
 
             // List of endpoints to exclude

--- a/DnsClientX.Examples/DemoResolveAll.cs
+++ b/DnsClientX.Examples/DemoResolveAll.cs
@@ -22,7 +22,8 @@ namespace DnsClientX.Examples {
                 DnsEndpoint.Quad9ECS,
                 DnsEndpoint.Quad9Unsecure,
                 DnsEndpoint.OpenDNS,
-                DnsEndpoint.OpenDNSFamily
+                DnsEndpoint.OpenDNSFamily,
+                DnsEndpoint.NextDNS
             };
 
             // List of endpoints to exclude

--- a/DnsClientX.Examples/DemoResolveFirst.cs
+++ b/DnsClientX.Examples/DemoResolveFirst.cs
@@ -21,7 +21,8 @@ namespace DnsClientX.Examples {
                 DnsEndpoint.Quad9ECS,
                 DnsEndpoint.Quad9Unsecure,
                 DnsEndpoint.OpenDNS,
-                DnsEndpoint.OpenDNSFamily
+                DnsEndpoint.OpenDNSFamily,
+                DnsEndpoint.NextDNS
             };
 
             // List of endpoints to exclude

--- a/DnsClientX.Examples/DemoResolveParallel.cs
+++ b/DnsClientX.Examples/DemoResolveParallel.cs
@@ -22,7 +22,8 @@ namespace DnsClientX.Examples {
                 DnsEndpoint.Quad9ECS,
                 DnsEndpoint.Quad9Unsecure,
                 DnsEndpoint.OpenDNS,
-                DnsEndpoint.OpenDNSFamily
+                DnsEndpoint.OpenDNSFamily,
+                DnsEndpoint.NextDNS
             };
 
             // List of endpoints to exclude

--- a/DnsClientX.Examples/DemoResolveReturn.cs
+++ b/DnsClientX.Examples/DemoResolveReturn.cs
@@ -23,7 +23,8 @@ namespace DnsClientX.Examples {
                 DnsEndpoint.Quad9ECS,
                 DnsEndpoint.Quad9Unsecure,
                 DnsEndpoint.OpenDNS,
-                DnsEndpoint.OpenDNSFamily
+                DnsEndpoint.OpenDNSFamily,
+                DnsEndpoint.NextDNS
             };
 
             // List of endpoints to exclude

--- a/DnsClientX.Examples/DemoResolveWithFilter.cs
+++ b/DnsClientX.Examples/DemoResolveWithFilter.cs
@@ -24,7 +24,8 @@ namespace DnsClientX.Examples {
                 DnsEndpoint.Quad9ECS,
                 DnsEndpoint.Quad9Unsecure,
                 DnsEndpoint.OpenDNS,
-                DnsEndpoint.OpenDNSFamily
+                DnsEndpoint.OpenDNSFamily,
+                DnsEndpoint.NextDNS
             };
 
             // List of endpoints to exclude
@@ -77,7 +78,8 @@ namespace DnsClientX.Examples {
                 DnsEndpoint.Quad9ECS,
                 DnsEndpoint.Quad9Unsecure,
                 DnsEndpoint.OpenDNS,
-                DnsEndpoint.OpenDNSFamily
+                DnsEndpoint.OpenDNSFamily,
+                DnsEndpoint.NextDNS
             };
 
             // List of endpoints to exclude

--- a/DnsClientX.Tests/NextDnsTests.cs
+++ b/DnsClientX.Tests/NextDnsTests.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class NextDnsTests {
+        [Fact]
+        public async Task ResolveUsingNextDns() {
+            using var client = new ClientX(DnsEndpoint.NextDNS) { Debug = false };
+            var response = await client.Resolve("github.com", DnsRecordType.A);
+            Assert.Equal(DnsResponseCode.NoError, response.Status);
+            Assert.NotNull(response.Answers);
+            Assert.True(response.Answers!.Length > 0);
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -322,6 +322,11 @@ namespace DnsClientX {
                     RequestFormat = DnsRequestFormat.DnsOverHttps;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
+                case DnsEndpoint.NextDNS:
+                    hostnames = new List<string> { "dns.nextdns.io" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
+                    baseUriFormat = "https://{0}/dns-query";
+                    break;
                 case DnsEndpoint.Quad9:
                     hostnames = new List<string> { "dns.quad9.net" };
                     RequestFormat = DnsRequestFormat.DnsOverHttps;

--- a/DnsClientX/Definitions/DnsEndpoint.cs
+++ b/DnsClientX/Definitions/DnsEndpoint.cs
@@ -87,6 +87,10 @@ namespace DnsClientX {
         /// </summary>
         AdGuardNonFiltering,
         /// <summary>
+        /// NextDNS DNS-over-HTTPS endpoint.
+        /// </summary>
+        NextDNS,
+        /// <summary>
         /// Cloudflare DNSCrypt endpoint.
         /// </summary>
         DnsCryptCloudflare,


### PR DESCRIPTION
## Summary
- add `NextDNS` enum constant
- map NextDNS in `Configuration` constructor
- provide NextDNS unit test
- show NextDNS usage in example apps

## Testing
- `dotnet test DnsClientX.sln -c Release` *(fails: network issues)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1dfdb28832e9785ba3f6357dd68