### PR TITLE
Enable cancellation for RunSync methods

### DIFF
--- a/DnsClientX.Tests/QueryDnsSyncCancellationTests.cs
+++ b/DnsClientX.Tests/QueryDnsSyncCancellationTests.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using Xunit;
+using DnsClientX;
+
+namespace DnsClientX.Tests {
+    public class QueryDnsSyncCancellationTests {
+        [Fact]
+        public void QueryDnsSync_RootServer_CancelledTask() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            Assert.Throws<TaskCanceledException>(() => ClientX.QueryDnsSync("example.com", DnsRecordType.A, DnsEndpoint.RootServer, cancellationToken: cts.Token));
+        }
+    }
+}

--- a/DnsClientX.Tests/TaskExtensionsTests.cs
+++ b/DnsClientX.Tests/TaskExtensionsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using DnsClientX;
 using System.Threading.Tasks;
+using System.Threading;
 using Xunit;
 
 namespace DnsClientX.Tests {
@@ -30,6 +31,22 @@ namespace DnsClientX.Tests {
             bool ran = false;
             ((Func<Task>)(() => { ran = true; return Task.CompletedTask; })).RunSync();
             Assert.True(ran);
+        }
+
+        [Fact]
+        public void RunSync_TaskOfT_Cancelled() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var task = Task.Delay(1000, cts.Token).ContinueWith(_ => 1, TaskContinuationOptions.ExecuteSynchronously);
+            Assert.Throws<TaskCanceledException>(() => task.RunSync(cts.Token));
+        }
+
+        [Fact]
+        public void RunSync_Task_Cancelled() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            Task task = Task.Delay(1000, cts.Token);
+            Assert.Throws<TaskCanceledException>(() => task.RunSync(cts.Token));
         }
     }
 }

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -57,7 +57,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -315,7 +315,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -357,7 +357,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+            return QueryDns(name, recordType, dnsEndpoint, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow `RunSync` to accept `CancellationToken`
- propagate token in QueryDnsSync
- add unit tests for new cancellation behavior

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test` *(fails: network requests blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686bc34bc7bc832ebe6f17a4d40a623f