### PR TITLE
Handle TLS auth failures

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveDotTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveDotTests.cs
@@ -40,7 +40,9 @@ namespace DnsClientX.Tests {
         private static X509Certificate2 CreateInvalidCertificate() {
             using var ecdsa = ECDsa.Create();
             var req = new CertificateRequest("CN=invalid", ecdsa, HashAlgorithmName.SHA256);
-            return req.CreateSelfSigned(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddDays(1));
+            using X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddDays(1));
+            byte[] pfx = cert.Export(X509ContentType.Pfx);
+            return new X509Certificate2(pfx, (string?)null, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet);
         }
 
         [Fact]

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -107,7 +107,7 @@ namespace DnsClientX {
                 response.AddServerDetails(endpointConfiguration);
                 return response;
             } catch (Exception ex) {
-                if (ex is AuthenticationException || ex is IOException { InnerException: AuthenticationException }) {
+                if (ex is AuthenticationException || (ex is IOException ioEx && ioEx.InnerException is AuthenticationException)) {
                     DnsResponse authResponse = new DnsResponse {
                         Questions = [
                             new DnsQuestion() {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -68,48 +68,84 @@ namespace DnsClientX {
                 Settings.Logger.WriteDebug($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
             }
 
-            // Create a new TCP client and connect to the DNS server
-            using var client = new TcpClient();
-            await ConnectAsync(client, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
-
-            // Create a new SSL stream for the secure connection
-            using var sslStream = new SslStream(client.GetStream(), false, (sender, certificate, chain, sslPolicyErrors) =>
-                sslPolicyErrors == SslPolicyErrors.None || ignoreCertificateErrors);
-
-
-            // Authenticate the client using the DNS server's name and the TLS protocol
             try {
+                // Create a new TCP client and connect to the DNS server
+                using var client = new TcpClient();
+                await ConnectAsync(client, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
+
+                // Create a new SSL stream for the secure connection
+                using var sslStream = new SslStream(client.GetStream(), false, (sender, certificate, chain, sslPolicyErrors) =>
+                    sslPolicyErrors == SslPolicyErrors.None || ignoreCertificateErrors);
+
+                // Authenticate the client using the DNS server's name and the TLS protocol
                 await sslStream.AuthenticateAsClientAsync(dnsServer, null, SslProtocols.Tls12, false).ConfigureAwait(false);
-            } catch (Exception ex) when (ex is AuthenticationException || ex is IOException) {
-                throw new DnsClientException($"TLS handshake failed: {ex.Message}");
-            }
 
-            // Write the combined query bytes to the SSL stream and flush it
-            await sslStream.WriteAsync(combinedQueryBytes, 0, combinedQueryBytes.Length, cancellationToken).ConfigureAwait(false);
-            await sslStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                // Write the combined query bytes to the SSL stream and flush it
+                await sslStream.WriteAsync(combinedQueryBytes, 0, combinedQueryBytes.Length, cancellationToken).ConfigureAwait(false);
+                await sslStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-            // Prepare to read the response with handling for length prefix
-            var lengthPrefixBuffer = new byte[2];
-            int prefixBytesRead = await sslStream.ReadAsync(lengthPrefixBuffer, 0, 2, cancellationToken).ConfigureAwait(false);
-            if (prefixBytesRead != 2) {
-                throw new Exception("Failed to read the length prefix of the response.");
-            }
-            int responseLength = (lengthPrefixBuffer[0] << 8) + lengthPrefixBuffer[1]; // Calculate total response length
-
-            var responseBuffer = new byte[responseLength];
-            int totalBytesRead = 0;
-            while (totalBytesRead < responseLength) {
-                int bytesRead = await sslStream.ReadAsync(responseBuffer, totalBytesRead, responseLength - totalBytesRead, cancellationToken).ConfigureAwait(false);
-                if (bytesRead == 0) {
-                    throw new Exception("The stream was closed before the entire response could be read.");
+                // Prepare to read the response with handling for length prefix
+                var lengthPrefixBuffer = new byte[2];
+                int prefixBytesRead = await sslStream.ReadAsync(lengthPrefixBuffer, 0, 2, cancellationToken).ConfigureAwait(false);
+                if (prefixBytesRead != 2) {
+                    throw new Exception("Failed to read the length prefix of the response.");
                 }
-                totalBytesRead += bytesRead;
-            }
+                int responseLength = (lengthPrefixBuffer[0] << 8) + lengthPrefixBuffer[1]; // Calculate total response length
 
-            // Deserialize the response from DNS wire format
-            var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
-            response.AddServerDetails(endpointConfiguration);
-            return response;
+                var responseBuffer = new byte[responseLength];
+                int totalBytesRead = 0;
+                while (totalBytesRead < responseLength) {
+                    int bytesRead = await sslStream.ReadAsync(responseBuffer, totalBytesRead, responseLength - totalBytesRead, cancellationToken).ConfigureAwait(false);
+                    if (bytesRead == 0) {
+                        throw new Exception("The stream was closed before the entire response could be read.");
+                    }
+                    totalBytesRead += bytesRead;
+                }
+
+                // Deserialize the response from DNS wire format
+                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
+                response.AddServerDetails(endpointConfiguration);
+                return response;
+            } catch (AuthenticationException ex) {
+                DnsResponse response = new DnsResponse {
+                    Questions = [
+                        new DnsQuestion() {
+                            Name = name,
+                            RequestFormat = DnsRequestFormat.DnsOverTLS,
+                            Type = type,
+                            OriginalName = name
+                        }
+                    ],
+                    Status = DnsResponseCode.Refused
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" => {ex.Message} {ex.InnerException?.Message}";
+                return response;
+            } catch (Exception ex) {
+                DnsResponseCode responseCode;
+                if (ex is SocketException) {
+                    responseCode = DnsResponseCode.Refused;
+                } else if (ex is TimeoutException) {
+                    responseCode = DnsResponseCode.ServerFailure;
+                } else {
+                    responseCode = DnsResponseCode.ServerFailure;
+                }
+
+                DnsResponse response = new DnsResponse {
+                    Questions = [
+                        new DnsQuestion() {
+                            Name = name,
+                            RequestFormat = DnsRequestFormat.DnsOverTLS,
+                            Type = type,
+                            OriginalName = name
+                        }
+                    ],
+                    Status = responseCode
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" => {ex.Message + " " + ex.InnerException?.Message}";
+                return response;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- handle AuthenticationException in DoT resolver by returning detailed `DnsResponse`
- generate an invalid cert in DoT tests and verify error message

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --filter FullyQualifiedName~DnsWireResolveDotTests -v minimal`
- `dotnet build DnsClientX.sln -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_686cd32253b4832ea9438a02d89857b7