### PR TITLE
Add endpoint descriptions and listing helper

### DIFF
--- a/DnsClientX.Cli/Program.cs
+++ b/DnsClientX.Cli/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using DnsClientX;
 
 namespace DnsClientX.Cli {
     internal static class Program {
@@ -78,6 +79,11 @@ namespace DnsClientX.Cli {
             Console.WriteLine("Options:");
             Console.WriteLine("  -t, --type <record>      DNS record type (default A)");
             Console.WriteLine("  -e, --endpoint <name>    DNS endpoint name (default System)");
+            Console.WriteLine();
+            Console.WriteLine("Available endpoints:");
+            foreach (var (ep, desc) in DnsEndpointExtensions.GetAllWithDescriptions()) {
+                Console.WriteLine($"  {ep,-20} {desc}");
+            }
         }
     }
 }

--- a/DnsClientX.Tests/DnsEndpointDescriptionTests.cs
+++ b/DnsClientX.Tests/DnsEndpointDescriptionTests.cs
@@ -1,0 +1,15 @@
+using System;
+using Xunit;
+using DnsClientX;
+
+namespace DnsClientX.Tests {
+    public class DnsEndpointDescriptionTests {
+        [Fact]
+        public void AllEndpointsHaveDescriptions() {
+            foreach (DnsEndpoint ep in Enum.GetValues(typeof(DnsEndpoint))) {
+                string desc = ep.GetDescription();
+                Assert.False(string.IsNullOrWhiteSpace(desc));
+            }
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsEndpoint.cs
+++ b/DnsClientX/Definitions/DnsEndpoint.cs
@@ -1,3 +1,8 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Collections.Generic;
+
 namespace DnsClientX {
     /// <summary>
     /// Enumerates known DNS endpoints including DNS-over-HTTPS and DNSCrypt
@@ -9,120 +14,175 @@ namespace DnsClientX {
         /// Use the system's default DNS resolver using UDP. When using this option, the system's default DNS resolver will be used.
         /// When UDP reaches the maximum packet size, it will automatically switch to TCP.
         /// </summary>
+        [Description("Use the system's default DNS resolver using UDP. When UDP reaches the maximum packet size, it will automatically switch to TCP.")]
         System,
         /// <summary>
         /// Use the system's default DNS resolver using TCP. When using this option, the system's default DNS resolver will be used.
         /// </summary>
+        [Description("Use the system's default DNS resolver using TCP.")]
         SystemTcp,
         /// <summary>
         /// Cloudflare DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("Cloudflare DNS-over-HTTPS endpoint.")]
         Cloudflare,
         /// <summary>
         /// Cloudflare's security-focused DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("Cloudflare's security-focused DNS-over-HTTPS endpoint.")]
         CloudflareSecurity,
         /// <summary>
         /// Cloudflare's family-friendly DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("Cloudflare's family-friendly DNS-over-HTTPS endpoint.")]
         CloudflareFamily,
         /// <summary>
         /// Cloudflare's DNS-over-HTTPS endpoint using wire format.
         /// </summary>
+        [Description("Cloudflare's DNS-over-HTTPS endpoint using wire format.")]
         CloudflareWireFormat,
         /// <summary>
         /// Cloudflare's DNS-over-HTTPS endpoint using wire format with POST method.
         /// </summary>
+        [Description("Cloudflare's DNS-over-HTTPS endpoint using wire format with POST method.")]
         CloudflareWireFormatPost,
         /// <summary>
         /// Cloudflare's DNS-over-HTTPS endpoint using JSON over POST method.
         /// </summary>
+        [Description("Cloudflare's DNS-over-HTTPS endpoint using JSON over POST method.")]
         CloudflareJsonPost,
         /// <summary>
         /// Google's DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("Google's DNS-over-HTTPS endpoint.")]
         Google,
         /// <summary>
         /// Google's DNS-over-HTTPS endpoint using wire format over GET method.
         /// </summary>
+        [Description("Google's DNS-over-HTTPS endpoint using wire format over GET method.")]
         GoogleWireFormat,
         /// <summary>
         /// Google's DNS-over-HTTPS endpoint using wire format over POST method.
         /// </summary>
+        [Description("Google's DNS-over-HTTPS endpoint using wire format over POST method.")]
         GoogleWireFormatPost,
         /// <summary>
         /// Google's DNS-over-HTTPS endpoint using JSON over POST method.
         /// </summary>
+        [Description("Google's DNS-over-HTTPS endpoint using JSON over POST method.")]
         GoogleJsonPost,
         /// <summary>
         /// Quad9's DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("Quad9's DNS-over-HTTPS endpoint.")]
         Quad9,
         /// <summary>
         /// Quad9's DNS-over-HTTPS endpoint with ECS support.
         /// </summary>
+        [Description("Quad9's DNS-over-HTTPS endpoint with ECS support.")]
         Quad9ECS,
         /// <summary>
         /// Quad9's unsecured DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("Quad9's unsecured DNS-over-HTTPS endpoint.")]
         Quad9Unsecure,
         /// <summary>
         /// OpenDNS's DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("OpenDNS's DNS-over-HTTPS endpoint.")]
         OpenDNS,
         /// <summary>
         /// OpenDNS's family-friendly DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("OpenDNS's family-friendly DNS-over-HTTPS endpoint.")]
         OpenDNSFamily,
         /// <summary>
         /// Cloudflare's DNS-over-QUIC endpoint.
         /// </summary>
+        [Description("Cloudflare's DNS-over-QUIC endpoint.")]
         CloudflareQuic,
         /// <summary>
         /// Google's DNS-over-QUIC endpoint.
         /// </summary>
+        [Description("Google's DNS-over-QUIC endpoint.")]
         GoogleQuic,
         /// <summary>
         /// AdGuard DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("AdGuard DNS-over-HTTPS endpoint.")]
         AdGuard,
         /// <summary>
         /// AdGuard family protection DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("AdGuard family protection DNS-over-HTTPS endpoint.")]
         AdGuardFamily,
         /// <summary>
         /// AdGuard non-filtering DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("AdGuard non-filtering DNS-over-HTTPS endpoint.")]
         AdGuardNonFiltering,
         /// <summary>
         /// NextDNS DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("NextDNS DNS-over-HTTPS endpoint.")]
         NextDNS,
         /// <summary>
         /// Cloudflare DNSCrypt endpoint.
         /// </summary>
+        [Description("Cloudflare DNSCrypt endpoint.")]
         DnsCryptCloudflare,
         /// <summary>
         /// Quad9 DNSCrypt endpoint.
         /// </summary>
+        [Description("Quad9 DNSCrypt endpoint.")]
         DnsCryptQuad9,
         /// <summary>
         /// DNSCrypt relay server option.
         /// </summary>
+        [Description("DNSCrypt relay server option.")]
         DnsCryptRelay,
         /// <summary>
         /// DNS root servers, queried iteratively starting from one of the
         /// well known A-M root server instances.
         /// </summary>
+        [Description("DNS root servers, queried iteratively starting from one of the well known A-M root server instances.")]
         RootServer,
         /// <summary>
         /// Cloudflare's Oblivious DNS-over-HTTPS endpoint.
         /// </summary>
+        [Description("Cloudflare's Oblivious DNS-over-HTTPS endpoint.")]
         CloudflareOdoh,
         /// <summary>
         /// Custom DNS endpoint configured via <see cref="Configuration"/>
         /// overrides.
         /// </summary>
+        [Description("Custom DNS endpoint configured via overrides.")]
         Custom
+    }
+
+    /// <summary>
+    /// Extension helpers for <see cref="DnsEndpoint"/>.
+    /// </summary>
+    public static class DnsEndpointExtensions {
+        /// <summary>
+        /// Gets the description associated with the specified <see cref="DnsEndpoint"/>.
+        /// </summary>
+        /// <param name="endpoint">Endpoint value.</param>
+        /// <returns>Description text if available; otherwise the enum name.</returns>
+        public static string GetDescription(this DnsEndpoint endpoint) {
+            var member = typeof(DnsEndpoint).GetMember(endpoint.ToString());
+            var attr = member.Length > 0 ? member[0].GetCustomAttribute<DescriptionAttribute>() : null;
+            return attr?.Description ?? endpoint.ToString();
+        }
+
+        /// <summary>
+        /// Returns all <see cref="DnsEndpoint"/> values with their descriptions.
+        /// </summary>
+        /// <returns>Sequence of endpoint and description pairs.</returns>
+        public static IEnumerable<(DnsEndpoint Endpoint, string Description)> GetAllWithDescriptions() {
+            foreach (DnsEndpoint value in Enum.GetValues(typeof(DnsEndpoint))) {
+                yield return (value, value.GetDescription());
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `Description` attributes to each DnsEndpoint value
- provide `DnsEndpointExtensions` helper with methods to fetch descriptions
- update CLI help to list endpoints and their descriptions
- add tests verifying each endpoint has a description

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Cannot connect to network)*

------
https://chatgpt.com/codex/tasks/task_e_686c445c49a4832e9e522bbab29485ae