### PR TITLE
Add DNSSEC root validation example

### DIFF
--- a/DnsClientX.Examples/DemoValidateAgainstRoot.cs
+++ b/DnsClientX.Examples/DemoValidateAgainstRoot.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates validating DNSSEC data using built-in root trust anchors.
+    /// </summary>
+    internal static class DemoValidateAgainstRoot {
+        /// <summary>Runs the example.</summary>
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            DnsResponse response = await client.Resolve(".", DnsRecordType.DNSKEY, requestDnsSec: true);
+            bool valid = DnsSecValidator.ValidateAgainstRoot(response);
+            Settings.Logger.WriteInformation($"Response validated against root anchors: {valid}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `DemoValidateAgainstRoot` example demonstrating use of `DnsSecValidator.ValidateAgainstRoot`
- ensure example project builds for `net8.0`

## Testing
- `dotnet build DnsClientX.Examples/DnsClientX.Examples.csproj -c Debug`
- `dotnet test --no-build` *(fails: Duplicate network calls blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686d30162398832eabe70a1a2239efc7