### PR TITLE
Refactor QueryDns initialization

### DIFF
--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -85,11 +85,8 @@ namespace DnsClientX {
                 });
                 return await Task.WhenAll(tasks).ConfigureAwait(false);
             } else {
-                using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy) {
-                    EndpointConfiguration = {
-                        TimeOut = timeOutMilliseconds
-                    }
-                };
+                using var client = new ClientX(endpoint: dnsEndpoint, dnsSelectionStrategy);
+                client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
                 if (cancellationToken.IsCancellationRequested) {
                     return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
                 }
@@ -131,11 +128,8 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            using var client = new ClientX(dnsUri, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            using var client = new ClientX(dnsUri, requestFormat);
+            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
@@ -175,11 +169,8 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            using var client = new ClientX(dnsUri, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            using var client = new ClientX(dnsUri, requestFormat);
+            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
@@ -219,11 +210,8 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            using var client = new ClientX(hostName, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            using var client = new ClientX(hostName, requestFormat);
+            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
@@ -263,11 +251,8 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            using var client = new ClientX(hostName, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            using var client = new ClientX(hostName, requestFormat);
+            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
@@ -289,11 +274,8 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            using var client = new ClientX(hostName, requestFormat) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            using var client = new ClientX(hostName, requestFormat);
+            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
@@ -331,11 +313,8 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            using var client = new ClientX(endpoint: dnsEndpoint) {
-                EndpointConfiguration = {
-                    TimeOut = timeOutMilliseconds
-                }
-            };
+            using var client = new ClientX(endpoint: dnsEndpoint);
+            client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
## Summary
- remove object initializers in `QueryDns` overloads
- use property assignment for `EndpointConfiguration.TimeOut`
- confirm timeout test `ShouldFailWithTimeout` passes

## Testing
- `dotnet test --no-build DnsClientX.Tests/DnsClientX.Tests.csproj --filter FullyQualifiedName~DnsClientX.Tests.QueryDnsFailing.ShouldFailWithTimeout -v minimal`
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686bcc47ab18832eb590b5d7e6543cc5