### PR TITLE
Include server metadata in resolver exceptions

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveDotTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveDotTests.cs
@@ -40,8 +40,11 @@ namespace DnsClientX.Tests {
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTLS) { Port = port };
 
-            await Assert.ThrowsAsync<DnsClientException>(async () =>
+            var ex = await Assert.ThrowsAsync<DnsClientException>(async () =>
                 await DnsWireResolveDot.ResolveWireFormatDoT("127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, true, cts.Token));
+
+            Assert.Equal(config.Hostname, ex.Response.Questions[0].HostName);
+            Assert.Equal(config.Port, ex.Response.Questions[0].Port);
 
             await serverTask;
         }

--- a/DnsClientX.Tests/DnsWireResolveHttp2Tests.cs
+++ b/DnsClientX.Tests/DnsWireResolveHttp2Tests.cs
@@ -51,6 +51,8 @@ namespace DnsClientX.Tests {
                 DnsWireResolveHttp2.ResolveWireFormatHttp2(client, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None));
 
             Assert.Contains("server error", ex.Message);
+            Assert.Equal(config.Hostname, ex.Response.Questions[0].HostName);
+            Assert.Equal(config.Port, ex.Response.Questions[0].Port);
         }
     }
 }

--- a/DnsClientX.Tests/DnsWireResolveHttp3Tests.cs
+++ b/DnsClientX.Tests/DnsWireResolveHttp3Tests.cs
@@ -50,6 +50,8 @@ namespace DnsClientX.Tests {
                 DnsWireResolveHttp3.ResolveWireFormatHttp3(client, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None));
 
             Assert.Contains("server error", ex.Message);
+            Assert.Equal(config.Hostname, ex.Response.Questions[0].HostName);
+            Assert.Equal(config.Port, ex.Response.Questions[0].Port);
         }
 
     }


### PR DESCRIPTION
## Summary
- ensure DNS over TLS exceptions include server info by creating a failure response and calling `AddServerDetails`
- verify error responses contain host and port in HTTP2/HTTP3/DoT tests

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686ced95e2f4832ebd53c410ee09d6d2