### PR TITLE
Add cache cleanup routine

### DIFF
--- a/DnsClientX.Tests/DnsResponseCacheTests.cs
+++ b/DnsClientX.Tests/DnsResponseCacheTests.cs
@@ -28,6 +28,18 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        public void ShouldCleanupExpiredEntries() {
+            var cache = new DnsResponseCache();
+            var response = new DnsResponse { Status = DnsResponseCode.NoError };
+            cache.Set("a", response, TimeSpan.FromMilliseconds(10));
+            cache.Set("b", response, TimeSpan.FromMilliseconds(10));
+            Thread.Sleep(20);
+            cache.Cleanup();
+            Assert.False(cache.TryGet("a", out _));
+            Assert.False(cache.TryGet("b", out _));
+        }
+
+        [Fact]
         public void ClientConstructorEnablesCache() {
             using var client = new ClientX(enableCache: true);
             PropertyInfo property = typeof(ClientX).GetProperty("CacheEnabled")!;


### PR DESCRIPTION
## Summary
- implement cache cleanup timer and threshold
- expose Cleanup method
- test cleanup behavior

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: DnssecTests.QueryDnskey_WithDnssec etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686cd3362d90832eb7ec95bbe1e07c85