### PR TITLE
Fix UDP client disposal and add tests

### DIFF
--- a/DnsClientX.Tests/UdpClientDisposeTests.cs
+++ b/DnsClientX.Tests/UdpClientDisposeTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class UdpClientDisposeTests {
+        private static byte[] CreateDnsHeader() {
+            byte[] bytes = new byte[12];
+            ushort id = 0x1234;
+            bytes[0] = (byte)(id >> 8);
+            bytes[1] = (byte)(id & 0xFF);
+            ushort flags = 0x8180;
+            bytes[2] = (byte)(flags >> 8);
+            bytes[3] = (byte)(flags & 0xFF);
+            return bytes;
+        }
+
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task<int> RunUdpServerCapturePortAsync(int port, byte[] response, CancellationToken token) {
+            using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
+            UdpReceiveResult result = await udp.ReceiveAsync();
+            await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
+            return result.RemoteEndPoint.Port;
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatUdp_ShouldDisposeClient() {
+            int port = GetFreePort();
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var udpTask = RunUdpServerCapturePortAsync(port, response, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            await task;
+
+            int clientPort = await udpTask;
+
+            UdpClient? testClient = null;
+            Exception? ex = null;
+            try {
+                testClient = new UdpClient(new IPEndPoint(IPAddress.Loopback, clientPort));
+            } catch (Exception e) {
+                ex = e;
+            } finally {
+                testClient?.Dispose();
+            }
+
+            Assert.Null(ex);
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -48,7 +48,8 @@ namespace DnsClientX {
 
             try {
                 // Send the DNS query over UDP and receive the response
-                var responseBuffer = await SendQueryOverUdp(queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
+                using var udpClient = new UdpClient();
+                var responseBuffer = await SendQueryOverUdp(udpClient, queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
 
                 // Deserialize the response from DNS wire format
                 var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
@@ -96,10 +97,9 @@ namespace DnsClientX {
         /// <param name="timeoutMilliseconds">Timeout in milliseconds.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Raw DNS response bytes.</returns>
-        private static async Task<byte[]> SendQueryOverUdp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
-            using (var udpClient = new UdpClient()) {
-                // Set the server IP address and port number
-                var serverEndpoint = new IPEndPoint(IPAddress.Parse(dnsServer), port);
+        private static async Task<byte[]> SendQueryOverUdp(UdpClient udpClient, byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
+            // Set the server IP address and port number
+            var serverEndpoint = new IPEndPoint(IPAddress.Parse(dnsServer), port);
 
                 // Send the query
 #if NET5_0_OR_GREATER
@@ -134,4 +134,3 @@ namespace DnsClientX {
             }
         }
     }
-}


### PR DESCRIPTION
## Summary
- dispose `UdpClient` created during UDP queries
- adjust helper to accept an existing `UdpClient`
- add unit test verifying UDP client disposal

## Testing
- `dotnet build DnsClientX/DnsClientX.csproj -v minimal`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -v minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bcc113af8832eb1de5ba7d5242826