### PR TITLE
Add concurrency test for jitter

### DIFF
--- a/DnsClientX.Tests/GetJitterConcurrencyTests.cs
+++ b/DnsClientX.Tests/GetJitterConcurrencyTests.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class GetJitterConcurrencyTests {
+        [Fact]
+        public async Task GetJitter_ShouldBeThreadSafe() {
+            MethodInfo method = typeof(ClientX).GetMethod("GetJitter", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var tasks = Enumerable.Range(0, 50)
+                .Select(_ => Task.Run(() => (int)method.Invoke(null, new object[] { 100 })!));
+            var results = await Task.WhenAll(tasks);
+            Assert.Equal(50, results.Length);
+            Assert.All(results, r => Assert.InRange(r, 0, 100));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a test verifying GetJitter is thread-safe

## Testing
- `dotnet restore`
- `dotnet test -v n` *(fails: DnsClientX.Tests failed to run due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_686c4423697c832ea9ddf08d9059d9c5