### PR TITLE
Fix multi-line zone records

### DIFF
--- a/DnsClientX.Tests/BindFileParserTests.cs
+++ b/DnsClientX.Tests/BindFileParserTests.cs
@@ -59,5 +59,24 @@ namespace DnsClientX.Tests {
             Assert.Equal(1800, records[1].TTL);
             Assert.Equal(7200, records[2].TTL);
         }
+
+        [Fact]
+        public void ParseZoneFile_JoinsParenthesizedRecords() {
+            string file = Path.GetTempFileName();
+            File.WriteAllLines(file, new[] {
+                "example.com. IN SOA ns.example.com. admin.example.com. (",
+                "  2024010101",
+                "  7200",
+                "  3600",
+                "  1209600",
+                "  3600 )"
+            });
+
+            var records = BindFileParser.ParseZoneFile(file);
+
+            Assert.Single(records);
+            Assert.Equal(DnsRecordType.SOA, records[0].Type);
+            Assert.Equal("ns.example.com. admin.example.com. 2024010101 7200 3600 1209600 3600", records[0].DataRaw);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support parenthesized record lines in BindFileParser
- test multi-line SOA parsing with parentheses

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -v minimal --filter FullyQualifiedName~BindFileParserTests`
- `dotnet build DnsClientX.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ced8df320832e99e52c7ea5fb08fc