### PR TITLE
Add uniqueness check for root servers

### DIFF
--- a/DnsClientX.Tests/RootServersTests.cs
+++ b/DnsClientX.Tests/RootServersTests.cs
@@ -10,5 +10,16 @@ namespace DnsClientX.Tests {
             Assert.Equal(13, servers.Count(s => !s.Contains(':')));
             Assert.Equal(13, servers.Count(s => s.Contains(':')));
         }
+
+        [Fact]
+        public void RootServersList_HasOnlyUniqueValues() {
+            var servers = RootServers.Servers;
+            var ipv4Servers = servers.Where(s => !s.Contains(':')).ToArray();
+            var ipv6Servers = servers.Where(s => s.Contains(':')).ToArray();
+
+            Assert.Equal(ipv4Servers.Length, ipv4Servers.Distinct().Count());
+            Assert.Equal(ipv6Servers.Length, ipv6Servers.Distinct().Count());
+            Assert.Equal(servers.Length, servers.Distinct().Count());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `RootServersList_HasOnlyUniqueValues` test

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: QueryDns over network)*

------
https://chatgpt.com/codex/tasks/task_e_686cd33fb3e0832e9b3a4f318d18355d