### PR TITLE
Add DNS endpoint listing helper example and tests

### DIFF
--- a/DnsClientX.Examples/DemoListDnsEndpoints.cs
+++ b/DnsClientX.Examples/DemoListDnsEndpoints.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Example that prints all available <see cref="DnsEndpoint"/> values
+    /// with their descriptions.
+    /// </summary>
+    internal static class DemoListDnsEndpoints {
+        public static void Example() {
+            foreach (var (endpoint, description) in DnsEndpointExtensions.GetAllWithDescriptions()) {
+                Console.WriteLine($"{endpoint,-20} {description}");
+            }
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsEndpointExtensionsTests.cs
+++ b/DnsClientX.Tests/DnsEndpointExtensionsTests.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsEndpointExtensionsTests {
+        [Fact]
+        public void GetAllWithDescriptions_ReturnsAllEndpoints() {
+            var all = DnsEndpointExtensions.GetAllWithDescriptions().ToList();
+            int expectedCount = Enum.GetValues(typeof(DnsEndpoint)).Length;
+            Assert.Equal(expectedCount, all.Count);
+            Assert.All(all, pair => Assert.False(string.IsNullOrWhiteSpace(pair.Description)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DemoListDnsEndpoints` example to enumerate endpoints with descriptions
- test `DnsEndpointExtensions.GetAllWithDescriptions`

## Testing
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d3004c288832e8f3537aa4f1a9712