### PR TITLE
Capture last retry exception

### DIFF
--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -120,6 +120,7 @@ namespace DnsClientX.Tests {
 
             var ex = await Assert.ThrowsAsync<DnsClientException>(Invoke);
             Assert.Equal(DnsResponseCode.ServerFailure, ex.Response.Status);
+            Assert.Same(transientResponse, ex.Response);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- keep the last `DnsClientException` from `RetryAsync`
- verify the captured response in tests

## Testing
- `dotnet test DnsClientX.sln` *(fails: The argument ... invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686cc4d9d36c832e90f84fd196575bb3