### PR TITLE
Add root anchor helper and update documentation

### DIFF
--- a/DeveloperNotes.md
+++ b/DeveloperNotes.md
@@ -1,0 +1,11 @@
+# Developer Notes
+
+## Updating Root Trust Anchors
+
+Run the `RootAnchorHelper` to download the latest trust anchors from IANA and update `RootTrustAnchors.cs`.
+
+```
+var records = await RootAnchorHelper.FetchLatestAsync();
+```
+
+Replace the `DsRecords` array in `DnsClientX/Security/RootTrustAnchors.cs` with the values returned by `FetchLatestAsync`.

--- a/DnsClientX.Tests/RootAnchorHelperTests.cs
+++ b/DnsClientX.Tests/RootAnchorHelperTests.cs
@@ -9,15 +9,15 @@ public class RootAnchorHelperTests
     public void ParseFromXml_ParsesRecords()
     {
         const string xml = """
-<TrustAnchor id=\"test\">
+<TrustAnchor id="test">
   <Zone>.</Zone>
-  <KeyDigest validFrom=\"2024-07-18T00:00:00+00:00\">
+  <KeyDigest validFrom="2024-07-18T00:00:00+00:00">
     <KeyTag>38696</KeyTag>
     <Algorithm>8</Algorithm>
     <DigestType>2</DigestType>
     <Digest>683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16</Digest>
   </KeyDigest>
-  <KeyDigest validFrom=\"2017-02-02T00:00:00+00:00\">
+  <KeyDigest validFrom="2017-02-02T00:00:00+00:00">
     <KeyTag>20326</KeyTag>
     <Algorithm>8</Algorithm>
     <DigestType>2</DigestType>

--- a/DnsClientX.Tests/RootAnchorHelperTests.cs
+++ b/DnsClientX.Tests/RootAnchorHelperTests.cs
@@ -1,0 +1,33 @@
+using DnsClientX;
+using Xunit;
+
+namespace DnsClientX.Tests;
+
+public class RootAnchorHelperTests
+{
+    [Fact]
+    public void ParseFromXml_ParsesRecords()
+    {
+        const string xml = """
+<TrustAnchor id=\"test\">
+  <Zone>.</Zone>
+  <KeyDigest validFrom=\"2024-07-18T00:00:00+00:00\">
+    <KeyTag>38696</KeyTag>
+    <Algorithm>8</Algorithm>
+    <DigestType>2</DigestType>
+    <Digest>683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16</Digest>
+  </KeyDigest>
+  <KeyDigest validFrom=\"2017-02-02T00:00:00+00:00\">
+    <KeyTag>20326</KeyTag>
+    <Algorithm>8</Algorithm>
+    <DigestType>2</DigestType>
+    <Digest>E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D</Digest>
+  </KeyDigest>
+</TrustAnchor>
+""";
+        RootDsRecord[] records = RootAnchorHelper.ParseFromXml(xml);
+        Assert.Equal(2, records.Length);
+        Assert.Contains(records, r => r.KeyTag == 38696);
+        Assert.Contains(records, r => r.KeyTag == 20326);
+    }
+}

--- a/DnsClientX/Security/RootAnchorHelper.cs
+++ b/DnsClientX/Security/RootAnchorHelper.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace DnsClientX;
+
+/// <summary>
+/// Provides helper methods for obtaining root DNSSEC trust anchors.
+/// </summary>
+internal static class RootAnchorHelper {
+    private const string Url = "https://data.iana.org/root-anchors/root-anchors.xml";
+
+    /// <summary>
+    /// Downloads and parses the current root trust anchor records.
+    /// </summary>
+    /// <returns>Array of <see cref="RootDsRecord"/> entries.</returns>
+    public static async Task<RootDsRecord[]> FetchLatestAsync() {
+        using HttpClient client = new();
+        string xml = await client.GetStringAsync(Url).ConfigureAwait(false);
+        return ParseFromXml(xml);
+    }
+
+    /// <summary>
+    /// Parses root anchor DS records from an XML string.
+    /// </summary>
+    /// <param name="xml">Root anchor XML document.</param>
+    /// <returns>Array of parsed records.</returns>
+    internal static RootDsRecord[] ParseFromXml(string xml) {
+        XDocument document = XDocument.Parse(xml);
+        DateTime now = DateTime.UtcNow;
+        return document
+            .Descendants("KeyDigest")
+            .Where(d => IsValid(d, now))
+            .Select(d => new RootDsRecord(
+                ushort.Parse(d.Element("KeyTag")!.Value, CultureInfo.InvariantCulture),
+                (DnsKeyAlgorithm)byte.Parse(d.Element("Algorithm")!.Value, CultureInfo.InvariantCulture),
+                byte.Parse(d.Element("DigestType")!.Value, CultureInfo.InvariantCulture),
+                d.Element("Digest")!.Value.ToUpperInvariant()))
+            .ToArray();
+    }
+
+    private static bool IsValid(XElement element, DateTime now) {
+        DateTime validFrom = DateTime.Parse(element.Attribute("validFrom")!.Value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+        DateTime validUntil = element.Attribute("validUntil") != null
+            ? DateTime.Parse(element.Attribute("validUntil")!.Value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal)
+            : DateTime.MaxValue;
+        return validFrom <= now && now <= validUntil;
+    }
+}

--- a/DnsClientX/Security/RootTrustAnchors.cs
+++ b/DnsClientX/Security/RootTrustAnchors.cs
@@ -1,33 +1,40 @@
-namespace DnsClientX {
-    /// <summary>
-    /// Represents a DNSSEC DS record used as a trust anchor.
-    /// </summary>
-    internal readonly struct RootDsRecord {
-        /// <summary>Key tag of the DNSKEY record.</summary>
-        public ushort KeyTag { get; }
-        /// <summary>DNSKEY algorithm identifier.</summary>
-        public DnsKeyAlgorithm Algorithm { get; }
-        /// <summary>Digest type as defined by RFC 4034.</summary>
-        public byte DigestType { get; }
-        /// <summary>Hex-encoded digest value.</summary>
-        public string Digest { get; }
+namespace DnsClientX;
 
-        public RootDsRecord(ushort keyTag, DnsKeyAlgorithm algorithm, byte digestType, string digest) {
-            KeyTag = keyTag;
-            Algorithm = algorithm;
-            DigestType = digestType;
-            Digest = digest;
-        }
-    }
+/// <summary>
+/// Represents a DNSSEC DS record used as a trust anchor.
+/// </summary>
+internal readonly struct RootDsRecord
+{
+    /// <summary>Key tag of the DNSKEY record.</summary>
+    public ushort KeyTag { get; }
 
-    /// <summary>
-    /// Collection of built-in root trust anchors for DNSSEC validation.
-    /// </summary>
-    internal static class RootTrustAnchors {
-        /// <summary>Default DS records for the DNS root.</summary>
-        internal static readonly RootDsRecord[] DsRecords = {
-            new RootDsRecord(20326, DnsKeyAlgorithm.RSASHA256, 2, "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"),
-            new RootDsRecord(38696, DnsKeyAlgorithm.RSASHA256, 2, "683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16")
-        };
+    /// <summary>DNSKEY algorithm identifier.</summary>
+    public DnsKeyAlgorithm Algorithm { get; }
+
+    /// <summary>Digest type as defined by RFC 4034.</summary>
+    public byte DigestType { get; }
+
+    /// <summary>Hex-encoded digest value.</summary>
+    public string Digest { get; }
+
+    public RootDsRecord(ushort keyTag, DnsKeyAlgorithm algorithm, byte digestType, string digest)
+    {
+        KeyTag = keyTag;
+        Algorithm = algorithm;
+        DigestType = digestType;
+        Digest = digest;
     }
+}
+
+/// <summary>
+/// Collection of built-in root trust anchors for DNSSEC validation.
+/// </summary>
+internal static class RootTrustAnchors
+{
+    /// <summary>Default DS records for the DNS root.</summary>
+    internal static readonly RootDsRecord[] DsRecords =
+    {
+        new(20326, DnsKeyAlgorithm.RSASHA256, 2, "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"),
+        new(38696, DnsKeyAlgorithm.RSASHA256, 2, "683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16")
+    };
 }


### PR DESCRIPTION
## Summary
- add `RootAnchorHelper` to fetch and parse IANA trust anchors
- regenerate `RootTrustAnchors.cs` using file‑scoped namespace style
- add unit test for `RootAnchorHelper`
- document the update process in new `DeveloperNotes.md`

## Testing
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686cde09b364832e9c49388dff9e2ce2