### PR TITLE
Fix disposed clients cleanup

### DIFF
--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -142,5 +142,16 @@ namespace DnsClientX.Tests {
             Assert.True(handler.DisposeAsyncCount >= handler.DisposeCount, $"AsyncCount={handler.DisposeAsyncCount} DisposeCount={handler.DisposeCount}");
         }
 #endif
+
+        [Fact]
+        public void Client_Dispose_ShouldClearDisposedClientsList() {
+            var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
+
+            clientX.Dispose();
+
+            var field = typeof(ClientX).GetField("_disposedClients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var disposedClients = (HashSet<HttpClient>)field.GetValue(clientX)!;
+            Assert.Empty(disposedClients);
+        }
     }
 }

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -52,6 +52,10 @@ namespace DnsClientX {
                         }
                     }
 
+                    lock (_lock) {
+                        _disposedClients.Clear();
+                    }
+
                     if (mainClient != null && TryAddDisposedClient(mainClient)) {
                         mainClient.Dispose();
                     }
@@ -106,6 +110,10 @@ namespace DnsClientX {
                         client.Dispose();
 #endif
                     }
+                }
+
+                lock (_lock) {
+                    _disposedClients.Clear();
                 }
 
                 if (mainClient != null && TryAddDisposedClient(mainClient)) {


### PR DESCRIPTION
## Summary
- clear `_disposedClients` after iterating clients during disposal
- add regression test to ensure `_disposedClients` stays empty post-disposal

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686cc4acd16c832e95fc0062c4386dc0