### PR TITLE
Ensure AXFR TCP streams closed on failure

### DIFF
--- a/DnsClientX.Tests/ZoneTransferDisposalTests.cs
+++ b/DnsClientX.Tests/ZoneTransferDisposalTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ZoneTransferDisposalTests {
+        [Fact]
+        public async Task SendAxfrOverTcp_ShouldDisposeResources_OnTimeout() {
+            MethodInfo method = typeof(ClientX).GetMethod(
+                "SendAxfrOverTcp",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync();
+
+            using var cts = new CancellationTokenSource(500);
+            var callTask = (Task)method.Invoke(null, new object[] { new byte[] { 0, 0 }, "127.0.0.1", port, 200, cts.Token })!;
+
+            TcpClient serverClient = await acceptTask;
+            var buf = new byte[4];
+            int read = 0;
+            var stream = serverClient.GetStream();
+            while (read < 4) {
+                int r = await stream.ReadAsync(buf, read, 4 - read, cts.Token);
+                if (r == 0) break;
+                read += r;
+            }
+
+            await Assert.ThrowsAsync<TimeoutException>(async () => await callTask);
+
+            await Task.Delay(100);
+            serverClient.ReceiveTimeout = 200;
+            int bytes;
+            try {
+                bytes = serverClient.Client.Receive(new byte[1]);
+            } catch (SocketException) {
+                bytes = 0;
+            } finally {
+                serverClient.Close();
+            }
+
+            Assert.Equal(0, bytes);
+            listener.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- wrap `SendAxfrOverTcp` connection and stream handling in try/finally
- add unit test validating handle cleanup when an AXFR transfer times out

## Testing
- `dotnet build DnsClientX.Tests/DnsClientX.Tests.csproj -c Release --no-restore -v minimal`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release --no-build --filter ZoneTransferDisposalTests --verbosity minimal`
- `dotnet build DnsClientX/DnsClientX.csproj -f net8.0 -c Release --no-restore -v minimal`
- ❌ `dotnet build DnsClientX/DnsClientX.csproj -f net472 -c Release --no-restore -v minimal` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ced9af6e4832ebda86b137de0834b