### PR TITLE
Apply inheritdoc style docs

### DIFF
--- a/DnsClientX.Benchmarks/DnsClientX.Benchmarks.csproj
+++ b/DnsClientX.Benchmarks/DnsClientX.Benchmarks.csproj
@@ -5,6 +5,7 @@
     <LangVersion>Latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />

--- a/DnsClientX.Cli/DnsClientX.Cli.csproj
+++ b/DnsClientX.Cli/DnsClientX.Cli.csproj
@@ -9,6 +9,7 @@
     </TargetFrameworks>
     <LangVersion>Latest</LangVersion>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DnsClientX\DnsClientX.csproj" />

--- a/DnsClientX.Examples/DnsClientX.Examples.csproj
+++ b/DnsClientX.Examples/DnsClientX.Examples.csproj
@@ -2,10 +2,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0</TargetFrameworks>
-        <LangVersion>Latest</LangVersion>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Spectre.Console" Version="0.50.0" />

--- a/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
+++ b/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
@@ -18,9 +18,7 @@ namespace DnsClientX.PowerShell {
         [Parameter(Mandatory = true, Position = 0)]
         public string Domain { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Executes the cmdlet logic asynchronously.
-        /// </summary>
+        /// <inheritdoc />
         protected override async Task ProcessRecordAsync() {
             using var client = new ClientX();
             var results = await client.DiscoverServices(Domain);

--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -148,10 +148,7 @@ namespace DnsClientX.PowerShell {
             return lastResults;
         }
 
-        /// <summary>
-        /// Begin record asynchronously.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc />
         protected override Task BeginProcessingAsync() {
 
             // Initialize the logger to be able to see verbose, warning, debug, error, progress, and information messages.
@@ -161,10 +158,7 @@ namespace DnsClientX.PowerShell {
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Process the record asynchronously.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc />
         protected override async Task ProcessRecordAsync() {
             if (TimeOut <= 0) {
                 throw new ArgumentOutOfRangeException(nameof(TimeOut), "TimeOut must be greater than zero.");

--- a/DnsClientX.PowerShell/Communication/AsyncPSCmdlet.cs
+++ b/DnsClientX.PowerShell/Communication/AsyncPSCmdlet.cs
@@ -38,9 +38,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     /// </summary>
     protected internal CancellationToken CancelToken { get => _cancelSource.Token; }
 
-    /// <summary>
-    /// Begins processing the cmdlet asynchronously.
-    /// </summary>
+    /// <inheritdoc />
     protected override void BeginProcessing()
         => RunBlockInAsync(BeginProcessingAsync);
 
@@ -51,9 +49,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     protected virtual Task BeginProcessingAsync()
         => Task.CompletedTask;
 
-    /// <summary>
-    /// Processes a record asynchronously.
-    /// </summary>
+    /// <inheritdoc />
     protected override void ProcessRecord()
         => RunBlockInAsync(ProcessRecordAsync);
 
@@ -64,9 +60,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     protected virtual Task ProcessRecordAsync()
         => Task.CompletedTask;
 
-    /// <summary>
-    /// Ends processing the cmdlet asynchronously.
-    /// </summary>
+    /// <inheritdoc />
     protected override void EndProcessing()
         => RunBlockInAsync(EndProcessingAsync);
 
@@ -77,9 +71,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     protected virtual Task EndProcessingAsync()
         => Task.CompletedTask;
 
-    /// <summary>
-    /// Stops the processing of the cmdlet.
-    /// </summary>
+    /// <inheritdoc />
     protected override void StopProcessing()
         => _cancelSource?.Cancel();
 

--- a/DnsClientX.PowerShell/OnImportAndRemove.cs
+++ b/DnsClientX.PowerShell/OnImportAndRemove.cs
@@ -9,19 +9,14 @@ using System.Collections.Generic;
 /// This class is used to handle the assembly resolve event when the module is imported and removed.
 /// </summary>
 public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemblyCleanup {
-    /// <summary>
-    /// OnImport is called when the module is imported.
-    /// </summary>
+    /// <inheritdoc />
     public void OnImport() {
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
         }
     }
 
-    /// <summary>
-    /// OnRemove is called when the module is removed.
-    /// </summary>
-    /// <param name="module"></param>
+    /// <inheritdoc />
     public void OnRemove(PSModuleInfo module) {
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -13,6 +13,7 @@
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <LangVersion>latest</LangVersion>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.0"

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -163,14 +163,7 @@ namespace DnsClientX {
     /// In some cases the comment field is an array of strings, so this converter will join them together.
     /// </summary>
     public class CommentConverter : JsonConverter<string> {
-        /// <summary>
-        /// Reads the string value from the JSON reader.
-        /// </summary>
-        /// <param name="reader"></param>
-        /// <param name="typeToConvert"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        /// <exception cref="JsonException"></exception>
+        /// <inheritdoc />
         public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
             switch (reader.TokenType) {
                 case JsonTokenType.String:
@@ -188,12 +181,7 @@ namespace DnsClientX {
             }
         }
 
-        /// <summary>
-        /// Writes the string value to the JSON writer.
-        /// </summary>
-        /// <param name="writer"></param>
-        /// <param name="value"></param>
-        /// <param name="options"></param>
+        /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) {
             writer.WriteStringValue(value);
         }


### PR DESCRIPTION
## Summary
- enable XML doc generation for all projects
- document overrides with `<inheritdoc/>`

## Testing
- `dotnet test` *(fails: The argument /workspace/DnsClientX/DnsClientX.Tests/bin/Debug/net8.0/DnsClientX.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686c4461f99c832e926162857b41cd30