### PR TITLE
Add RequestFormat setter to update port

### DIFF
--- a/DnsClientX.Tests/ConfigurationTests.cs
+++ b/DnsClientX.Tests/ConfigurationTests.cs
@@ -17,5 +17,20 @@ namespace DnsClientX.Tests {
         public void Constructor_ShouldThrowOnNullOrWhitespaceHostname(string hostname) {
             Assert.Throws<ArgumentException>(() => new Configuration(hostname!, DnsRequestFormat.DnsOverHttpsJSON));
         }
+
+        [Fact]
+        public void ShouldUpdatePortWhenFormatChanges() {
+            var config = new Configuration("1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            Assert.Equal(443, config.Port);
+
+            config.RequestFormat = DnsRequestFormat.DnsOverTCP;
+            Assert.Equal(53, config.Port);
+
+            config.RequestFormat = DnsRequestFormat.DnsOverTLS;
+            Assert.Equal(853, config.Port);
+
+            config.RequestFormat = DnsRequestFormat.Multicast;
+            Assert.Equal(5353, config.Port);
+        }
     }
 }

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -105,10 +105,28 @@ namespace DnsClientX {
         /// </summary>
         public EdnsOptions? EdnsOptions { get; set; }
 
+        private DnsRequestFormat requestFormat;
+
         /// <summary>
         /// Gets or sets the format of the DNS requests.
+        /// Updating the format adjusts <see cref="Port"/> according
+        /// to the same rules used by the constructors.
         /// </summary>
-        public DnsRequestFormat RequestFormat { get; set; }
+        public DnsRequestFormat RequestFormat {
+            get => requestFormat;
+            set {
+                requestFormat = value;
+                if (value == DnsRequestFormat.DnsOverTLS || value == DnsRequestFormat.DnsOverQuic) {
+                    Port = 853;
+                } else if (value == DnsRequestFormat.DnsOverUDP || value == DnsRequestFormat.DnsOverTCP || value == DnsRequestFormat.DnsCryptRelay) {
+                    Port = 53;
+                } else if (value == DnsRequestFormat.Multicast) {
+                    Port = 5353;
+                } else {
+                    Port = 443;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the port. The default value is 53 for DNS over UDP or DNS over TCP, and 853 for DNS over TLS.


### PR DESCRIPTION
## Summary
- update `Configuration.RequestFormat` setter to sync `Port`
- add unit test verifying port changes when request format changes

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~ConfigurationTests.ShouldUpdatePortWhenFormatChanges`

------
https://chatgpt.com/codex/tasks/task_e_686cc4b85524832eb94e45c51e88372e