### PR TITLE
Enable IPv6 UDP queries

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveUdpIPv6Tests.cs
+++ b/DnsClientX.Tests/DnsWireResolveUdpIPv6Tests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireResolveUdpIPv6Tests {
+        private static byte[] CreateDnsHeader() {
+            byte[] bytes = new byte[12];
+            ushort id = 0x1234;
+            bytes[0] = (byte)(id >> 8);
+            bytes[1] = (byte)(id & 0xFF);
+            ushort flags = 0x8180;
+            bytes[2] = (byte)(flags >> 8);
+            bytes[3] = (byte)(flags & 0xFF);
+            return bytes;
+        }
+
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.IPv6Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
+            using var udp = new UdpClient(new IPEndPoint(IPAddress.IPv6Loopback, port));
+            UdpReceiveResult result = await udp.ReceiveAsync();
+            await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatUdp_ShouldWorkWithIPv6Server() {
+            int port = GetFreePort();
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var udpTask = RunUdpServerAsync(port, response, cts.Token);
+
+            var config = new Configuration("::1", DnsRequestFormat.DnsOverUDP) { Port = port };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "::1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            DnsResponse dnsResponse = await task;
+
+            await udpTask;
+            Assert.Equal(DnsResponseCode.NoError, dnsResponse.Status);
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -48,7 +48,8 @@ namespace DnsClientX {
 
             try {
                 // Send the DNS query over UDP and receive the response
-                using var udpClient = new UdpClient();
+                var address = IPAddress.Parse(dnsServer);
+                using var udpClient = new UdpClient(address.AddressFamily);
                 var responseBuffer = await SendQueryOverUdp(udpClient, queryBytes, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
 
                 // Deserialize the response from DNS wire format
@@ -99,7 +100,11 @@ namespace DnsClientX {
         /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverUdp(UdpClient udpClient, byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             // Set the server IP address and port number
-            var serverEndpoint = new IPEndPoint(IPAddress.Parse(dnsServer), port);
+            var ipAddress = IPAddress.Parse(dnsServer);
+            if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6) {
+                udpClient.Client.DualMode = true;
+            }
+            var serverEndpoint = new IPEndPoint(ipAddress, port);
 
                 // Send the query
 #if NET5_0_OR_GREATER


### PR DESCRIPTION
## Summary
- fix IPv6 handling for UDP queries by picking address family and enabling dual mode
- add a regression test covering IPv6 UDP server

## Testing
- `dotnet test DnsClientX.sln --verbosity minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686cc4c8cc3c832e91001b12032f6d8b