### PR TITLE
Fix tcp timeout disposal

### DIFF
--- a/DnsClientX.Tests/ConnectTimeoutDisposalTests.cs
+++ b/DnsClientX.Tests/ConnectTimeoutDisposalTests.cs
@@ -12,7 +12,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("ConnectAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             using var tcpClient = new TcpClient();
             await Assert.ThrowsAsync<TimeoutException>(async () =>
-                await (Task)method.Invoke(null, new object[] { tcpClient, "127.0.0.1", 65535, 1, CancellationToken.None })!);
+                await (Task)method.Invoke(null, new object[] { tcpClient, "localhost", 65535, 0, CancellationToken.None })!);
             Assert.Null(tcpClient.Client);
         }
     }

--- a/DnsClientX.Tests/ConnectTimeoutDisposalTests.cs
+++ b/DnsClientX.Tests/ConnectTimeoutDisposalTests.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ConnectTimeoutDisposalTests {
+        [Fact]
+        public async Task ConnectAsync_ShouldDisposeSocketOnTimeout() {
+            MethodInfo method = typeof(ClientX).GetMethod("ConnectAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
+            using var tcpClient = new TcpClient();
+            await Assert.ThrowsAsync<TimeoutException>(async () =>
+                await (Task)method.Invoke(null, new object[] { tcpClient, "127.0.0.1", 65535, 1, CancellationToken.None })!);
+            Assert.Null(tcpClient.Client);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -161,6 +161,7 @@ namespace DnsClientX {
                 await tcpClient.ConnectAsync(host, port, linkedCts.Token).ConfigureAwait(false);
             } catch (OperationCanceledException) {
                 tcpClient.Close();
+                tcpClient.Dispose();
                 cancellationToken.ThrowIfCancellationRequested();
                 throw new TimeoutException($"Connection to {host}:{port} timed out after {timeoutMilliseconds} milliseconds.");
             }
@@ -170,6 +171,7 @@ namespace DnsClientX {
             var completed = await Task.WhenAny(connectTask, delayTask).ConfigureAwait(false);
             if (completed != connectTask) {
                 tcpClient.Close();
+                tcpClient.Dispose();
                 cancellationToken.ThrowIfCancellationRequested();
                 throw new TimeoutException($"Connection to {host}:{port} timed out after {timeoutMilliseconds} milliseconds.");
             }


### PR DESCRIPTION
## Summary
- dispose `TcpClient` when ConnectAsync times out
- add unit test checking TcpClient gets disposed on timeout

## Testing
- `dotnet test` *(fails: network unreachable)*
- `dotnet build DnsClientX.sln`

------
https://chatgpt.com/codex/tasks/task_e_686bcc4d904c832ebe040d55e92b35a0