### PR TITLE
Fix ResolveServiceAsync when no SRV records

### DIFF
--- a/DnsClientX.Tests/ResolveServiceAsyncTests.cs
+++ b/DnsClientX.Tests/ResolveServiceAsyncTests.cs
@@ -59,5 +59,17 @@ namespace DnsClientX.Tests {
             Assert.Contains(IPAddress.Parse("10.0.0.1"), r.Addresses!);
             Assert.Contains(IPAddress.Parse("::1"), r.Addresses!);
         }
+
+        [Fact]
+        public async Task ShouldReturnEmptyArrayWhenNoSrvRecords() {
+            using var client = new ClientX(DnsEndpoint.System);
+            client.ResolverOverride = (name, type, ct) =>
+                Task.FromException<DnsResponse>(new DnsClientException(
+                    "not found",
+                    new DnsResponse { Status = DnsResponseCode.NXDomain }));
+
+            var records = await client.ResolveServiceAsync("http", "tcp", "example.com");
+            Assert.Empty(records);
+        }
     }
 }

--- a/DnsClientX/DnsClientX.ServiceDiscovery.cs
+++ b/DnsClientX/DnsClientX.ServiceDiscovery.cs
@@ -163,7 +163,12 @@ namespace DnsClientX {
             if (!protocol.StartsWith("_", StringComparison.Ordinal)) protocol = "_" + protocol;
 
             string query = $"{service}.{protocol}.{domain}";
-            var response = await ResolveForSd(query, DnsRecordType.SRV, cancellationToken).ConfigureAwait(false);
+            DnsResponse response;
+            try {
+                response = await ResolveForSd(query, DnsRecordType.SRV, cancellationToken).ConfigureAwait(false);
+            } catch (DnsClientException ex) when (ex.Response?.Status == DnsResponseCode.NXDomain || ex.Response?.Status == DnsResponseCode.NXRRSet) {
+                return Array.Empty<DnsSrvRecord>();
+            }
             if (response.Answers == null) return Array.Empty<DnsSrvRecord>();
 
             var records = new List<DnsSrvRecord>();


### PR DESCRIPTION
## Summary
- handle missing SRV records in `ResolveServiceAsync`
- return empty array for NXDOMAIN/NXRRSet cases
- add regression test for empty SRV queries

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `dotnet test DnsClientX.sln` *(fails: DNS network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686ceda2bfd8832eac82d74e45388911