### PR TITLE
Refactor DisposeAsyncCore and add disposal test

### DIFF
--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -112,6 +112,16 @@ namespace DnsClientX.Tests {
             Assert.Equal(1, handler.DisposeCount);
         }
 
+        [Fact]
+        public async Task Client_DisposeAsync_ShouldIncrementDisposalCount() {
+            ClientX.DisposalCount = 0;
+            await using var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
+
+            await clientX.DisposeAsync();
+
+            Assert.Equal(1, ClientX.DisposalCount);
+        }
+
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         [Fact]
         public async Task Client_DisposeAsync_ShouldPreferAsyncHandlerDisposal() {

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -75,11 +75,9 @@ namespace DnsClientX {
         /// Disposes managed resources asynchronously when possible.
         /// </summary>
         /// <returns>A task representing the asynchronous disposal.</returns>
+        protected virtual async ValueTask DisposeAsyncCore() {
 #if !(NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER)
-        protected virtual async ValueTask DisposeAsyncCore() {
             await Task.CompletedTask;
-#else
-        protected virtual async ValueTask DisposeAsyncCore() {
 #endif
             if (!_disposed) {
                 HttpClientHandler? handlerLocal;


### PR DESCRIPTION
## Summary
- refactor `DisposeAsyncCore` to one implementation using conditional async disposal
- add unit test ensuring disposal count increments via `DisposeAsync`

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `dotnet test --no-build --filter FullyQualifiedName~Client_DisposeAsync_ShouldIncrementDisposalCount -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_686c2ca499ac832e8a407938819f2b6f