### PR TITLE
Add pattern based Resolve support

### DIFF
--- a/DnsClientX.Examples/DemoResolvePattern.cs
+++ b/DnsClientX.Examples/DemoResolvePattern.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates resolving multiple hostnames generated from a pattern.
+    /// </summary>
+    internal class DemoResolvePattern {
+        /// <summary>Runs the demo.</summary>
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var responses = await client.ResolvePattern("server[1-3].example.com", DnsRecordType.A);
+            responses.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Examples/DemoResolvePatternBraces.cs
+++ b/DnsClientX.Examples/DemoResolvePatternBraces.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates brace expansion with <see cref="ClientX.ResolvePattern"/>.
+    /// </summary>
+    internal class DemoResolvePatternBraces {
+        /// <summary>Runs the demo.</summary>
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var responses = await client.ResolvePattern("host{a,b}.example.com", DnsRecordType.A);
+            responses.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Examples/DemoResolvePatternRange.cs
+++ b/DnsClientX.Examples/DemoResolvePatternRange.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates numeric range expansion with <see cref="ClientX.ResolvePattern"/>.
+    /// </summary>
+    internal class DemoResolvePatternRange {
+        /// <summary>Runs the demo.</summary>
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var responses = await client.ResolvePattern("web{01..03}.example.com", DnsRecordType.A);
+            responses.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolvePatternTests.cs
+++ b/DnsClientX.Tests/ResolvePatternTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolvePatternTests {
+        private class CountingHandler : HttpMessageHandler {
+            public int CallCount;
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                Interlocked.Increment(ref CallCount);
+                var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent("{\"Status\":0}")
+                };
+                return Task.FromResult(response);
+            }
+        }
+
+        private static void InjectClient(ClientX client, HttpClient httpClient) {
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(client)!;
+            clients[client.EndpointConfiguration.SelectionStrategy] = httpClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(client, httpClient);
+        }
+
+        [Fact]
+        public async Task ResolvePattern_ExpandsWildcards() {
+            var handler = new CountingHandler();
+            using var client = new ClientX("https://example.com/dns-query", DnsRequestFormat.DnsOverHttpsJSON);
+            var httpClient = new HttpClient(handler) { BaseAddress = client.EndpointConfiguration.BaseUri };
+            InjectClient(client, httpClient);
+
+            var responses = await client.ResolvePattern("host[1-3].example.com", DnsRecordType.A, retryOnTransient: false);
+
+            Assert.Equal(3, handler.CallCount);
+            Assert.Equal(3, responses.Length);
+        }
+    }
+}

--- a/Module/Examples/Example.ResolveDnsPattern.ps1
+++ b/Module/Examples/Example.ResolveDnsPattern.ps1
@@ -1,0 +1,3 @@
+Import-Module $PSScriptRoot\..\DnsClientX.psd1 -Force
+
+Resolve-Dns -Pattern 'server[1-3].example.com' -DnsProvider Cloudflare | Format-Table

--- a/Module/Tests/ResolveDnsPattern.Tests.ps1
+++ b/Module/Tests/ResolveDnsPattern.Tests.ps1
@@ -1,0 +1,7 @@
+Import-Module "$PSScriptRoot/../DnsClientX.psd1" -Force
+
+Describe 'Resolve-Dns pattern parameter' {
+    It 'Fails when TimeOut is less than or equal to zero' {
+        { Resolve-Dns -Pattern 'host[1-2].example.com' -TimeOut 0 -ErrorAction Stop } | Should -Throw -ExceptionType System.ArgumentOutOfRangeException
+    }
+}


### PR DESCRIPTION
## Summary
- support brace and range patterns in resolve
- add `ResolvePattern` example with numeric ranges and braces
- integrate pattern expansion into `Resolve-Dns` cmdlet
- add PowerShell pattern example and Pester tests

## Testing
- `dotnet build`
- `dotnet test` *(fails: network unreachable)*
- `pwsh ./Module/DnsClientX.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686bf18c6b24832ea5cc8a62f7ef1953