### PR TITLE
Configure Codecov as informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -61,6 +61,7 @@ jobs:
               uses: codecov/codecov-action@v4
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
 
     test-ubuntu:
         name: 'Ubuntu'
@@ -104,6 +105,7 @@ jobs:
               uses: codecov/codecov-action@v4
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
 
     test-macos:
         name: 'macOS'
@@ -147,4 +149,5 @@ jobs:
               uses: codecov/codecov-action@v4
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary
- add Codecov configuration so coverage is informational only
- ensure uploads won't fail CI

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration Release --framework net8.0 --no-build` *(fails: Cannot resolve DNS queries in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_686bb4fbc4f0832eba445715d2b6a152