### PR TITLE
Implement CD bit support

### DIFF
--- a/DnsClientX.Tests/CdBitTests.cs
+++ b/DnsClientX.Tests/CdBitTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class CdBitTests {
+        private static byte[] CreateDnsHeader() {
+            byte[] bytes = new byte[12];
+            ushort id = 0x1234;
+            bytes[0] = (byte)(id >> 8);
+            bytes[1] = (byte)(id & 0xFF);
+            ushort flags = 0x8180;
+            bytes[2] = (byte)(flags >> 8);
+            bytes[3] = (byte)(flags & 0xFF);
+            return bytes;
+        }
+
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task<byte[]> RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
+            using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
+            UdpReceiveResult result = await udp.ReceiveAsync();
+            await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
+            return result.Buffer;
+        }
+
+        private static async Task<byte[]> RunTcpServerAsync(int port, byte[] response, CancellationToken token) {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            NetworkStream stream = client.GetStream();
+            byte[] lengthBuffer = new byte[2];
+            await stream.ReadAsync(lengthBuffer, 0, 2, token);
+            if (BitConverter.IsLittleEndian) Array.Reverse(lengthBuffer);
+            int length = BitConverter.ToUInt16(lengthBuffer, 0);
+            byte[] queryBuffer = new byte[length];
+            await stream.ReadAsync(queryBuffer, 0, length, token);
+            byte[] prefix = BitConverter.GetBytes((ushort)response.Length);
+            if (BitConverter.IsLittleEndian) Array.Reverse(prefix);
+            await stream.WriteAsync(prefix, 0, prefix.Length, token);
+            await stream.WriteAsync(response, 0, response.Length, token);
+            listener.Stop();
+            return queryBuffer;
+        }
+
+        private static void AssertCdBit(byte[] query, string name, uint expectedTtl) {
+            int additionalCount = (query[10] << 8) | query[11];
+            Assert.Equal(1, additionalCount);
+
+            int offset = 12;
+            foreach (var label in name.Split('.')) {
+                offset += 1 + label.Length;
+            }
+            offset += 1 + 2 + 2;
+
+            Assert.Equal(0, query[offset]);
+            ushort type = (ushort)((query[offset + 1] << 8) | query[offset + 2]);
+            Assert.Equal((ushort)DnsRecordType.OPT, type);
+            uint ttl = (uint)((query[offset + 5] << 24) | (query[offset + 6] << 16) | (query[offset + 7] << 8) | query[offset + 8]);
+            Assert.Equal(expectedTtl, ttl);
+        }
+
+        [Fact]
+        public async Task UdpRequest_ShouldIncludeCdBit_WhenConfigured() {
+            int port = GetFreePort();
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var udpTask = RunUdpServerAsync(port, response, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, CheckingDisabled = true };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            await task;
+            byte[] query = await udpTask;
+
+            AssertCdBit(query, "example.com", 0x10u);
+        }
+
+        [Fact]
+        public async Task TcpRequest_ShouldIncludeCdBit_WhenConfigured() {
+            int port = GetFreePort();
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var tcpTask = RunTcpServerAsync(port, response, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port, CheckingDisabled = true };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            await task;
+            byte[] query = await tcpTask;
+
+            AssertCdBit(query, "example.com", 0x10u);
+        }
+
+        [Fact]
+        public void DotRequest_ShouldIncludeCdBit_WhenConfigured() {
+            var message = new DnsMessage("example.com", DnsRecordType.A, false, true, 4096, null, true);
+            byte[] data = message.SerializeDnsWireFormat();
+            AssertCdBit(data, "example.com", 0x10u);
+        }
+
+        [Fact]
+        public void DoqRequest_ShouldIncludeCdBit_WhenConfigured() {
+            var message = new DnsMessage("example.com", DnsRecordType.A, false, true, 4096, null, true);
+            byte[] data = message.SerializeDnsWireFormat();
+            AssertCdBit(data, "example.com", 0x10u);
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -75,6 +75,11 @@ namespace DnsClientX {
         public bool ValidateRootDnsSec { get; set; }
 
         /// <summary>
+        /// Sets the CD (Checking Disabled) flag on queries.
+        /// </summary>
+        public bool CheckingDisabled { get; set; }
+
+        /// <summary>
         /// Determines whether to fall back to TCP when a UDP response is truncated.
         /// </summary>
         public bool UseTcpFallback { get; set; } = true;

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -63,6 +63,11 @@ namespace DnsClientX {
         private async Task<DnsResponse> ResolveInternal(string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool returnAllTypes, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
+            bool originalCd = EndpointConfiguration.CheckingDisabled;
+            if (validateDnsSec) {
+                EndpointConfiguration.CheckingDisabled = !originalCd;
+            }
+
             // lets we execute valid dns host name strategy
             EndpointConfiguration.SelectHostNameStrategy();
 
@@ -171,6 +176,8 @@ namespace DnsClientX {
                 }
                 _auditTrail.Enqueue(auditEntry);
             }
+
+            EndpointConfiguration.CheckingDisabled = originalCd;
 
             return response;
         }

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -34,7 +34,7 @@ namespace DnsClientX {
 
             EndpointConfiguration.SelectHostNameStrategy();
 
-            var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize, null);
+            var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize, null, EndpointConfiguration.CheckingDisabled);
             var queryBytes = query.SerializeDnsWireFormat();
 
             async Task<List<byte[]>> Execute() => await SendAxfrOverTcp(queryBytes, EndpointConfiguration.Hostname, EndpointConfiguration.Port, EndpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);

--- a/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
+++ b/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
@@ -24,7 +24,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatHttp2(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet, endpointConfiguration.CheckingDisabled);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -28,7 +28,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -40,7 +40,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
             var queryBytes = query.SerializeDnsWireFormat();
 
             var lengthPrefix = BitConverter.GetBytes((ushort)queryBytes.Length);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -37,7 +37,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
             var queryBytes = query.SerializeDnsWireFormat();
 
             // Calculate the length prefix for the query

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
@@ -13,7 +13,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {


### PR DESCRIPTION
## Summary
- add `CheckingDisabled` property to configuration
- support CD flag in DNS message construction
- propagate CheckingDisabled to all wire resolvers
- toggle CD flag when DNSSEC validation requested
- test new CD bit handling

## Testing
- `dotnet test` *(fails: connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cd04727c8832ebeffd42a01469f6d