### PR TITLE
Support JSON POST DNS queries

### DIFF
--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -71,6 +71,14 @@ namespace DnsClientX.Examples {
             data.Answers.DisplayTable();
         }
 
+        public static async Task ExampleJsonPost() {
+            HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"),
+                DnsRequestFormat.DnsOverHttpsJSONPOST);
+            var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"),
+                DnsRequestFormat.DnsOverHttpsJSONPOST);
+            data.Answers.DisplayTable();
+        }
+
         public static async Task ExampleGoogleOverWire() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, DnsEndpoint.GoogleWireFormat);
             var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, DnsEndpoint.GoogleWireFormat);

--- a/DnsClientX.Tests/QueryDnsJsonPost.cs
+++ b/DnsClientX.Tests/QueryDnsJsonPost.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class QueryDnsJsonPost {
+        [Theory]
+        [InlineData(DnsEndpoint.CloudflareJsonPost)]
+        [InlineData(DnsEndpoint.GoogleJsonPost)]
+        public async Task ShouldWorkForA(DnsEndpoint endpoint) {
+            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint);
+            Assert.NotEmpty(response.Answers);
+        }
+    }
+}

--- a/DnsClientX.Tests/QueryDnsJsonPost.cs
+++ b/DnsClientX.Tests/QueryDnsJsonPost.cs
@@ -1,14 +1,49 @@
 using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
     public class QueryDnsJsonPost {
+        private class JsonPostHandler : HttpMessageHandler {
+            public HttpRequestMessage? Request { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                Request = request;
+                if (request.Content != null) {
+                    // no-op: ensure content is created but do not read
+                }
+                var json = "{\"Status\":0,\"Answer\":[{\"name\":\"evotec.pl\",\"type\":1,\"TTL\":60,\"data\":\"1.1.1.1\"}]}";
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+                return Task.FromResult(response);
+            }
+        }
+
+        private static void InjectClient(ClientX client, HttpClient httpClient) {
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(client)!;
+            clients[client.EndpointConfiguration.SelectionStrategy] = httpClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(client, httpClient);
+        }
+
         [Theory]
         [InlineData(DnsEndpoint.CloudflareJsonPost)]
         [InlineData(DnsEndpoint.GoogleJsonPost)]
-        public async Task ShouldWorkForA(DnsEndpoint endpoint) {
-            var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint);
+        public async Task ShouldPostJson(DnsEndpoint endpoint) {
+            var handler = new JsonPostHandler();
+            using var clientX = new ClientX(endpoint);
+            var httpClient = new HttpClient(handler) { BaseAddress = clientX.EndpointConfiguration.BaseUri };
+            InjectClient(clientX, httpClient);
+
+            var response = await clientX.Resolve("evotec.pl", DnsRecordType.A, retryOnTransient: false);
+
+            Assert.Equal(HttpMethod.Post, handler.Request?.Method);
+            Assert.Equal("application/json", handler.Request?.Content?.Headers.ContentType?.MediaType);
             Assert.NotEmpty(response.Answers);
         }
     }

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -262,6 +262,11 @@ namespace DnsClientX {
                     RequestFormat = DnsRequestFormat.DnsOverHttpsPOST;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
+                case DnsEndpoint.CloudflareJsonPost:
+                    hostnames = new List<string> { "1.1.1.1", "1.0.0.1" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSONPOST;
+                    baseUriFormat = "https://{0}/dns-query";
+                    break;
                 case DnsEndpoint.CloudflareSecurity:
                     hostnames = new List<string> { "1.1.1.2", "1.0.0.2" };
                     RequestFormat = DnsRequestFormat.DnsOverHttpsJSON;
@@ -301,6 +306,11 @@ namespace DnsClientX {
                     hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };
                     RequestFormat = DnsRequestFormat.DnsOverHttpsPOST;
                     baseUriFormat = "https://{0}/dns-query";
+                    break;
+                case DnsEndpoint.GoogleJsonPost:
+                    hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };
+                    RequestFormat = DnsRequestFormat.DnsOverHttpsJSONPOST;
+                    baseUriFormat = "https://{0}/resolve";
                     break;
                 case DnsEndpoint.GoogleQuic:
                     hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };

--- a/DnsClientX/Definitions/DnsEndpoint.cs
+++ b/DnsClientX/Definitions/DnsEndpoint.cs
@@ -35,6 +35,10 @@ namespace DnsClientX {
         /// </summary>
         CloudflareWireFormatPost,
         /// <summary>
+        /// Cloudflare's DNS-over-HTTPS endpoint using JSON over POST method.
+        /// </summary>
+        CloudflareJsonPost,
+        /// <summary>
         /// Google's DNS-over-HTTPS endpoint.
         /// </summary>
         Google,
@@ -46,6 +50,10 @@ namespace DnsClientX {
         /// Google's DNS-over-HTTPS endpoint using wire format over POST method.
         /// </summary>
         GoogleWireFormatPost,
+        /// <summary>
+        /// Google's DNS-over-HTTPS endpoint using JSON over POST method.
+        /// </summary>
+        GoogleJsonPost,
         /// <summary>
         /// Quad9's DNS-over-HTTPS endpoint.
         /// </summary>

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -18,6 +18,10 @@ namespace DnsClientX {
         /// </summary>
         DnsOverHttpsPOST,
         /// <summary>
+        /// JSON format for DNS requests sent using POST method.
+        /// </summary>
+        DnsOverHttpsJSONPOST,
+        /// <summary>
         /// Format for DNS requests using UDP.
         /// </summary>
         DnsOverUDP,

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -90,6 +90,8 @@ namespace DnsClientX {
                     response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
                     response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSONPOST) {
+                    response = await Client.ResolveJsonFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.ObliviousDnsOverHttps) {
                     response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2) {


### PR DESCRIPTION
## Summary
- extend `DnsRequestFormat` with `DnsOverHttpsJSONPOST`
- add new endpoints `CloudflareJsonPost` and `GoogleJsonPost`
- map new endpoints in `Configuration`
- support JSON POST in the HTTP resolver
- expose example usage
- test JSON POST endpoints

## Testing
- `dotnet build DnsClientX/DnsClientX.csproj -c Debug -v minimal`
- `dotnet build DnsClientX.Tests/DnsClientX.Tests.csproj -c Debug -v minimal`
- `dotnet test --no-build --filter QueryDnsJsonPost --verbosity minimal` *(fails: Assert.NotEmpty() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_686bf17db3f4832e9a8781da59dd29bd