### PR TITLE
Handle unsupported QUIC

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveQuicTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveQuicTests.cs
@@ -1,8 +1,10 @@
 #if NET8_0_OR_GREATER
+#pragma warning disable CA2252
 using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.Quic;
 using Xunit;
 
 namespace DnsClientX.Tests {
@@ -19,6 +21,24 @@ namespace DnsClientX.Tests {
                 DnsWireResolveQuic.HostEntryResolver = previous;
             }
         }
+
+        [Fact]
+        public async Task ResolveWireFormatQuic_ReturnsNotImplemented_WhenQuicUnsupported() {
+            var previousFactory = DnsWireResolveQuic.QuicConnectionFactory;
+            var previousResolver = DnsWireResolveQuic.HostEntryResolver;
+            try {
+                DnsWireResolveQuic.HostEntryResolver = _ => new IPHostEntry { AddressList = [IPAddress.Loopback] };
+                DnsWireResolveQuic.QuicConnectionFactory = (_, _) => ValueTask.FromException<QuicConnection>(new PlatformNotSupportedException("QUIC unsupported"));
+                var config = new Configuration("dummy", DnsRequestFormat.DnsOverQuic);
+                var response = await DnsWireResolveQuic.ResolveWireFormatQuic("dummy", 853, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None);
+                Assert.Equal(DnsResponseCode.NotImplemented, response.Status);
+                Assert.Contains("not supported", response.Error, StringComparison.OrdinalIgnoreCase);
+            } finally {
+                DnsWireResolveQuic.QuicConnectionFactory = previousFactory;
+                DnsWireResolveQuic.HostEntryResolver = previousResolver;
+            }
+        }
     }
 }
+#pragma warning restore CA2252
 #endif


### PR DESCRIPTION
## Summary
- improve ResolveWireFormatQuic to catch PlatformNotSupportedException earlier
- allow injecting a Quic connection factory for testing
- test DOQ path on unsupported environments

## Testing
- `dotnet test --filter "FullyQualifiedName~DnsClientX.Tests.DnsWireResolveQuicTests"`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_686bc339cb50832ea368a3236740a7ab