### PR TITLE
Deduplicate DNS servers in Resolve-Dns

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -165,7 +165,7 @@ namespace DnsClientX.PowerShell {
                     return;
                 }
 
-                IEnumerable<string> serverOrder = validServers;
+                List<string> serverOrder = validServers.Distinct().ToList();
                 if (RandomServer.IsPresent) {
                     var random = new Random();
                     serverOrder = serverOrder.OrderBy(_ => random.Next()).ToList();

--- a/Module/Tests/ResolveDns.Tests.ps1
+++ b/Module/Tests/ResolveDns.Tests.ps1
@@ -4,4 +4,9 @@ Describe 'Resolve-Dns cmdlet' {
     It 'Fails when TimeOut is less than or equal to zero' {
         { Resolve-Dns -Name 'example.com' -TimeOut 0 -ErrorAction Stop } | Should -Throw -ExceptionType System.ArgumentOutOfRangeException
     }
+
+    It 'Removes duplicate servers before processing' {
+        $result = Resolve-Dns -Name 'example.com' -Server @('127.0.0.1','127.0.0.1') -AllServers -FullResponse -TimeOut 10 -ErrorAction SilentlyContinue
+        $result.Count | Should -Be 1
+    }
 }


### PR DESCRIPTION
## Summary
- dedupe server list before applying random order
- add Pester test ensuring duplicates are removed

## Testing
- `dotnet build DnsClientX.PowerShell/DnsClientX.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -Command './Module/DnsClientX.Tests.ps1 2>&1 | Select-String -Pattern "Tests Passed"'`

------
https://chatgpt.com/codex/tasks/task_e_686c2caa810c832e9d32c89b0e55ca2b