### PR TITLE
Ensure enumerator disposal in ResolveStream

### DIFF
--- a/DnsClientX.Tests/ResolveStreamEnumeratorDisposeTests.cs
+++ b/DnsClientX.Tests/ResolveStreamEnumeratorDisposeTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ResolveStreamEnumeratorDisposeTests {
+        private class TrackingEnumerable<T> : IEnumerable<T> {
+            private readonly T[] _items;
+            public int DisposeCount { get; private set; }
+
+            public TrackingEnumerable(params T[] items) => _items = items;
+
+            public IEnumerator<T> GetEnumerator() => new TrackingEnumerator(this, _items);
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            private class TrackingEnumerator : IEnumerator<T> {
+                private readonly TrackingEnumerable<T> _parent;
+                private readonly T[] _items;
+                private int _index = -1;
+
+                public TrackingEnumerator(TrackingEnumerable<T> parent, T[] items) {
+                    _parent = parent;
+                    _items = items;
+                }
+
+                public T Current => _items[_index];
+
+                object IEnumerator.Current => Current!;
+
+                public bool MoveNext() => ++_index < _items.Length;
+
+                public void Reset() => _index = -1;
+
+                public void Dispose() {
+                    _parent.DisposeCount++;
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ResolveStream_ShouldDisposeEnumerators() {
+            using var client = new ClientX(DnsEndpoint.System);
+            var names = new TrackingEnumerable<string>("example.com");
+            var types = new TrackingEnumerable<DnsRecordType>(DnsRecordType.A);
+
+            MethodInfo method = typeof(ClientX).GetMethod(
+                "ResolveStream",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                new[] {
+                    typeof(IEnumerable<string>),
+                    typeof(IEnumerable<DnsRecordType>),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(int),
+                    typeof(int),
+                    typeof(CancellationToken)
+                },
+                null)!;
+
+            var enumerable = (IAsyncEnumerable<DnsResponse>)method.Invoke(
+                client,
+                new object[] { names, types, false, false, false, false, 3, 200, CancellationToken.None })!;
+
+            await foreach (var _ in enumerable) {
+            }
+
+            Assert.Equal(1, names.DisposeCount);
+            Assert.Equal(1, types.DisposeCount);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- dispose enumerators in ResolveStream methods with finally blocks
- add internal enumerable overload for testing
- test enumerator disposal to ensure `Dispose` is called

## Testing
- `dotnet test --filter "FullyQualifiedName~ResolveStreamEnumeratorDisposeTests" -c Release`
- `dotnet build DnsClientX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686c2bf9bfec832eb63b023b041b218b