### PR TITLE
Fix duplicate DNS server results

### DIFF
--- a/DnsClientX.Tests/DeduplicateDnsServersTests.cs
+++ b/DnsClientX.Tests/DeduplicateDnsServersTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
@@ -10,6 +11,13 @@ namespace DnsClientX.Tests {
             var input = new List<string> { "1.1.1.1", "1.1.1.1", "[2001:db8::1]", "[2001:db8::1]" };
             var result = (List<string>)method.Invoke(null, new object[] { input })!;
             Assert.Equal(new[] { "1.1.1.1", "[2001:db8::1]" }, result);
+        }
+
+        [Fact]
+        public void GetDnsFromActiveNetworkCard_ReturnsDistinctList() {
+            var servers = SystemInformation.GetDnsFromActiveNetworkCard(refresh: true);
+            var distinct = servers.Distinct().ToList();
+            Assert.Equal(distinct, servers);
         }
     }
 }

--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -125,7 +126,7 @@ namespace DnsClientX {
                 dnsServers.Add(FormatDnsAddress(IPAddress.Parse("8.8.8.8"))); // Google Primary
             }
 
-            dnsServers = DeduplicateDnsServers(dnsServers);
+            dnsServers = dnsServers.Distinct().ToList();
             DebugPrint($"Final DNS server list: {string.Join(", ", dnsServers)}");
 
             return dnsServers;


### PR DESCRIPTION
## Summary
- remove duplicate DNS servers with `Distinct()`
- test that `GetDnsFromActiveNetworkCard` never returns duplicates

## Testing
- `dotnet test DnsClientX.sln --verbosity minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686c2bf20d14832e99abcdebb0491f88