### PR TITLE
Add endpoint details to DnsClientException

### DIFF
--- a/DnsClientX.Tests/DnsClientExceptionTests.cs
+++ b/DnsClientX.Tests/DnsClientExceptionTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsClientExceptionTests {
+        [Fact]
+        public void MessageIncludesEndpointDetails() {
+            var response = new DnsResponse {
+                Questions = new[] {
+                    new DnsQuestion {
+                        Name = "example.com",
+                        Type = DnsRecordType.A,
+                        HostName = "8.8.8.8",
+                        Port = 53,
+                        RequestFormat = DnsRequestFormat.DnsOverHttps
+                    }
+                },
+                Status = DnsResponseCode.ServerFailure
+            };
+
+            var ex = new DnsClientException("error", response);
+            Assert.Contains("error", ex.Message);
+            Assert.Contains("8.8.8.8", ex.Message);
+            Assert.Contains("53", ex.Message);
+            Assert.Contains(nameof(DnsRequestFormat.DnsOverHttps), ex.Message);
+        }
+
+        [Fact]
+        public void MessageWithoutEndpointDetailsUnchanged() {
+            var response = new DnsResponse { Status = DnsResponseCode.ServerFailure };
+
+            var ex = new DnsClientException("oops", response);
+            Assert.Equal("oops", ex.Message);
+        }
+    }
+}

--- a/DnsClientX/Exception.cs
+++ b/DnsClientX/Exception.cs
@@ -22,8 +22,28 @@ namespace DnsClientX {
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         /// <param name="response">The DNS response that caused this exception.</param>
-        public DnsClientException(string message, DnsResponse response) : base(message) {
+        public DnsClientException(string message, DnsResponse response)
+            : base(FormatMessage(message, response)) {
             Response = response;
+        }
+
+        private static string FormatMessage(string message, DnsResponse response) {
+            if (response?.Questions is { Length: > 0 }) {
+                var q = response.Questions[0];
+                string? host = string.IsNullOrEmpty(q.HostName)
+                    ? q.BaseUri?.Host
+                    : q.HostName;
+                if (!string.IsNullOrEmpty(host) || q.Port != 0 || q.BaseUri != null) {
+                    int port = q.Port != 0 ? q.Port : q.BaseUri?.Port ?? 0;
+                    string endpoint = host ?? string.Empty;
+                    if (port != 0 && (q.BaseUri == null || !q.BaseUri.IsDefaultPort || q.Port != 0)) {
+                        endpoint = string.Concat(endpoint, ":", port);
+                    }
+                    return string.Concat(message, " (Endpoint: ", endpoint, ", ", q.RequestFormat, ")");
+                }
+            }
+
+            return message;
         }
     }
 }


### PR DESCRIPTION
## Summary
- include endpoint details in DnsClientException when response is provided
- add unit tests for message formatting

## Testing
- `dotnet test --verbosity minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bc344110c832e9d93b98d54e67bcc