### PR TITLE
Add TCP read timeout support

### DIFF
--- a/DnsClientX.Tests/DnsWireReadTimeoutTests.cs
+++ b/DnsClientX.Tests/DnsWireReadTimeoutTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireReadTimeoutTests {
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task RunStallingServerAsync(int port, CancellationToken token) {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            NetworkStream stream = client.GetStream();
+            byte[] len = new byte[2];
+            await stream.ReadAsync(len, 0, 2, token);
+            if (BitConverter.IsLittleEndian) Array.Reverse(len);
+            int length = BitConverter.ToUInt16(len, 0);
+            byte[] buffer = new byte[length];
+            await stream.ReadAsync(buffer, 0, length, token);
+            await Task.Delay(Timeout.Infinite, token);
+            listener.Stop();
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatTcp_ShouldTimeoutOnStalledServer() {
+            int port = GetFreePort();
+            using var cts = new CancellationTokenSource();
+            var serverTask = RunStallingServerAsync(port, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port, TimeOut = 200 };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+            await Assert.ThrowsAsync<TimeoutException>(async () => {
+                var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None })!;
+                await task;
+            });
+
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverTask);
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -159,6 +159,11 @@ namespace DnsClientX {
         /// Helper to read exactly the requested number of bytes from a stream with timeout.
         /// </summary>
         private static async Task ReadExactWithTimeoutAsync(Stream stream, byte[] buffer, int offset, int count, int timeoutMilliseconds, CancellationToken cancellationToken) {
+#if NET5_0_OR_GREATER || NET472 || NETSTANDARD2_0
+            if (stream.CanTimeout) {
+                stream.ReadTimeout = timeoutMilliseconds;
+            }
+#endif
             var readTask = DnsWire.ReadExactAsync(stream, buffer, offset, count, cancellationToken);
             var timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
             var completedTask = await Task.WhenAny(readTask, timeoutTask).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- apply `ReadTimeout` to TCP streams when reading DNS responses
- add test to verify stalled servers trigger `TimeoutException`

## Testing
- `dotnet test` *(fails: HttpRequestException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686cd32b2678832ea43be5f91e0d2f8d