### PR TITLE
Handle handshake errors in DoT

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveDotTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveDotTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireResolveDotTests {
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task RunInvalidTlsServerAsync(int port, CancellationToken token) {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            using TcpClient client = await listener.AcceptTcpClientAsync(token);
+            NetworkStream stream = client.GetStream();
+            byte[] data = Encoding.ASCII.GetBytes("plain text");
+            await stream.WriteAsync(data, 0, data.Length, token);
+            await stream.FlushAsync(token);
+            listener.Stop();
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatDoT_ShouldWrapAuthenticationException() {
+            int port = GetFreePort();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var serverTask = RunInvalidTlsServerAsync(port, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTLS) { Port = port };
+
+            await Assert.ThrowsAsync<DnsClientException>(async () =>
+                await DnsWireResolveDot.ResolveWireFormatDoT("127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, true, cts.Token));
+
+            await serverTask;
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -77,7 +77,11 @@ namespace DnsClientX {
 
 
             // Authenticate the client using the DNS server's name and the TLS protocol
-            await sslStream.AuthenticateAsClientAsync(dnsServer, null, SslProtocols.Tls12, false).ConfigureAwait(false);
+            try {
+                await sslStream.AuthenticateAsClientAsync(dnsServer, null, SslProtocols.Tls12, false).ConfigureAwait(false);
+            } catch (AuthenticationException ex) {
+                throw new DnsClientException($"TLS handshake failed: {ex.Message}");
+            }
 
             // Write the combined query bytes to the SSL stream and flush it
             await sslStream.WriteAsync(combinedQueryBytes, 0, combinedQueryBytes.Length, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- wrap TLS handshake failures as `DnsClientException`
- test handshake error for DoT connections

## Testing
- `dotnet restore DnsClientX.sln`
- `dotnet build DnsClientX.sln --configuration Release --no-restore`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration Release --framework net8.0 --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686bcc1bb7bc832ead4e57dbd265be12