### PR TITLE
Add DNS UPDATE support

### DIFF
--- a/DnsClientX.Examples/DemoDnsUpdate.cs
+++ b/DnsClientX.Examples/DemoDnsUpdate.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Example usage of <see cref="ClientX"/> DNS UPDATE methods.
+    /// </summary>
+    internal class DemoDnsUpdate {
+        /// <summary>
+        /// Demonstrates adding a record to a zone.
+        /// </summary>
+        public static async Task ExampleAdd() {
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP);
+            await client.UpdateRecordAsync("example.com", "www.example.com", DnsRecordType.A, "1.2.3.4");
+        }
+
+        /// <summary>
+        /// Demonstrates deleting a record from a zone.
+        /// </summary>
+        public static async Task ExampleDelete() {
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP);
+            await client.DeleteRecordAsync("example.com", "www.example.com", DnsRecordType.A);
+        }
+    }
+}

--- a/DnsClientX.PowerShell/CmdletDnsUpdate.cs
+++ b/DnsClientX.PowerShell/CmdletDnsUpdate.cs
@@ -1,0 +1,58 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DnsClientX.PowerShell;
+
+/// <summary>
+/// <para type="synopsis">Sends DNS UPDATE messages to a server.</para>
+/// <para type="description">Adds or removes records in a zone using RFC 2136 over TCP.</para>
+/// <example>
+///   <para>Add a record</para>
+///   <code>Invoke-DnsUpdate -Zone example.com -Server 127.0.0.1 -Name www -Type A -Data 1.2.3.4</code>
+/// </example>
+/// </summary>
+[Cmdlet(VerbsLifecycle.Invoke, "DnsUpdate")]
+public sealed class CmdletDnsUpdate : AsyncPSCmdlet {
+    /// <summary>Zone to update.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Zone { get; set; } = string.Empty;
+
+    /// <summary>DNS server to send the update to.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    [Alias("ServerName")]
+    public string Server { get; set; } = string.Empty;
+
+    /// <summary>Port number to use. Defaults to 53.</summary>
+    [Parameter(Mandatory = false)]
+    public int Port { get; set; } = 53;
+
+    /// <summary>Record name.</summary>
+    [Parameter(Mandatory = true, Position = 2)]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Type of record.</summary>
+    [Parameter(Mandatory = true, Position = 3)]
+    public DnsRecordType Type { get; set; }
+
+    /// <summary>Record data used when adding a record.</summary>
+    [Parameter(Position = 4)]
+    public string Data { get; set; } = string.Empty;
+
+    /// <summary>TTL for the new record. Defaults to 300 seconds.</summary>
+    [Parameter]
+    public int Ttl { get; set; } = 300;
+
+    /// <summary>If specified, the record is removed instead of added.</summary>
+    [Parameter]
+    public SwitchParameter Delete;
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        using var client = new ClientX(Server, DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = Port } };
+        DnsResponse result = Delete.IsPresent
+            ? await client.DeleteRecordAsync(Zone, Name, Type)
+            : await client.UpdateRecordAsync(Zone, Name, Type, Data, Ttl);
+        WriteObject(result);
+    }
+}
+

