### PR TITLE
Dispose outdated client on strategy change

### DIFF
--- a/DnsClientX.Tests/StrategySwitchDisposalTests.cs
+++ b/DnsClientX.Tests/StrategySwitchDisposalTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class StrategySwitchDisposalTests {
+        private class JsonResponseHandler : HttpMessageHandler {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"Status\":0}") };
+                return Task.FromResult(response);
+            }
+        }
+
+        private static void InjectClient(ClientX client, HttpClient httpClient) {
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(client)!;
+            clients[client.EndpointConfiguration.SelectionStrategy] = httpClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(client, httpClient);
+        }
+
+        [Fact]
+        public async Task MultipleStrategySwitches_ShouldIncreaseDisposalCount() {
+            ClientX.DisposalCount = 0;
+            var handler = new JsonResponseHandler();
+            using (var client = new ClientX("https://example.com/dns-query", DnsRequestFormat.DnsOverHttpsJSON)) {
+                var httpClient = new HttpClient(handler) { BaseAddress = client.EndpointConfiguration.BaseUri };
+                InjectClient(client, httpClient);
+
+                await client.Resolve("example.com", DnsRecordType.A, retryOnTransient: false);
+                client.EndpointConfiguration.SelectionStrategy = DnsSelectionStrategy.Random;
+                await client.Resolve("example.com", DnsRecordType.A, retryOnTransient: false);
+                client.EndpointConfiguration.SelectionStrategy = DnsSelectionStrategy.Failover;
+                await client.Resolve("example.com", DnsRecordType.A, retryOnTransient: false);
+            }
+
+            Assert.Equal(3, ClientX.DisposalCount);
+        }
+    }
+}

--- a/DnsClientX.Tests/StrategySwitchDisposalTests.cs
+++ b/DnsClientX.Tests/StrategySwitchDisposalTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    [Collection("NoParallel")]
     public class StrategySwitchDisposalTests {
         private class JsonResponseHandler : HttpMessageHandler {
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -31,21 +31,25 @@ namespace DnsClientX {
         /// <param name="disposing">Whether managed resources should be disposed.</param>
         protected virtual void Dispose(bool disposing) {
             if (!_disposed) {
-                if (disposing) {
-                    HttpClientHandler? handlerLocal;
-                    List<HttpClient> clients;
-                    HttpClient? mainClient;
+                HttpClientHandler? handlerLocal;
+                List<HttpClient> clients;
+                HttpClient? mainClient;
 
-                    lock (_lock) {
-                        clients = new List<HttpClient>(_clients.Values);
-                        _clients.Clear();
-
-                        mainClient = Client;
-                        handlerLocal = handler;
-                        Client = null;
-                        handler = null;
+                lock (_lock) {
+                    if (_disposed) {
+                        return;
                     }
+                    _disposed = true;
 
+                    clients = new List<HttpClient>(_clients.Values);
+                    _clients.Clear();
+
+                    mainClient = Client;
+                    handlerLocal = handler;
+                    Client = null;
+                    handler = null;
+                }
+                if (disposing) {
                     foreach (HttpClient client in clients) {
                         if (TryAddDisposedClient(client)) {
                             client.Dispose();
@@ -59,7 +63,6 @@ namespace DnsClientX {
                     handlerLocal?.Dispose();
                 }
 
-                _disposed = true;
                 System.Threading.Interlocked.Increment(ref DisposalCount);
             }
         }
@@ -87,6 +90,11 @@ namespace DnsClientX {
                 HttpClient? mainClient;
 
                 lock (_lock) {
+                    if (_disposed) {
+                        return;
+                    }
+                    _disposed = true;
+
                     clients = new List<HttpClient>(_clients.Values);
                     _clients.Clear();
 
@@ -122,19 +130,20 @@ namespace DnsClientX {
 #endif
                 }
 
-                if (handlerLocal != null) {
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                if (handlerLocal != null) {
                     if (handlerLocal is IAsyncDisposable asyncHandler) {
                         await asyncHandler.DisposeAsync().ConfigureAwait(false);
                     } else {
                         handlerLocal.Dispose();
                     }
-#else
-                    handlerLocal.Dispose();
-#endif
                 }
+#else
+                if (handlerLocal != null) {
+                    handlerLocal.Dispose();
+                }
+#endif
 
-                _disposed = true;
                 System.Threading.Interlocked.Increment(ref DisposalCount);
             }
         }

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -318,6 +318,7 @@ namespace DnsClientX {
                 handler?.Dispose();
 
                 Client = CreateOptimizedHttpClient();
+                _clients[EndpointConfiguration.SelectionStrategy] = Client;
             }
         }
 


### PR DESCRIPTION
## Summary
- dispose old HTTP clients when switching DNS selection strategies
- test disposal count increases after strategy changes

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet vstest DnsClientX.Tests/bin/Release/net8.0/DnsClientX.Tests.dll --TestCaseFilter:FullyQualifiedName~StrategySwitchDisposalTests`


------
https://chatgpt.com/codex/tasks/task_e_686c2c9b771c832eb579d02fad135b89