### PR TITLE
Implement DNSSEC chain verification

### DIFF
--- a/DnsClientX.Examples/DemoDnsSecValidation.cs
+++ b/DnsClientX.Examples/DemoDnsSecValidation.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates performing a DNS query with DNSSEC validation enabled.
+    /// </summary>
+    internal class DemoDnsSecValidation {
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            DnsResponse response = await client.Resolve("evotec.pl", DnsRecordType.DNSKEY, requestDnsSec: true, validateDnsSec: true);
+            response.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Tests/DnssecChainValidatorTests.cs
+++ b/DnsClientX.Tests/DnssecChainValidatorTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnssecChainValidatorTests {
+        private static byte[] DomainToWireFormat(string domain) {
+            if (string.IsNullOrEmpty(domain) || domain == ".") return new byte[] { 0 };
+            string[] labels = domain.TrimEnd('.').Split('.');
+            var data = new List<byte>();
+            foreach (string label in labels) {
+                byte[] bytes = System.Text.Encoding.ASCII.GetBytes(label.ToLowerInvariant());
+                data.Add((byte)bytes.Length);
+                data.AddRange(bytes);
+            }
+            data.Add(0);
+            return data.ToArray();
+        }
+
+        private static ushort ComputeKeyTag(ushort flags, byte protocol, DnsKeyAlgorithm algorithm, byte[] publicKey) {
+            byte[] rdata = new byte[4 + publicKey.Length];
+            BinaryPrimitives.WriteUInt16BigEndian(rdata, flags);
+            rdata[2] = protocol;
+            rdata[3] = (byte)algorithm;
+            Buffer.BlockCopy(publicKey, 0, rdata, 4, publicKey.Length);
+            uint acc = 0;
+            for (int i = 0; i < rdata.Length; i++) {
+                acc += (i & 1) == 0 ? (uint)rdata[i] << 8 : rdata[i];
+            }
+            acc += acc >> 16;
+            return (ushort)(acc & 0xFFFF);
+        }
+
+        private static string ComputeDigest(string name, ushort flags, byte protocol, DnsKeyAlgorithm algorithm, byte[] publicKey) {
+            byte[] owner = DomainToWireFormat(name);
+            byte[] rdata = new byte[4 + publicKey.Length];
+            BinaryPrimitives.WriteUInt16BigEndian(rdata, flags);
+            rdata[2] = protocol;
+            rdata[3] = (byte)algorithm;
+            Buffer.BlockCopy(publicKey, 0, rdata, 4, publicKey.Length);
+            byte[] message = new byte[owner.Length + rdata.Length];
+            Buffer.BlockCopy(owner, 0, message, 0, owner.Length);
+            Buffer.BlockCopy(rdata, 0, message, owner.Length, rdata.Length);
+            using SHA256 sha256 = SHA256.Create();
+            byte[] digestBytes = sha256.ComputeHash(message);
+            return BitConverter.ToString(digestBytes).Replace("-", string.Empty).ToUpperInvariant();
+        }
+
+        private static byte[] BuildSignedData(string name, int ttl, DateTime exp, DateTime inc, ushort keyTag, byte[] publicKey) {
+            Type validator = typeof(DnsSecValidator);
+            Type dnsKeyRec = validator.GetNestedType("DnsKeyRecord", System.Reflection.BindingFlags.NonPublic)!;
+            Type rrsigRec = validator.GetNestedType("RrsigRecord", System.Reflection.BindingFlags.NonPublic)!;
+            object dnsKey = Activator.CreateInstance(dnsKeyRec, name, (ushort)257, (byte)3, DnsKeyAlgorithm.RSASHA256, publicKey)!;
+            var list = (System.Collections.IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(dnsKeyRec))!;
+            list.Add(dnsKey);
+            object rrsig = Activator.CreateInstance(rrsigRec, DnsRecordType.DNSKEY, DnsKeyAlgorithm.RSASHA256, (byte)name.TrimEnd('.').Split('.').Length, ttl, exp, inc, keyTag, name, Array.Empty<byte>())!;
+            var method = validator.GetMethod("BuildDnskeySignedData", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            return (byte[])method.Invoke(null, new object[] { rrsig, list })!;
+        }
+
+
+        [Fact]
+        public void ValidateChain_Succeeds() {
+            using RSA rsa = RSA.Create(1024);
+            RSAParameters p = rsa.ExportParameters(true);
+            byte[] pub = BuildPublicKey(p);
+            string pubB64 = Convert.ToBase64String(pub);
+            const string name = "example.com.";
+            const ushort flags = 257;
+            const byte protocol = 3;
+            const DnsKeyAlgorithm alg = DnsKeyAlgorithm.RSASHA256;
+            var dnskey = new DnsAnswer { Name = name, Type = DnsRecordType.DNSKEY, TTL = 3600, DataRaw = $"{flags} {protocol} {(int)alg} {pubB64}" };
+            ushort tag = ComputeKeyTag(flags, protocol, alg, pub);
+            string digest = ComputeDigest(name, flags, protocol, alg, pub);
+            var ds = new DnsAnswer { Name = name, Type = DnsRecordType.DS, TTL = 3600, DataRaw = $"{tag} {(int)alg} 2 {digest}" };
+            DateTime inception = DateTime.UtcNow.AddMinutes(-1);
+            DateTime expiration = DateTime.UtcNow.AddHours(1);
+            byte[] data = BuildSignedData(name, 3600, expiration, inception, tag, pub);
+            byte[] sig = rsa.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            string sigB64 = Convert.ToBase64String(sig);
+            var rrsig = new DnsAnswer { Name = name, Type = DnsRecordType.RRSIG, TTL = 3600, DataRaw = $"DNSKEY {(int)alg} 2 3600 {(uint)(expiration - new DateTime(1970,1,1)).TotalSeconds} {(uint)(inception - new DateTime(1970,1,1)).TotalSeconds} {tag} {name} {sigB64}" };
+            var response = new DnsResponse { Answers = new[] { dnskey, ds, rrsig } };
+            Assert.True(DnsSecValidator.ValidateChain(response));
+        }
+
+        [Fact]
+        public void ValidateChain_InvalidSignature() {
+            using RSA rsa = RSA.Create(1024);
+            RSAParameters p = rsa.ExportParameters(true);
+            byte[] pub = BuildPublicKey(p);
+            string pubB64 = Convert.ToBase64String(pub);
+            const string name = "example.com.";
+            const ushort flags = 257;
+            const byte protocol = 3;
+            var dnskey = new DnsAnswer { Name = name, Type = DnsRecordType.DNSKEY, TTL = 3600, DataRaw = $"{flags} {protocol} 8 {pubB64}" };
+            ushort tag = ComputeKeyTag(flags, protocol, DnsKeyAlgorithm.RSASHA256, pub);
+            string digest = ComputeDigest(name, flags, protocol, DnsKeyAlgorithm.RSASHA256, pub);
+            var ds = new DnsAnswer { Name = name, Type = DnsRecordType.DS, TTL = 3600, DataRaw = $"{tag} 8 2 {digest}" };
+            DateTime inception = DateTime.UtcNow.AddMinutes(-1);
+            DateTime expiration = DateTime.UtcNow.AddHours(1);
+            byte[] data = BuildSignedData(name, 3600, expiration, inception, tag, pub);
+            byte[] sig = rsa.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            sig[0] ^= 0xFF; // corrupt
+            string sigB64 = Convert.ToBase64String(sig);
+            var rrsig = new DnsAnswer { Name = name, Type = DnsRecordType.RRSIG, TTL = 3600, DataRaw = $"DNSKEY 8 2 3600 {(uint)(expiration - new DateTime(1970,1,1)).TotalSeconds} {(uint)(inception - new DateTime(1970,1,1)).TotalSeconds} {tag} {name} {sigB64}" };
+            var response = new DnsResponse { Answers = new[] { dnskey, ds, rrsig } };
+            Assert.False(DnsSecValidator.ValidateChain(response));
+        }
+
+        private static byte[] BuildPublicKey(RSAParameters p) {
+            byte[] exponent = p.Exponent;
+            byte[] modulus = p.Modulus;
+            var key = new byte[(exponent.Length > 255 ? 3 : 1) + exponent.Length + modulus.Length];
+            int index = 0;
+            if (exponent.Length > 255) {
+                key[index++] = 0;
+                key[index++] = (byte)(exponent.Length >> 8);
+                key[index++] = (byte)exponent.Length;
+            } else {
+                key[index++] = (byte)exponent.Length;
+            }
+            Buffer.BlockCopy(exponent, 0, key, index, exponent.Length);
+            index += exponent.Length;
+            Buffer.BlockCopy(modulus, 0, key, index, modulus.Length);
+            return key;
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -154,6 +154,10 @@ namespace DnsClientX {
                         response.Error = string.IsNullOrEmpty(response.Error) ? validationError : $"{response.Error} {validationError}";
                     }
                 }
+                if (hasRrsig && !DnsSecValidator.ValidateChain(response)) {
+                    string validationError = "DNSSEC signature verification failed.";
+                    response.Error = string.IsNullOrEmpty(response.Error) ? validationError : $"{response.Error} {validationError}";
+                }
             }
 
             if (_cacheEnabled) {

--- a/DnsClientX/Security/DnsSecValidator.cs
+++ b/DnsClientX/Security/DnsSecValidator.cs
@@ -10,6 +10,61 @@ namespace DnsClientX {
     /// Provides helper methods for validating DNSSEC responses against the built-in root trust anchors.
     /// </summary>
     public static class DnsSecValidator {
+        private readonly struct DnsKeyRecord {
+            public string Name { get; }
+            public ushort Flags { get; }
+            public byte Protocol { get; }
+            public DnsKeyAlgorithm Algorithm { get; }
+            public byte[] PublicKey { get; }
+
+            public DnsKeyRecord(string name, ushort flags, byte protocol, DnsKeyAlgorithm algorithm, byte[] publicKey) {
+                Name = name;
+                Flags = flags;
+                Protocol = protocol;
+                Algorithm = algorithm;
+                PublicKey = publicKey;
+            }
+        }
+
+        private readonly struct DsRecord {
+            public string Name { get; }
+            public ushort KeyTag { get; }
+            public DnsKeyAlgorithm Algorithm { get; }
+            public byte DigestType { get; }
+            public string Digest { get; }
+
+            public DsRecord(string name, ushort keyTag, DnsKeyAlgorithm algorithm, byte digestType, string digest) {
+                Name = name;
+                KeyTag = keyTag;
+                Algorithm = algorithm;
+                DigestType = digestType;
+                Digest = digest;
+            }
+        }
+
+        private readonly struct RrsigRecord {
+            public DnsRecordType TypeCovered { get; }
+            public DnsKeyAlgorithm Algorithm { get; }
+            public byte Labels { get; }
+            public int OriginalTtl { get; }
+            public DateTime Expiration { get; }
+            public DateTime Inception { get; }
+            public ushort KeyTag { get; }
+            public string SignerName { get; }
+            public byte[] Signature { get; }
+
+            public RrsigRecord(DnsRecordType typeCovered, DnsKeyAlgorithm algorithm, byte labels, int originalTtl, DateTime expiration, DateTime inception, ushort keyTag, string signerName, byte[] signature) {
+                TypeCovered = typeCovered;
+                Algorithm = algorithm;
+                Labels = labels;
+                OriginalTtl = originalTtl;
+                Expiration = expiration;
+                Inception = inception;
+                KeyTag = keyTag;
+                SignerName = signerName;
+                Signature = signature;
+            }
+        }
         /// <summary>
         /// Validates the supplied <see cref="DnsResponse"/> against known root DS records.
         /// </summary>
@@ -37,6 +92,60 @@ namespace DnsClientX {
                 }
             }
             return false;
+        }
+
+        /// <summary>
+        /// Validates DNSSEC data by verifying DS records and RRSIG signatures for DNSKEY sets.
+        /// </summary>
+        /// <param name="response">DNS response to validate.</param>
+        /// <returns><c>true</c> when validation succeeds; otherwise <c>false</c>.</returns>
+        public static bool ValidateChain(DnsResponse response) {
+            if (response.Answers == null) {
+                return false;
+            }
+
+            var dnsKeys = new List<DnsKeyRecord>();
+            var dsRecords = new List<DsRecord>();
+            var rrsigs = new List<RrsigRecord>();
+
+            foreach (DnsAnswer answer in response.Answers) {
+                if (answer.Type == DnsRecordType.DNSKEY) {
+                    if (TryParseDnsKey(answer, out ushort flags, out byte protocol, out DnsKeyAlgorithm algorithm, out byte[] publicKey)) {
+                        dnsKeys.Add(new DnsKeyRecord(answer.Name, flags, protocol, algorithm, publicKey));
+                    }
+                } else if (answer.Type == DnsRecordType.DS) {
+                    if (TryParseDs(answer.DataRaw, out RootDsRecord ds)) {
+                        dsRecords.Add(new DsRecord(answer.Name, ds.KeyTag, ds.Algorithm, ds.DigestType, ds.Digest));
+                    }
+                } else if (answer.Type == DnsRecordType.RRSIG) {
+                    if (TryParseRrsig(answer, out RrsigRecord sig)) {
+                        rrsigs.Add(sig);
+                    }
+                }
+            }
+
+            if (dnsKeys.Count == 0 || rrsigs.Count == 0) {
+                return false;
+            }
+
+            foreach (RrsigRecord sig in rrsigs.Where(s => s.TypeCovered == DnsRecordType.DNSKEY)) {
+                if (!VerifyDnskeyRrsig(sig, dnsKeys)) {
+                    return false;
+                }
+            }
+
+            foreach (DsRecord ds in dsRecords) {
+                DnsKeyRecord? key = dnsKeys.FirstOrDefault(k => ComputeKeyTag(k.Flags, k.Protocol, k.Algorithm, k.PublicKey) == ds.KeyTag && k.Algorithm == ds.Algorithm);
+                if (key == null) {
+                    return false;
+                }
+                string digest = ComputeDigest(ds.Name, key.Value.Flags, key.Value.Protocol, key.Value.Algorithm, key.Value.PublicKey);
+                if (!digest.Equals(ds.Digest, StringComparison.OrdinalIgnoreCase)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -118,6 +227,63 @@ namespace DnsClientX {
             return true;
         }
 
+        private static bool TryParseRrsig(DnsAnswer answer, out RrsigRecord record) {
+            record = default;
+            if (string.IsNullOrWhiteSpace(answer.DataRaw)) {
+                return false;
+            }
+
+            string[] parts = answer.DataRaw.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 9) {
+                return false;
+            }
+
+            if (!Enum.TryParse(parts[0], true, out DnsRecordType typeCovered)) {
+                if (ushort.TryParse(parts[0], out ushort typeVal)) {
+                    typeCovered = (DnsRecordType)typeVal;
+                } else {
+                    return false;
+                }
+            }
+
+            if (!Enum.TryParse(parts[1], true, out DnsKeyAlgorithm alg)) {
+                if (byte.TryParse(parts[1], out byte algVal) && Enum.IsDefined(typeof(DnsKeyAlgorithm), (int)algVal)) {
+                    alg = (DnsKeyAlgorithm)algVal;
+                } else {
+                    return false;
+                }
+            }
+
+            if (!byte.TryParse(parts[2], out byte labels)) {
+                return false;
+            }
+
+            if (!int.TryParse(parts[3], out int originalTtl)) {
+                return false;
+            }
+
+            if (!uint.TryParse(parts[4], out uint expirationUnix)) {
+                return false;
+            }
+            if (!uint.TryParse(parts[5], out uint inceptionUnix)) {
+                return false;
+            }
+
+            if (!ushort.TryParse(parts[6], out ushort keyTag)) {
+                return false;
+            }
+
+            string signerName = parts[7];
+            string sigBase64 = string.Concat(parts.Skip(8));
+            try {
+                byte[] sig = Convert.FromBase64String(sigBase64);
+                record = new RrsigRecord(typeCovered, alg, labels, originalTtl, UnixToDateTime(expirationUnix), UnixToDateTime(inceptionUnix), keyTag, signerName, sig);
+                return true;
+            } catch {
+                return false;
+            }
+        }
+
         /// <summary>
         /// Computes the key tag value for a DNSKEY record as defined in RFC 4034.
         /// </summary>
@@ -164,6 +330,148 @@ namespace DnsClientX {
             return BitConverter.ToString(digestBytes).Replace("-", string.Empty).ToUpperInvariant();
         }
 
+        private static byte[] BuildDnskeySignedData(RrsigRecord rrsig, IReadOnlyCollection<DnsKeyRecord> dnsKeys) {
+            byte[] signerName = DomainToWireFormat(rrsig.SignerName);
+            byte[] header = new byte[18 + signerName.Length];
+            BinaryPrimitives.WriteUInt16BigEndian(header.AsSpan(0), (ushort)rrsig.TypeCovered);
+            header[2] = (byte)rrsig.Algorithm;
+            header[3] = rrsig.Labels;
+            BinaryPrimitives.WriteUInt32BigEndian(header.AsSpan(4), (uint)rrsig.OriginalTtl);
+            BinaryPrimitives.WriteUInt32BigEndian(header.AsSpan(8), (uint)(rrsig.Expiration.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds);
+            BinaryPrimitives.WriteUInt32BigEndian(header.AsSpan(12), (uint)(rrsig.Inception.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds);
+            BinaryPrimitives.WriteUInt16BigEndian(header.AsSpan(16), rrsig.KeyTag);
+            Buffer.BlockCopy(signerName, 0, header, 18, signerName.Length);
+
+            var rrBytes = new List<byte[]>();
+            foreach (DnsKeyRecord key in dnsKeys) {
+                byte[] owner = DomainToWireFormat(key.Name);
+                byte[] rdata = new byte[4 + key.PublicKey.Length];
+                BinaryPrimitives.WriteUInt16BigEndian(rdata, key.Flags);
+                rdata[2] = key.Protocol;
+                rdata[3] = (byte)key.Algorithm;
+                Buffer.BlockCopy(key.PublicKey, 0, rdata, 4, key.PublicKey.Length);
+                byte[] rr = new byte[owner.Length + 10 + rdata.Length];
+                int pos = 0;
+                Buffer.BlockCopy(owner, 0, rr, pos, owner.Length);
+                pos += owner.Length;
+                BinaryPrimitives.WriteUInt16BigEndian(rr.AsSpan(pos), (ushort)DnsRecordType.DNSKEY);
+                pos += 2;
+                BinaryPrimitives.WriteUInt16BigEndian(rr.AsSpan(pos), 1);
+                pos += 2;
+                BinaryPrimitives.WriteUInt32BigEndian(rr.AsSpan(pos), (uint)rrsig.OriginalTtl);
+                pos += 4;
+                BinaryPrimitives.WriteUInt16BigEndian(rr.AsSpan(pos), (ushort)rdata.Length);
+                pos += 2;
+                Buffer.BlockCopy(rdata, 0, rr, pos, rdata.Length);
+                rrBytes.Add(rr);
+            }
+
+            rrBytes.Sort(ByteArrayComparer.Instance);
+
+            int totalLength = header.Length + rrBytes.Sum(r => r.Length);
+            byte[] data = new byte[totalLength];
+            Buffer.BlockCopy(header, 0, data, 0, header.Length);
+            int offset = header.Length;
+            foreach (byte[] rr in rrBytes) {
+                Buffer.BlockCopy(rr, 0, data, offset, rr.Length);
+                offset += rr.Length;
+            }
+
+            return data;
+        }
+
+        private static bool VerifyDnskeyRrsig(RrsigRecord rrsig, IReadOnlyCollection<DnsKeyRecord> dnsKeys) {
+            foreach (DnsKeyRecord key in dnsKeys) {
+                ushort tag = ComputeKeyTag(key.Flags, key.Protocol, key.Algorithm, key.PublicKey);
+                if (tag != rrsig.KeyTag || key.Algorithm != rrsig.Algorithm) {
+                    continue;
+                }
+
+                byte[] data = BuildDnskeySignedData(rrsig, dnsKeys);
+
+                if (key.Algorithm == DnsKeyAlgorithm.RSASHA256 || key.Algorithm == DnsKeyAlgorithm.RSASHA512) {
+                    if (TryGetRsaParameters(key.PublicKey, out RSAParameters p)) {
+                        using RSA rsa = RSA.Create();
+                        rsa.ImportParameters(p);
+                        HashAlgorithmName hashAlg = key.Algorithm == DnsKeyAlgorithm.RSASHA256 ? HashAlgorithmName.SHA256 : HashAlgorithmName.SHA512;
+                        if (rsa.VerifyData(data, rrsig.Signature, hashAlg, RSASignaturePadding.Pkcs1)) {
+                            return true;
+                        }
+                    }
+                }
+#if NET5_0_OR_GREATER
+                else if (key.Algorithm == DnsKeyAlgorithm.ECDSAP256SHA256 || key.Algorithm == DnsKeyAlgorithm.ECDSAP384SHA384) {
+                    if (TryGetEcdsa(key.PublicKey, key.Algorithm, out ECDsa? ecdsa)) {
+                        using (ecdsa) {
+                            HashAlgorithmName hashAlg = key.Algorithm == DnsKeyAlgorithm.ECDSAP256SHA256 ? HashAlgorithmName.SHA256 : HashAlgorithmName.SHA384;
+                            if (ecdsa.VerifyData(data, rrsig.Signature, hashAlg)) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+#endif
+            }
+
+            return false;
+        }
+
+        private static bool TryGetRsaParameters(byte[] keyData, out RSAParameters parameters) {
+            parameters = default;
+            try {
+                int index = 0;
+                int exponentLength = keyData[index++];
+                if (exponentLength == 0) {
+                    exponentLength = (keyData[index] << 8) | keyData[index + 1];
+                    index += 2;
+                }
+                byte[] exponent = new byte[exponentLength];
+                Buffer.BlockCopy(keyData, index, exponent, 0, exponentLength);
+                index += exponentLength;
+                byte[] modulus = new byte[keyData.Length - index];
+                Buffer.BlockCopy(keyData, index, modulus, 0, modulus.Length);
+                parameters = new RSAParameters { Exponent = exponent, Modulus = modulus };
+                return true;
+            } catch {
+                return false;
+            }
+        }
+
+#if NET5_0_OR_GREATER
+        private static bool TryGetEcdsa(byte[] keyData, DnsKeyAlgorithm algorithm, out ECDsa? ecdsa) {
+            ecdsa = null;
+            try {
+                ECParameters ec = new();
+                ec.Curve = algorithm == DnsKeyAlgorithm.ECDSAP384SHA384 ? ECCurve.NamedCurves.nistP384 : ECCurve.NamedCurves.nistP256;
+                int coordLength = keyData.Length / 2;
+                ec.Q = new ECPoint {
+                    X = keyData.AsSpan(0, coordLength).ToArray(),
+                    Y = keyData.AsSpan(coordLength).ToArray()
+                };
+                ecdsa = ECDsa.Create(ec);
+                return true;
+            } catch {
+                return false;
+            }
+        }
+#endif
+
+        private sealed class ByteArrayComparer : IComparer<byte[]> {
+            internal static readonly ByteArrayComparer Instance = new();
+
+            public int Compare(byte[]? x, byte[]? y) {
+                if (x is null && y is null) return 0;
+                if (x is null) return -1;
+                if (y is null) return 1;
+                int len = Math.Min(x.Length, y.Length);
+                for (int i = 0; i < len; i++) {
+                    int cmp = x[i].CompareTo(y[i]);
+                    if (cmp != 0) return cmp;
+                }
+                return x.Length.CompareTo(y.Length);
+            }
+        }
+
         /// <summary>
         /// Converts a domain name to its DNS wire format representation.
         /// </summary>
@@ -182,6 +490,10 @@ namespace DnsClientX {
             }
             data.Add(0);
             return data.ToArray();
+        }
+
+        private static DateTime UnixToDateTime(uint seconds) {
+            return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(seconds);
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate DNSSEC chains by verifying RRSIG, DNSKEY and DS records
- integrate DNSSEC chain validation into the client
- add demo example showing validation usage
- add unit tests for DNSSEC chain validator

## Testing
- `dotnet build`
- `dotnet test --no-build --filter FullyQualifiedName~DnssecChainValidatorTests`

------
https://chatgpt.com/codex/tasks/task_e_686cde04e3e8832ebf0df38454408f28