### PR TITLE
Fix zone transfer SOA validation

### DIFF
--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -75,7 +75,7 @@ namespace DnsClientX {
 
             var lastResponse = await DnsWire.DeserializeDnsWireFormat(null, Debug, responses[responses.Count - 1]).ConfigureAwait(false);
             lastResponse.AddServerDetails(EndpointConfiguration);
-            if (lastResponse.Answers == null || lastResponse.Answers.Length == 0 || lastResponse.Answers[^1].Type != DnsRecordType.SOA) {
+            if (lastResponse.Answers == null || lastResponse.Answers.Length == 0 || lastResponse.Answers[lastResponse.Answers.Length - 1].Type != DnsRecordType.SOA) {
                 throw new DnsClientException("Zone transfer incomplete: closing SOA record missing.");
             }
 

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -75,7 +75,7 @@ namespace DnsClientX {
 
             var lastResponse = await DnsWire.DeserializeDnsWireFormat(null, Debug, responses[responses.Count - 1]).ConfigureAwait(false);
             lastResponse.AddServerDetails(EndpointConfiguration);
-            if (lastResponse.Answers == null || !lastResponse.Answers.Any(a => a.Type == DnsRecordType.SOA)) {
+            if (lastResponse.Answers == null || lastResponse.Answers.Length == 0 || lastResponse.Answers[^1].Type != DnsRecordType.SOA) {
                 throw new DnsClientException("Zone transfer incomplete: closing SOA record missing.");
             }
 


### PR DESCRIPTION
## Summary
- validate closing SOA record is last in zone transfer
- add test for misplaced closing SOA

## Testing
- `dotnet test` *(fails: Cannot connect to external hosts)*

------
https://chatgpt.com/codex/tasks/task_e_686cc4c0cba0832e86cae7de35a5ad43