### PR TITLE
Add HTTP/3 conditional compilation and tests

### DIFF
--- a/DnsClientX.Tests/QueryDnsOverHttp3.cs
+++ b/DnsClientX.Tests/QueryDnsOverHttp3.cs
@@ -1,5 +1,6 @@
-#if DNS_OVER_HTTP3 && NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Threading.Tasks;
+using Xunit;
 
 namespace DnsClientX.Tests {
     public class QueryDnsOverHttp3 {

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -95,7 +95,11 @@ namespace DnsClientX {
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2) {
                     response = await Client.ResolveWireFormatHttp2(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3) {
+#if NET8_0_OR_GREATER
                     response = await Client.ResolveWireFormatHttp3(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+#else
+                    throw new DnsClientException("DNS over HTTP/3 is not supported on this platform.");
+#endif
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {
                     response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, IgnoreCertificateErrors, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverQuic) {

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -296,7 +296,9 @@ namespace DnsClientX {
             if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2 ||
+#if NET8_0_OR_GREATER
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3 ||
+#endif
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.ObliviousDnsOverHttps) {
                 client.DefaultRequestHeaders.Accept.Add(
                     new MediaTypeWithQualityHeaderValue("application/dns-message"));


### PR DESCRIPTION
## Summary
- enable HTTP/3 resolver only on modern frameworks
- adjust Accept header logic for HTTP/3
- run HTTP/3 integration test automatically on .NET 8+

## Testing
- `dotnet test` *(fails: Failed: 143, Passed: 303, Skipped: 15)*

------
https://chatgpt.com/codex/tasks/task_e_686bc3290374832e9328ff14cc4c8e8e