### PR TITLE
Add cancellation token to RetryTest

### DIFF
--- a/DnsClientX.Tests/CancellationTimeoutTests.cs
+++ b/DnsClientX.Tests/CancellationTimeoutTests.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class CancellationTimeoutTests {
+        [Fact]
+        public async Task TasksCancelAfterTimeout() {
+            using var cts = new CancellationTokenSource(100);
+            var tasks = new[] {
+                Task.Delay(1000, cts.Token),
+                Task.Delay(1000, cts.Token)
+            };
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await Task.WhenAll(tasks));
+        }
+    }
+}

--- a/RetryTest/Program.cs
+++ b/RetryTest/Program.cs
@@ -1,10 +1,27 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using DnsClientX;
 
 namespace RetryTest {
     class Program {
         static async Task Main(string[] args) {
+            // Cancel all DNS operations after a timeout to prevent endless waits.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await RunAsync(cts.Token);
+        }
+
+        /// <summary>
+        /// Executes the DNS tests. Pass a cancellation token to control the lifetime.
+        /// </summary>
+        /// <remarks>
+        /// Example:
+        /// <code>
+        /// using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        /// await Program.RunAsync(cts.Token);
+        /// </code>
+        /// </remarks>
+        internal static async Task RunAsync(CancellationToken cancellationToken) {
             var logger = new InternalLogger(true) { IsInformation = true };
             logger.WriteInformation("Testing Quad9 DNS servers for empty response patterns...");
 
@@ -22,6 +39,7 @@ namespace RetryTest {
             };
 
             foreach (var (domain, recordType) in testCases) {
+                cancellationToken.ThrowIfCancellationRequested();
                 logger.WriteInformation($"\n=== Testing {domain} / {recordType} ===");
 
                 foreach (var (name, endpoint) in endpoints) {
@@ -29,12 +47,12 @@ namespace RetryTest {
                         var client = new ClientX(endpoint);
 
                         // Test ResolveAll which is what the failing test uses
-                        var answers = await client.ResolveAll(domain, recordType);
+                        var answers = await client.ResolveAll(domain, recordType, cancellationToken: cancellationToken);
 
                         logger.WriteInformation($"{name}: {answers.Length} records");
                         if (answers.Length == 0) {
                             // Get the full response to see status code
-                            var fullResponse = await client.Resolve(domain, recordType);
+                            var fullResponse = await client.Resolve(domain, recordType, cancellationToken: cancellationToken);
                             logger.WriteInformation($"  Status: {fullResponse.Status}");
                             logger.WriteInformation($"  Error: {fullResponse.Error ?? "None"}");
                         } else {


### PR DESCRIPTION
## Summary
- add a RunAsync method that accepts a CancellationToken
- demonstrate usage and enforce a 10 second timeout
- pass the token when calling `ClientX` methods
- add a unit test ensuring tasks cancel after the timeout

## Testing
- `dotnet test --no-build` *(fails: 141 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686cd306fd48832e890494c07c220f9f