### PR TITLE
Fix BaseUri nullability

### DIFF
--- a/DnsClientX.Examples/HelpersSpectre.cs
+++ b/DnsClientX.Examples/HelpersSpectre.cs
@@ -180,7 +180,13 @@ namespace DnsClientX.Examples {
             table.AddColumn("RequestFormat");
             table.AddColumn("BaseUri");
             foreach (var question in questions) {
-                table.AddRow(new Markup(question.Name), new Markup(question.Type.ToString()), new Markup(question.HostName), new Markup(question.Port.ToString()), new Markup(question.RequestFormat.ToString()), new Markup(question.BaseUri.ToString()));
+                table.AddRow(
+                    new Markup(question.Name),
+                    new Markup(question.Type.ToString()),
+                    new Markup(question.HostName),
+                    new Markup(question.Port.ToString()),
+                    new Markup(question.RequestFormat.ToString()),
+                    new Markup(question.BaseUri?.ToString() ?? string.Empty));
             }
             AnsiConsole.Write(table);
         }

--- a/DnsClientX.Tests/DnsResponseTests.cs
+++ b/DnsClientX.Tests/DnsResponseTests.cs
@@ -23,6 +23,36 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        public void AddServerDetailsLeavesBaseUriNullForUdp() {
+            var response = new DnsResponse {
+                Questions = new[] { new DnsQuestion { Name = "example.com", Type = DnsRecordType.A } }
+            };
+            var config = new Configuration("8.8.8.8", DnsRequestFormat.DnsOverUDP);
+
+            response.AddServerDetails(config);
+
+            Assert.Equal(config.Hostname, response.Questions[0].HostName);
+            Assert.Null(response.Questions[0].BaseUri);
+            Assert.Equal(config.RequestFormat, response.Questions[0].RequestFormat);
+            Assert.Equal(config.Port, response.Questions[0].Port);
+        }
+
+        [Fact]
+        public void AddServerDetailsLeavesBaseUriNullForTcp() {
+            var response = new DnsResponse {
+                Questions = new[] { new DnsQuestion { Name = "example.com", Type = DnsRecordType.A } }
+            };
+            var config = new Configuration("8.8.8.8", DnsRequestFormat.DnsOverTCP);
+
+            response.AddServerDetails(config);
+
+            Assert.Equal(config.Hostname, response.Questions[0].HostName);
+            Assert.Null(response.Questions[0].BaseUri);
+            Assert.Equal(config.RequestFormat, response.Questions[0].RequestFormat);
+            Assert.Equal(config.Port, response.Questions[0].Port);
+        }
+
+        [Fact]
         public void CommentConverterReadsArray() {
             var json = "[\"a\",\"b\"]";
             var options = new JsonSerializerOptions();

--- a/DnsClientX/Definitions/DnsQuestion.cs
+++ b/DnsClientX/Definitions/DnsQuestion.cs
@@ -17,7 +17,7 @@ namespace DnsClientX {
             OriginalName = string.Empty;
             Type = DnsRecordType.A;
             HostName = string.Empty;
-            BaseUri = null!;
+            BaseUri = null;
             RequestFormat = DnsRequestFormat.DnsOverHttps;
             Port = 0;
         }
@@ -61,7 +61,7 @@ namespace DnsClientX {
         /// Base URI of the DNS server which received the query.
         /// </summary>
         [JsonIgnore]
-        public Uri BaseUri { get; set; }
+        public Uri? BaseUri { get; set; }
 
         /// <summary>
         /// Request format of the DNS server which received the query.

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -122,7 +122,9 @@ namespace DnsClientX {
             }
             for (int i = 0; i < Questions.Length; i++) {
                 Questions[i].HostName = configuration.Hostname;
-                Questions[i].BaseUri = configuration.BaseUri;
+                if (configuration.BaseUri != null) {
+                    Questions[i].BaseUri = configuration.BaseUri;
+                }
                 Questions[i].RequestFormat = configuration.RequestFormat;
                 Questions[i].Port = configuration.Port;
             }


### PR DESCRIPTION
## Summary
- make `DnsQuestion.BaseUri` nullable
- skip BaseUri assignment when configuration has no BaseUri
- show `BaseUri` safely in examples
- test that UDP/TCP server details leave BaseUri null

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686cb632fc78832ebab701d585e55a64