### PR TITLE
Fix Get-DnsService empty result handling

### DIFF
--- a/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
+++ b/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
@@ -24,7 +24,7 @@ namespace DnsClientX.PowerShell {
         protected override async Task ProcessRecordAsync() {
             using var client = new ClientX();
             var results = await client.DiscoverServices(Domain);
-            WriteObject(results, true);
+            WriteObject(results);
         }
     }
 }

--- a/Module/Tests/DiscoverService.Tests.ps1
+++ b/Module/Tests/DiscoverService.Tests.ps1
@@ -1,0 +1,10 @@
+Import-Module "$PSScriptRoot/../DnsClientX.psd1" -Force
+
+Describe 'Get-DnsService cmdlet' {
+    It 'Returns empty array when no services are discovered' {
+        $result = Get-DnsService -Domain 'example.com'
+        ($null -ne $result) | Should -BeTrue
+        $result.GetType().FullName | Should -Be 'DnsClientX.DnsServiceDiscovery[]'
+        $result.Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
## Summary
- emit an empty `DnsServiceDiscovery[]` from Get-DnsService
- add Pester test for empty discovery scenario

## Testing
- `pwsh -NoLogo -NoProfile ./Module/DnsClientX.Tests.ps1`
- `dotnet test DnsClientX.sln -c Debug --no-build` *(fails: DNS network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bcc285d00832e8740f8f180c1398f