### PR TITLE
Add DNSSEC options to PowerShell cmdlet

### DIFF
--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -24,7 +24,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
             if (dnsEndpoint == DnsEndpoint.RootServer) {
                 using var client = new ClientX();
                 if (cancellationToken.IsCancellationRequested) {
@@ -37,7 +37,7 @@ namespace DnsClientX {
                 if (cancellationToken.IsCancellationRequested) {
                     return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
                 }
-                var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return data;
             }
         }
@@ -56,8 +56,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
-        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
             if (dnsEndpoint == DnsEndpoint.RootServer) {
                 var tasks = name.Select(n => {
                     using var client = new ClientX();
@@ -90,7 +90,7 @@ namespace DnsClientX {
                 if (cancellationToken.IsCancellationRequested) {
                     return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
                 }
-                var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return data;
             }
         }
@@ -109,8 +109,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
-        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -127,13 +127,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(dnsUri, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -151,8 +151,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
-        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -168,13 +168,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(dnsUri, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -191,8 +191,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -209,13 +209,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -233,8 +233,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
-        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -250,13 +250,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -273,13 +273,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -296,8 +296,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -312,13 +312,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(endpoint: dnsEndpoint);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -335,8 +335,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsEndpoint, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, cancellationToken).RunSync(cancellationToken);
         }
     }
 }

--- a/Module/Examples/Example.ResolveDnsQuery.ps1
+++ b/Module/Examples/Example.ResolveDnsQuery.ps1
@@ -24,3 +24,4 @@ Resolve-DnsQuery -Name 'github.com', 'evotec.pl', 'google.com' -Type TXT -DnsPro
 # Should fail next two
 Resolve-DnsQuery -Name 'evotec.pl' -Type SOA -Server 8.8.4.1 -Verbose -TimeOut 500 | Format-Table
 Resolve-DnsQuery -Name 'evotec.pl' -Type SOA -Server a1.net -Verbose -TimeOut 500 | Format-Table
+\n# Request and validate DNSSEC\nResolve-DnsQuery -Name 'example.com' -Type A -DnsProvider Cloudflare -RequestDnsSec -ValidateDnsSec | Format-Table

--- a/Module/Tests/DnssecMessage.Tests.ps1
+++ b/Module/Tests/DnssecMessage.Tests.ps1
@@ -1,0 +1,14 @@
+Import-Module "$PSScriptRoot/../DnsClientX.psd1" -Force
+Add-Type -Path "$PSScriptRoot/../../DnsClientX/bin/Debug/net8.0/DnsClientX.dll"
+
+Describe 'DnsMessage DO bit' {
+    It 'Sets DO bit when requestDnsSec is true' {
+        $msg = [DnsClientX.DnsMessage]::new('example.com',[DnsClientX.DnsRecordType]::A,$true)
+        $bytes = $msg.SerializeDnsWireFormat()
+        $offset = 12
+        foreach($label in 'example.com'.Split('.')){ $offset += 1 + $label.Length }
+        $offset += 1 + 2 + 2
+        $ttl = ($bytes[$offset+5] -shl 24) -bor ($bytes[$offset+6] -shl 16) -bor ($bytes[$offset+7] -shl 8) -bor $bytes[$offset+8]
+        ($ttl -band 0x00008000) | Should -Be 0x00008000
+    }
+}

--- a/Module/Tests/DnssecMessage.Tests.ps1
+++ b/Module/Tests/DnssecMessage.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'DnsMessage DO bit' {
         $offset = 12
         foreach($label in 'example.com'.Split('.')){ $offset += 1 + $label.Length }
         $offset += 1 + 2 + 2
-        $ttl = ($bytes[$offset+5] -shl 24) -bor ($bytes[$offset+6] -shl 16) -bor ($bytes[$offset+7] -shl 8) -bor $bytes[$offset+8]
+        $ttl = ([int]$bytes[$offset+5] -shl 24) -bor ([int]$bytes[$offset+6] -shl 16) -bor ([int]$bytes[$offset+7] -shl 8) -bor [int]$bytes[$offset+8]
         ($ttl -band 0x00008000) | Should -Be 0x00008000
     }
 }


### PR DESCRIPTION
## Summary
- expose `RequestDnsSec` and `ValidateDnsSec` switches for `Resolve-Dns` cmdlet
- forward DNSSEC options through the query helpers
- show DNSSEC usage in example script
- add basic test ensuring DO bit when requesting DNSSEC

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `pwsh -NoLogo -NoProfile -File Module/DnsClientX.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686ce4624d34832eb6bc80fed62e2fc7