### PR TITLE
Add cancellation token support for ZoneTransferSync

### DIFF
--- a/DnsClientX.Tests/ZoneTransferCancellationTests.cs
+++ b/DnsClientX.Tests/ZoneTransferCancellationTests.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ZoneTransferCancellationTests {
+        [Fact]
+        public async Task ZoneTransferAsync_CancelledTask() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => client.ZoneTransferAsync("example.com", cancellationToken: cts.Token));
+        }
+    }
+}

--- a/DnsClientX.Tests/ZoneTransferSyncCancellationTests.cs
+++ b/DnsClientX.Tests/ZoneTransferSyncCancellationTests.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ZoneTransferSyncCancellationTests {
+        [Fact]
+        public void ZoneTransferSync_CancelledTask() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP);
+            Assert.Throws<TaskCanceledException>(() => client.ZoneTransferSync("example.com", cancellationToken: cts.Token));
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -106,7 +106,7 @@ namespace DnsClientX {
             int maxRetries = 3,
             int retryDelayMs = 100,
             CancellationToken cancellationToken = default) {
-            return ZoneTransferAsync(zone, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+            return ZoneTransferAsync(zone, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync(cancellationToken);
         }
 
         private static async Task<List<byte[]>> SendAxfrOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {


### PR DESCRIPTION
## Summary
- wire ZoneTransferSync cancellation token through RunSync
- test that cancelling ZoneTransferAsync and ZoneTransferSync throws

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -v minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686cedb54c30832e995926536dad7118