### PR TITLE
Add cancellation tests for QueryDns arrays

### DIFF
--- a/DnsClientX.Tests/CancellationTests.cs
+++ b/DnsClientX.Tests/CancellationTests.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Net.Http;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,6 +38,24 @@ namespace DnsClientX.Tests {
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             await Assert.ThrowsAsync<TaskCanceledException>(() => ClientX.QueryDns("example.com", DnsRecordType.A, cancellationToken: cts.Token));
+        }
+
+        [Fact]
+        public async Task QueryDns_ArrayNames_ShouldCancelEarly() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                () => ClientX.QueryDns(new[] { "example.com" }, DnsRecordType.A, cancellationToken: cts.Token));
+        }
+
+        [Fact]
+        public async Task QueryDns_ArrayTypes_ShouldCancelEarly() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                () => ClientX.QueryDns(new[] { "example.com" }, new[] { DnsRecordType.A }, cancellationToken: cts.Token));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- add more early-cancellation tests for QueryDns overloads

## Testing
- `dotnet test --verbosity minimal` *(fails: DNS network tests fail in environment)*

------
https://chatgpt.com/codex/tasks/task_e_686cd2f64eb8832ea43296776eb12b86