### PR TITLE
Add multicast DNS resolver

### DIFF
--- a/DnsClientX.Examples/DemoResolveMulticast.cs
+++ b/DnsClientX.Examples/DemoResolveMulticast.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    internal class DemoResolveMulticast {
+        public static async Task Example() {
+            HelpersSpectre.AddLine("Resolve", "example.local", DnsRecordType.A, "224.0.0.251", DnsRequestFormat.Multicast);
+            using var client = new ClientX("224.0.0.251", DnsRequestFormat.Multicast) {
+                EndpointConfiguration = { Port = 5353 },
+                Debug = true
+            };
+            var response = await client.Resolve("example.local", DnsRecordType.A);
+            response.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsWireResolveMulticastTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveMulticastTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireResolveMulticastTests {
+        private static byte[] CreateDnsHeader() {
+            byte[] bytes = new byte[12];
+            ushort id = 0x1234;
+            bytes[0] = (byte)(id >> 8);
+            bytes[1] = (byte)(id & 0xFF);
+            ushort flags = 0x8180;
+            bytes[2] = (byte)(flags >> 8);
+            bytes[3] = (byte)(flags & 0xFF);
+            return bytes;
+        }
+
+        private static async Task<byte[]> RunMulticastServerAsync(byte[] response, CancellationToken token) {
+            using var server = new UdpClient(AddressFamily.InterNetwork);
+            server.ExclusiveAddressUse = false;
+            server.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            server.Client.Bind(new IPEndPoint(IPAddress.Any, 5353));
+            server.JoinMulticastGroup(IPAddress.Parse("224.0.0.251"));
+            UdpReceiveResult result = await server.ReceiveAsync();
+            await server.SendAsync(response, response.Length, result.RemoteEndPoint);
+            return result.Buffer;
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatMulticast_ShouldReturnResponse() {
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var serverTask = RunMulticastServerAsync(response, cts.Token);
+
+            var config = new Configuration("224.0.0.251", DnsRequestFormat.Multicast);
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveMulticast")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatMulticast", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "224.0.0.251", 5353, "example.local", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            DnsResponse dnsResponse = await task;
+            byte[] query = await serverTask;
+
+            Assert.NotNull(dnsResponse);
+            Assert.NotEmpty(query);
+            Assert.Equal(DnsRequestFormat.Multicast, dnsResponse.Questions[0].RequestFormat);
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -157,6 +157,8 @@ namespace DnsClientX {
                 Port = 853;
             } else if (requestFormat == DnsRequestFormat.DnsOverUDP || requestFormat == DnsRequestFormat.DnsOverTCP) {
                 Port = 53;
+            } else if (requestFormat == DnsRequestFormat.Multicast) {
+                Port = 5353;
             } else {
                 Port = 443;
             }
@@ -398,6 +400,8 @@ namespace DnsClientX {
                        RequestFormat == DnsRequestFormat.DnsOverTCP ||
                        RequestFormat == DnsRequestFormat.DnsCryptRelay) {
                 Port = 53;
+            } else if (RequestFormat == DnsRequestFormat.Multicast) {
+                Port = 5353;
             } else {
                 Port = 443;
             }

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -57,5 +57,9 @@ namespace DnsClientX {
         /// Oblivious DNS over HTTPS (RFC 9230).
         /// </summary>
         ObliviousDnsOverHttps,
+        /// <summary>
+        /// DNS over UDP multicast (mDNS on port 5353).
+        /// </summary>
+        Multicast,
     }
 }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -115,6 +115,8 @@ namespace DnsClientX {
                     response = await DnsWireResolveTcp.ResolveWireFormatTcp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverUDP) {
                     response = await DnsWireResolveUdp.ResolveWireFormatUdp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.Multicast) {
+                    response = await DnsWireResolveMulticast.ResolveWireFormatMulticast(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else {
                     throw new DnsClientException($"Invalid RequestFormat: {EndpointConfiguration.RequestFormat}");
                 }

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    internal static class DnsWireResolveMulticast {
+        internal static async Task<DnsResponse> ResolveWireFormatMulticast(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
+
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
+            int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
+            string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var queryBytes = query.SerializeDnsWireFormat();
+
+            if (debug) {
+                Settings.Logger.WriteDebug($"Query Name: " + name + " type: " + type);
+                Settings.Logger.WriteDebug($"Sending query: {BitConverter.ToString(queryBytes)}");
+            }
+
+            using var udpClient = new UdpClient(AddressFamily.InterNetwork);
+            try {
+                udpClient.ExclusiveAddressUse = false;
+                udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                udpClient.Client.Bind(new IPEndPoint(IPAddress.Any, 0));
+                var multicastAddress = IPAddress.Parse(dnsServer);
+#if NET5_0_OR_GREATER
+                udpClient.JoinMulticastGroup(multicastAddress);
+#else
+                udpClient.JoinMulticastGroup(multicastAddress, 50);
+#endif
+                var serverEndpoint = new IPEndPoint(multicastAddress, port);
+#if NET5_0_OR_GREATER
+                await udpClient.SendAsync(queryBytes, serverEndpoint, cancellationToken).ConfigureAwait(false);
+#else
+                await udpClient.SendAsync(queryBytes, queryBytes.Length, serverEndpoint).ConfigureAwait(false);
+#endif
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(endpointConfiguration.TimeOut);
+#if NET5_0_OR_GREATER
+                var responseTask = udpClient.ReceiveAsync(cancellationToken).AsTask();
+#else
+                var responseTask = udpClient.ReceiveAsync();
+#endif
+                var completedTask = await Task.WhenAny(responseTask, Task.Delay(endpointConfiguration.TimeOut, cts.Token)).ConfigureAwait(false);
+                if (completedTask == responseTask) {
+                    var responseBuffer = responseTask.Result.Buffer;
+                    var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
+                    response.AddServerDetails(endpointConfiguration);
+                    return response;
+                }
+                throw new TimeoutException("The UDP multicast query timed out.");
+            } catch (Exception ex) {
+                DnsResponseCode responseCode = ex is TimeoutException ? DnsResponseCode.ServerFailure : DnsResponseCode.Refused;
+                DnsResponse response = new DnsResponse {
+                    Questions = [new DnsQuestion { Name = name, RequestFormat = DnsRequestFormat.Multicast, Type = type, OriginalName = name }],
+                    Status = responseCode
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" => {ex.Message + " " + ex.InnerException?.Message}";
+                return response;
+            } finally {
+                try {
+                    udpClient.DropMulticastGroup(IPAddress.Parse(dnsServer));
+                } catch {
+                    // ignore cleanup errors
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -588,6 +588,15 @@ var zoneRecords = await client.ZoneTransferAsync("example.com");
 Get-DnsZoneTransfer -Zone 'example.com' -Server '127.0.0.1' -Port 5353
 ```
 
+### Multicast Queries
+
+Query devices advertising mDNS on your local network:
+
+```csharp
+using var client = new ClientX("224.0.0.251", DnsRequestFormat.Multicast) { EndpointConfiguration = { Port = 5353 } };
+var response = await client.Resolve("example.local", DnsRecordType.A);
+```
+
 ## Please share with the community
 
 Please consider sharing a post about DnsClientX and the value it provides. It really does help!


### PR DESCRIPTION
## Summary
- add `DnsRequestFormat.Multicast` option
- implement UDP multicast resolver
- default port to 5353 when using multicast
- integrate new resolver with examples and README
- include unit test for multicast resolver

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: 144 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c44e6b960832eb7af53816cc94bed