--- a/DnsClientX.Tests/DnsUpdateTests.cs
+++ b/DnsClientX.Tests/DnsUpdateTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsUpdateTests {
+        private static byte[] EncodeName(string name) {
+            name = name.TrimEnd('.');
+            using var ms = new System.IO.MemoryStream();
+            foreach (var part in name.Split('.')) {
+                var bytes = System.Text.Encoding.ASCII.GetBytes(part);
+                ms.WriteByte((byte)bytes.Length);
+                ms.Write(bytes, 0, bytes.Length);
+            }
+            ms.WriteByte(0);
+            return ms.ToArray();
+        }
+
+        private static void WriteUInt16(System.IO.Stream s, ushort val) {
+            var b = new byte[2];
+            b[0] = (byte)(val >> 8);
+            b[1] = (byte)val;
+            s.Write(b, 0, 2);
+        }
+
+        private static byte[] BuildResponse(DnsResponseCode code) {
+            using var ms = new System.IO.MemoryStream();
+            WriteUInt16(ms, 1);
+            ushort flags = (ushort)(0x8000 | (ushort)code);
+            WriteUInt16(ms, flags);
+            WriteUInt16(ms, 1);
+            WriteUInt16(ms, 0);
+            WriteUInt16(ms, 0);
+            WriteUInt16(ms, 0);
+            var zone = EncodeName("example.com");
+            ms.Write(zone, 0, zone.Length);
+            WriteUInt16(ms, (ushort)DnsRecordType.SOA);
+            WriteUInt16(ms, 1);
+            return ms.ToArray();
+        }
+
+        private sealed class UpdateServer {
+            public int Port { get; }
+            public Task Task { get; }
+            public UpdateServer(int port, Task task) { Port = port; Task = task; }
+        }
+
+        private static UpdateServer RunServerAsync(byte[] response, CancellationToken token) {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+            async Task Serve() {
+#if NETFRAMEWORK
+                using TcpClient client = await listener.AcceptTcpClientAsync();
+#else
+                using TcpClient client = await listener.AcceptTcpClientAsync(token);
+#endif
+                NetworkStream stream = client.GetStream();
+                byte[] len = new byte[2];
+                await stream.ReadAsync(len, 0, 2, token);
+                if (BitConverter.IsLittleEndian) Array.Reverse(len);
+                int qLen = BitConverter.ToUInt16(len, 0);
+                byte[] q = new byte[qLen];
+                await stream.ReadAsync(q, 0, qLen, token);
+                byte[] prefix = BitConverter.GetBytes((ushort)response.Length);
+                if (BitConverter.IsLittleEndian) Array.Reverse(prefix);
+                await stream.WriteAsync(prefix, 0, prefix.Length, token);
+                await stream.WriteAsync(response, 0, response.Length, token);
+                listener.Stop();
+            }
+
+            return new UpdateServer(port, Serve());
+        }
+
+        [Fact]
+        public async Task UpdateRecordAsync_ReturnsSuccess() {
+            byte[] resp = BuildResponse(DnsResponseCode.NoError);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var server = RunServerAsync(resp, cts.Token);
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = server.Port } };
+            var res = await client.UpdateRecordAsync("example.com", "www.example.com", DnsRecordType.A, "1.2.3.4");
+            await server.Task;
+            Assert.Equal(DnsResponseCode.NoError, res.Status);
+        }
+
+        [Fact]
+        public async Task UpdateRecordAsync_FailsWithError() {
+            byte[] resp = BuildResponse(DnsResponseCode.Refused);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var server = RunServerAsync(resp, cts.Token);
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = server.Port } };
+            await Assert.ThrowsAsync<DnsClientException>(() => client.UpdateRecordAsync("example.com", "www.example.com", DnsRecordType.A, "1.2.3.4"));
+            await server.Task;
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.Update.cs
+++ b/DnsClientX/DnsClientX.Update.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class providing DNS UPDATE operations.
+    /// </summary>
+    public partial class ClientX {
+        /// <summary>
+        /// Sends a DNS UPDATE request to add or modify a record in a zone.
+        /// </summary>
+        /// <param name="zone">Zone to update.</param>
+        /// <param name="name">Record name.</param>
+        /// <param name="type">Type of record.</param>
+        /// <param name="data">Record data.</param>
+        /// <param name="ttl">Time to live for the record.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>DNS response returned by the server.</returns>
+        /// <exception cref="DnsClientException">Thrown when the server returns an error.</exception>
+        public async Task<DnsResponse> UpdateRecordAsync(string zone, string name, DnsRecordType type, string data, int ttl = 300, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrEmpty(zone)) throw new ArgumentNullException(nameof(zone));
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
+            EndpointConfiguration.SelectHostNameStrategy();
+            var response = await DnsWireUpdateTcp.UpdateRecordAsync(EndpointConfiguration.Hostname, EndpointConfiguration.Port, zone, name, type, data, ttl, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            if (response.Status != DnsResponseCode.NoError) {
+                throw new DnsClientException($"DNS update failed with {response.Status}", response);
+            }
+            return response;
+        }
+
+        /// <summary>
+        /// Sends a DNS UPDATE request to delete a record from a zone.
+        /// </summary>
+        /// <param name="zone">Zone containing the record.</param>
+        /// <param name="name">Record name.</param>
+        /// <param name="type">Type of record.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>DNS response returned by the server.</returns>
+        /// <exception cref="DnsClientException">Thrown when the server returns an error.</exception>
+        public async Task<DnsResponse> DeleteRecordAsync(string zone, string name, DnsRecordType type, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrEmpty(zone)) throw new ArgumentNullException(nameof(zone));
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
+            EndpointConfiguration.SelectHostNameStrategy();
+            var response = await DnsWireUpdateTcp.DeleteRecordAsync(EndpointConfiguration.Hostname, EndpointConfiguration.Port, zone, name, type, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            if (response.Status != DnsResponseCode.NoError) {
+                throw new DnsClientException($"DNS update failed with {response.Status}", response);
+            }
+            return response;
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsUpdateMessage.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsUpdateMessage.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Helper methods for constructing DNS UPDATE messages.
+    /// </summary>
+    internal static class DnsUpdateMessage {
+        private static void WriteUInt16(Stream stream, ushort value) {
+            var bytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)value));
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static void WriteUInt32(Stream stream, uint value) {
+            var bytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((int)value));
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static void WriteName(Stream stream, string name) {
+            foreach (var part in name.TrimEnd('.').Split('.')) {
+                var bytes = Encoding.ASCII.GetBytes(part);
+                stream.WriteByte((byte)bytes.Length);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+            stream.WriteByte(0);
+        }
+
+        private static byte[] BuildRdata(DnsRecordType type, string data) {
+            return type switch {
+                DnsRecordType.A => IPAddress.Parse(data).GetAddressBytes(),
+                DnsRecordType.AAAA => IPAddress.Parse(data).GetAddressBytes(),
+                DnsRecordType.CNAME or DnsRecordType.NS => BuildNameRdata(data),
+                DnsRecordType.TXT => BuildTxtRdata(data),
+                _ => Encoding.ASCII.GetBytes(data)
+            };
+        }
+
+        private static byte[] BuildNameRdata(string name) {
+            using var ms = new MemoryStream();
+            WriteName(ms, name);
+            return ms.ToArray();
+        }
+
+        private static byte[] BuildTxtRdata(string text) {
+            using var ms = new MemoryStream();
+            if (text.Length > 255) {
+                var parts = text.Split(' ');
+                foreach (var part in parts) {
+                    var bytes = Encoding.ASCII.GetBytes(part);
+                    ms.WriteByte((byte)bytes.Length);
+                    ms.Write(bytes, 0, bytes.Length);
+                }
+            } else {
+                var bytes = Encoding.ASCII.GetBytes(text);
+                ms.WriteByte((byte)bytes.Length);
+                ms.Write(bytes, 0, bytes.Length);
+            }
+            return ms.ToArray();
+        }
+
+        /// <summary>
+        /// Creates a wire formatted message for adding a DNS record.
+        /// </summary>
+        /// <param name="zone">Zone to update.</param>
+        /// <param name="name">Record name.</param>
+        /// <param name="type">Record type.</param>
+        /// <param name="data">Record data.</param>
+        /// <param name="ttl">Time to live of the record.</param>
+        /// <returns>Serialized DNS UPDATE packet.</returns>
+        internal static byte[] CreateAddMessage(string zone, string name, DnsRecordType type, string data, int ttl) {
+            using var ms = new MemoryStream();
+            var rand = new Random();
+            WriteUInt16(ms, (ushort)rand.Next(ushort.MinValue, ushort.MaxValue));
+            WriteUInt16(ms, 0x2800); // opcode UPDATE
+            WriteUInt16(ms, 1); // zone count
+            WriteUInt16(ms, 0); // prereq count
+            WriteUInt16(ms, 1); // update count
+            WriteUInt16(ms, 0); // additional
+            WriteName(ms, zone);
+            WriteUInt16(ms, (ushort)DnsRecordType.SOA);
+            WriteUInt16(ms, 1); // class IN
+            WriteName(ms, name);
+            WriteUInt16(ms, (ushort)type);
+            WriteUInt16(ms, 1);
+            WriteUInt32(ms, (uint)ttl);
+            var rdata = BuildRdata(type, data);
+            WriteUInt16(ms, (ushort)rdata.Length);
+            ms.Write(rdata, 0, rdata.Length);
+            return ms.ToArray();
+        }
+
+        /// <summary>
+        /// Creates a wire formatted message for deleting a DNS record.
+        /// </summary>
+        /// <param name="zone">Zone containing the record.</param>
+        /// <param name="name">Record name.</param>
+        /// <param name="type">Record type.</param>
+        /// <returns>Serialized DNS UPDATE packet.</returns>
+        internal static byte[] CreateDeleteMessage(string zone, string name, DnsRecordType type) {
+            using var ms = new MemoryStream();
+            var rand = new Random();
+            WriteUInt16(ms, (ushort)rand.Next(ushort.MinValue, ushort.MaxValue));
+            WriteUInt16(ms, 0x2800); // opcode UPDATE
+            WriteUInt16(ms, 1); // zone count
+            WriteUInt16(ms, 0); // prereq
+            WriteUInt16(ms, 1); // update count
+            WriteUInt16(ms, 0); // additional
+            WriteName(ms, zone);
+            WriteUInt16(ms, (ushort)DnsRecordType.SOA);
+            WriteUInt16(ms, 1);
+            WriteName(ms, name);
+            WriteUInt16(ms, (ushort)type);
+            WriteUInt16(ms, 255); // class ANY for delete
+            WriteUInt32(ms, 0);
+            WriteUInt16(ms, 0);
+            return ms.ToArray();
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWireUpdateTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireUpdateTcp.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Sends DNS UPDATE messages using TCP transport.
+    /// </summary>
+    internal static class DnsWireUpdateTcp {
+        private static async Task<byte[]> SendMessageOverTcp(byte[] message, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
+            var tcpClient = new TcpClient();
+            NetworkStream? stream = null;
+            try {
+                await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
+                stream = tcpClient.GetStream();
+                var lengthBytes = BitConverter.GetBytes((ushort)message.Length);
+                if (BitConverter.IsLittleEndian) Array.Reverse(lengthBytes);
+                await stream.WriteAsync(lengthBytes, 0, lengthBytes.Length, cancellationToken).ConfigureAwait(false);
+                await stream.WriteAsync(message, 0, message.Length, cancellationToken).ConfigureAwait(false);
+                lengthBytes = new byte[2];
+                await ReadExactWithTimeoutAsync(stream, lengthBytes, 0, 2, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
+                if (BitConverter.IsLittleEndian) Array.Reverse(lengthBytes);
+                var responseLength = BitConverter.ToUInt16(lengthBytes, 0);
+                var responseBuffer = new byte[responseLength];
+                await ReadExactWithTimeoutAsync(stream, responseBuffer, 0, responseBuffer.Length, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
+                return responseBuffer;
+            } finally {
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                if (stream is not null) await stream.DisposeAsync().ConfigureAwait(false);
+#else
+                stream?.Dispose();
+#endif
+                tcpClient.Close();
+                tcpClient.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Sends a DNS UPDATE message to add or modify a record.
+        /// </summary>
+        /// <param name="dnsServer">Server address.</param>
+        /// <param name="port">Server port.</param>
+        /// <param name="zone">Zone to update.</param>
+        /// <param name="name">Record name.</param>
+        /// <param name="type">Record type.</param>
+        /// <param name="data">Record data.</param>
+        /// <param name="ttl">Record TTL.</param>
+        /// <param name="debug">Whether debugging is enabled.</param>
+        /// <param name="endpointConfiguration">Endpoint settings.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>Response from the DNS server.</returns>
+        internal static async Task<DnsResponse> UpdateRecordAsync(string dnsServer, int port, string zone, string name, DnsRecordType type, string data, int ttl, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            var message = DnsUpdateMessage.CreateAddMessage(zone, name, type, data, ttl);
+            var responseBuffer = await SendMessageOverTcp(message, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
+            var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
+            response.AddServerDetails(endpointConfiguration);
+            return response;
+        }
+
+        /// <summary>
+        /// Sends a DNS UPDATE message to delete a record.
+        /// </summary>
+        /// <param name="dnsServer">Server address.</param>
+        /// <param name="port">Server port.</param>
+        /// <param name="zone">Zone containing the record.</param>
+        /// <param name="name">Record name.</param>
+        /// <param name="type">Record type.</param>
+        /// <param name="debug">Whether debugging is enabled.</param>
+        /// <param name="endpointConfiguration">Endpoint settings.</param>
+        /// <param name="cancellationToken">Token used to cancel the request.</param>
+        /// <returns>Response from the DNS server.</returns>
+        internal static async Task<DnsResponse> DeleteRecordAsync(string dnsServer, int port, string zone, string name, DnsRecordType type, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            var message = DnsUpdateMessage.CreateDeleteMessage(zone, name, type);
+            var responseBuffer = await SendMessageOverTcp(message, dnsServer, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
+            var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
+            response.AddServerDetails(endpointConfiguration);
+            return response;
+        }
+
+        private static async Task ReadExactWithTimeoutAsync(Stream stream, byte[] buffer, int offset, int count, int timeoutMilliseconds, CancellationToken cancellationToken) {
+            var readTask = DnsWire.ReadExactAsync(stream, buffer, offset, count, cancellationToken);
+            var timeoutTask = Task.Delay(timeoutMilliseconds, cancellationToken);
+            var completedTask = await Task.WhenAny(readTask, timeoutTask).ConfigureAwait(false);
+
+            if (completedTask == timeoutTask) {
+                throw new TimeoutException($"Reading from stream timed out after {timeoutMilliseconds} milliseconds.");
+            }
+
+            await readTask.ConfigureAwait(false);
+        }
+
+        private static async Task ConnectAsync(TcpClient tcpClient, string host, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            if (timeoutMilliseconds <= 0) {
+                linkedCts.Cancel();
+            } else {
+                linkedCts.CancelAfter(timeoutMilliseconds);
+            }
+#if NET5_0_OR_GREATER
+            try {
+                await tcpClient.ConnectAsync(host, port, linkedCts.Token).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                tcpClient.Close();
+                cancellationToken.ThrowIfCancellationRequested();
+                throw new TimeoutException($"Connection to {host}:{port} timed out after {timeoutMilliseconds} milliseconds.");
+            }
+#else
+            var connectTask = tcpClient.ConnectAsync(host, port);
+            var delayTask = Task.Delay(Timeout.Infinite, linkedCts.Token);
+
+            var completed = await Task.WhenAny(connectTask, delayTask).ConfigureAwait(false);
+            if (completed != connectTask) {
+                tcpClient.Close();
+                cancellationToken.ThrowIfCancellationRequested();
+                throw new TimeoutException($"Connection to {host}:{port} timed out after {timeoutMilliseconds} milliseconds.");
+            }
+
+            await connectTask.ConfigureAwait(false);
+#endif
+        }
+    }
+}

--- a/Module/DnsClientX.psd1
+++ b/Module/DnsClientX.psd1
@@ -1,7 +1,7 @@
 @{
     AliasesToExport      = @('Get-DnsZoneTransfer', 'Resolve-DnsQuery')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-DnsService', 'Get-DnsZone', 'Resolve-Dns')
+    CmdletsToExport      = @('Get-DnsService', 'Get-DnsZone', 'Resolve-Dns', 'Invoke-DnsUpdate')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Examples/Example.DnsUpdate.ps1
+++ b/Module/Examples/Example.DnsUpdate.ps1
@@ -1,0 +1,8 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DnsClientX.psd1 -Force
+
+# Add a record
+Invoke-DnsUpdate -Zone 'example.com' -Server '127.0.0.1' -Name 'www' -Type A -Data '192.0.2.1' -Ttl 300
+
+# Delete a record
+Invoke-DnsUpdate -Zone 'example.com' -Server '127.0.0.1' -Name 'www' -Type A -Delete

--- a/Module/Tests/InvokeDnsUpdate.Tests.ps1
+++ b/Module/Tests/InvokeDnsUpdate.Tests.ps1
@@ -1,0 +1,11 @@
+Import-Module "$PSScriptRoot/../DnsClientX.psd1" -Force
+
+Describe 'Invoke-DnsUpdate cmdlet' {
+    It 'Cmdlet is available' {
+        Get-Command Invoke-DnsUpdate | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Fails when server is unreachable' {
+        { Invoke-DnsUpdate -Zone 'example.com' -Server '127.0.0.1' -Name 'www' -Type A -Data '1.1.1.1' -Port 1 -ErrorAction Stop } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- add DNS update message builder and TCP sender
- implement `UpdateRecordAsync` and `DeleteRecordAsync` in ClientX
- expose new `Invoke-DnsUpdate` PowerShell cmdlet
- add example scripts and tests
- document public APIs for DNS UPDATE

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build -v minimal` *(fails: DNS tests require network)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path Module/Tests"` *(failed: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd2df4d80832eb826ccafae0b07cd