### PR TITLE
Fix ConnectAsync immediate timeout handling

### DIFF
--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -155,7 +155,11 @@ namespace DnsClientX {
 
         private static async Task ConnectAsync(TcpClient tcpClient, string host, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            linkedCts.CancelAfter(timeoutMilliseconds);
+            if (timeoutMilliseconds <= 0) {
+                linkedCts.Cancel();
+            } else {
+                linkedCts.CancelAfter(timeoutMilliseconds);
+            }
 #if NET5_0_OR_GREATER
             try {
                 await tcpClient.ConnectAsync(host, port, linkedCts.Token).ConfigureAwait(false);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -122,7 +122,11 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         private static async Task ConnectAsync(TcpClient tcpClient, string host, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            linkedCts.CancelAfter(timeoutMilliseconds);
+            if (timeoutMilliseconds <= 0) {
+                linkedCts.Cancel();
+            } else {
+                linkedCts.CancelAfter(timeoutMilliseconds);
+            }
 #if NET5_0_OR_GREATER
             try {
                 await tcpClient.ConnectAsync(host, port, linkedCts.Token).ConfigureAwait(false);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -173,7 +173,11 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         private static async Task ConnectAsync(TcpClient tcpClient, string host, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            linkedCts.CancelAfter(timeoutMilliseconds);
+            if (timeoutMilliseconds <= 0) {
+                linkedCts.Cancel();
+            } else {
+                linkedCts.CancelAfter(timeoutMilliseconds);
+            }
 #if NET5_0_OR_GREATER
             try {
                 await tcpClient.ConnectAsync(host, port, linkedCts.Token).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- ensure immediate timeout cancellation occurs before calling TcpClient.ConnectAsync
- apply fix across ConnectAsync implementations

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~DnsClientX.Tests.ConnectTimeoutDisposalTests.ConnectAsync_ShouldDisposeSocketOnTimeout`
- `dotnet test` *(fails: 143 failed, 315 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686c3070f21c832e892f18c22d679d01