### PR TITLE
Add retry limit to UDP resolver

### DIFF
--- a/DnsClientX.Tests/CdBitTests.cs
+++ b/DnsClientX.Tests/CdBitTests.cs
@@ -80,7 +80,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, CheckingDisabled = true };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await udpTask;
 

--- a/DnsClientX.Tests/DnsWireFallbackTests.cs
+++ b/DnsClientX.Tests/DnsWireFallbackTests.cs
@@ -66,7 +66,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             DnsResponse response = await task;
 
             await Task.WhenAll(udpTask, tcpTask);
@@ -84,7 +84,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, UseTcpFallback = false };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             DnsResponse response = await task;
 
             await udpTask;

--- a/DnsClientX.Tests/DnsWireResolveUdpIPv6Tests.cs
+++ b/DnsClientX.Tests/DnsWireResolveUdpIPv6Tests.cs
@@ -49,7 +49,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("::1", DnsRequestFormat.DnsOverUDP) { Port = port };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "::1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "::1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             DnsResponse dnsResponse = await task;
 
             await udpTask;

--- a/DnsClientX.Tests/DnsWireUdpRetryLimitTests.cs
+++ b/DnsClientX.Tests/DnsWireUdpRetryLimitTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireUdpRetryLimitTests {
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task<int> RunUdpServerNoReplyAsync(int port, int expected, CancellationToken token) {
+            using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
+            int count = 0;
+            while (count < expected && !token.IsCancellationRequested) {
+                var receiveTask = udp.ReceiveAsync();
+                var completed = await Task.WhenAny(receiveTask, Task.Delay(100, token));
+                if (completed == receiveTask) {
+                    await receiveTask;
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatUdp_ShouldRespectMaxRetries() {
+            int port = GetFreePort();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var serverTask = RunUdpServerNoReplyAsync(port, 2, cts.Token);
+
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) {
+                Port = port,
+                TimeOut = 10
+            };
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 2, cts.Token })!;
+            DnsResponse response = await task;
+
+            cts.Cancel();
+            int attempts = await serverTask;
+
+            Assert.Equal(2, attempts);
+            Assert.NotEqual(DnsResponseCode.NoError, response.Status);
+        }
+    }
+}

--- a/DnsClientX.Tests/EcsOptionTests.cs
+++ b/DnsClientX.Tests/EcsOptionTests.cs
@@ -70,7 +70,7 @@ namespace DnsClientX.Tests {
             };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await udpTask;
 

--- a/DnsClientX.Tests/EdnsDoBitTests.cs
+++ b/DnsClientX.Tests/EdnsDoBitTests.cs
@@ -137,7 +137,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, 1, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, cts.Token })!;
             await task;
             byte[] query = await tcpTask;
 

--- a/DnsClientX.Tests/EdnsDoBitTests.cs
+++ b/DnsClientX.Tests/EdnsDoBitTests.cs
@@ -120,7 +120,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await udpTask;
 
@@ -137,7 +137,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await tcpTask;
 
@@ -154,7 +154,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, EnableEdns = true, UdpBufferSize = 1234 };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await udpTask;
 
@@ -174,7 +174,7 @@ namespace DnsClientX.Tests {
             };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await udpTask;
 
@@ -191,7 +191,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, EnableEdns = true };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await udpTask;
 

--- a/DnsClientX.Tests/EdnsOptionsTests.cs
+++ b/DnsClientX.Tests/EdnsOptionsTests.cs
@@ -66,7 +66,7 @@ namespace DnsClientX.Tests {
             };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await udpTask;
 

--- a/DnsClientX.Tests/UdpClientDisposeTests.cs
+++ b/DnsClientX.Tests/UdpClientDisposeTests.cs
@@ -44,7 +44,7 @@ namespace DnsClientX.Tests {
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
 
             int clientPort = await udpTask;

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -46,7 +46,7 @@ namespace DnsClientX {
                         : null;
 
                     return await RetryAsync(
-                        () => ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, cancellationToken),
+                        () => ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, maxRetries, cancellationToken),
                         maxRetries,
                         retryDelayMs,
                         beforeRetry,
@@ -56,11 +56,11 @@ namespace DnsClientX {
                     return ex.Response;
                 }
             } else {
-                return await ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, cancellationToken).ConfigureAwait(false);
+                return await ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, maxRetries, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task<DnsResponse> ResolveInternal(string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool returnAllTypes, CancellationToken cancellationToken) {
+        private async Task<DnsResponse> ResolveInternal(string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool returnAllTypes, int maxRetries, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
             bool originalCd = EndpointConfiguration.CheckingDisabled;
@@ -119,7 +119,7 @@ namespace DnsClientX {
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTCP) {
                     response = await DnsWireResolveTcp.ResolveWireFormatTcp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverUDP) {
-                    response = await DnsWireResolveUdp.ResolveWireFormatUdp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+                    response = await DnsWireResolveUdp.ResolveWireFormatUdp(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, maxRetries, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.Multicast) {
                     response = await DnsWireResolveMulticast.ResolveWireFormatMulticast(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else {

--- a/DnsClientX/DnsClientX.ResolveRoot.cs
+++ b/DnsClientX/DnsClientX.ResolveRoot.cs
@@ -21,7 +21,7 @@ namespace DnsClientX {
                 foreach (var server in servers) {
                     var host = server.TrimEnd('.');
                     var cfg = new Configuration(host, DnsRequestFormat.DnsOverUDP) { UseTcpFallback = true };
-                    lastResponse = await DnsWireResolveUdp.ResolveWireFormatUdp(host, cfg.Port, name, type, false, false, Debug, cfg, cancellationToken).ConfigureAwait(false);
+                    lastResponse = await DnsWireResolveUdp.ResolveWireFormatUdp(host, cfg.Port, name, type, false, false, Debug, cfg, 1, cancellationToken).ConfigureAwait(false);
                     if (lastResponse.Answers?.Any(a => a.Type == type) == true) {
                         return lastResponse;
                     }


### PR DESCRIPTION
## Summary
- enforce retry limit in `ResolveWireFormatUdp`
- propagate `maxRetries` through `ResolveInternal`
- adjust callers and unit tests
- add a new test verifying UDP retry cap

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `dotnet test` *(fails: connection related test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686cedd984b8832e99e29766e13d4801