### PR TITLE
Improve brace expansion logic

### DIFF
--- a/DnsClientX.Tests/ResolvePatternTests.cs
+++ b/DnsClientX.Tests/ResolvePatternTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -38,6 +39,15 @@ namespace DnsClientX.Tests {
 
             Assert.Equal(3, handler.CallCount);
             Assert.Equal(3, responses.Length);
+        }
+
+        [Fact]
+        public void ExpandPattern_MultipleBraces() {
+            string pattern = "srv{a,b}{1,2}.example.com";
+
+            string[] names = ClientX.ExpandPattern(pattern).ToArray();
+
+            Assert.Equal(new[] { "srva1.example.com", "srva2.example.com", "srvb1.example.com", "srvb2.example.com" }, names);
         }
     }
 }


### PR DESCRIPTION
## Summary
- enhance pattern expansion to handle multiple brace expressions recursively
- add helper to find matching closing brace
- test brace expansion with sequential expressions

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: Failed: 143, Passed: 327, Skipped: 16)*

------
https://chatgpt.com/codex/tasks/task_e_686cc4e6a37c832ebf14cbf14b655d13