### PR TITLE
Add LINQ support directly in core library

### DIFF
--- a/DnsClientX.Examples/DemoDnsLinq.cs
+++ b/DnsClientX.Examples/DemoDnsLinq.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using System.Threading.Tasks;
+
+using DnsClientX.Linq;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates usage of the LINQ provider.
+    /// </summary>
+    internal class DemoDnsLinq {
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var names = new[] { "evotec.pl", "google.com" };
+            HelpersSpectre.AddLine("DnsQueryable", string.Join(",", names), DnsRecordType.A, DnsEndpoint.Cloudflare);
+            var query = client.AsQueryable(names, DnsRecordType.A)
+                .Where(a => a.Data.Contains("216.58"));
+            var results = await query.ToListAsync();
+            results.ToArray().DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Examples/DnsClientX.Examples.csproj
+++ b/DnsClientX.Examples/DnsClientX.Examples.csproj
@@ -8,9 +8,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
         <PackageReference Include="Spectre.Console" Version="0.50.0" />
-    </ItemGroup>
+  </ItemGroup>
 
   <ItemGroup>
         <ProjectReference Include="..\DnsClientX\DnsClientX.csproj" />

--- a/DnsClientX.Examples/Program.cs
+++ b/DnsClientX.Examples/Program.cs
@@ -17,6 +17,7 @@ namespace DnsClientX.Examples {
             await DemoDnsAnswer.ExampleDnsAnswerParsing();
             await DemoServiceDiscovery.Example();
             await DemoServiceDiscovery.ExampleEnumerate();
+            await DemoDnsLinq.Example();
 
             //await DemoQuery.ExampleTXTAll();
             //await DemoQuery.ExampleTXT();

--- a/DnsClientX.Tests/DnsQueryableTests.cs
+++ b/DnsClientX.Tests/DnsQueryableTests.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using System.Threading.Tasks;
+using DnsClientX.Linq;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsQueryableTests {
+        [Fact(Skip = "External dependency - network unreachable in CI")]
+        public async Task ShouldFilterResults() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var query = client.AsQueryable(new[] { "evotec.pl" }, DnsRecordType.A)
+                .Where(a => a.Data.Length > 0);
+            var results = await query.ToListAsync();
+            Assert.NotEmpty(results);
+        }
+    }
+}

--- a/DnsClientX/Linq/DnsQueryProvider.cs
+++ b/DnsClientX/Linq/DnsQueryProvider.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Linq {
+    internal class DnsQueryProvider : IQueryProvider {
+        private readonly ClientX _client;
+        private readonly IEnumerable<string> _names;
+        private readonly DnsRecordType _type;
+
+        public DnsQueryProvider(ClientX client, IEnumerable<string> names, DnsRecordType type) {
+            _client = client;
+            _names = names;
+            _type = type;
+        }
+
+        public IQueryable CreateQuery(Expression expression) => new DnsQueryable(this, expression);
+
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression) =>
+            (IQueryable<TElement>)new DnsQueryable(this, expression);
+
+        public object Execute(Expression expression) => Execute<IEnumerable<DnsAnswer>>(expression);
+
+        public TResult Execute<TResult>(Expression expression) {
+            return ExecuteAsync<TResult>(expression).GetAwaiter().GetResult();
+        }
+
+        public async Task<TResult> ExecuteAsync<TResult>(Expression expression) {
+            var responses = await Task.WhenAll(_names.Select(n => _client.Resolve(n, _type)));
+            var answers = responses.SelectMany(r => r.Answers ?? Array.Empty<DnsAnswer>()).AsQueryable();
+            var visitor = new ExpressionTreeModifier(answers);
+            var newExpression = visitor.Visit(expression);
+            return answers.Provider.Execute<TResult>(newExpression);
+        }
+    }
+}

--- a/DnsClientX/Linq/DnsQueryable.cs
+++ b/DnsClientX/Linq/DnsQueryable.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Linq {
+    /// <summary>
+    /// Represents a LINQ queryable source of <see cref="DnsAnswer"/>.
+    /// </summary>
+    public class DnsQueryable : IQueryable<DnsAnswer> {
+        internal DnsQueryProvider ProviderInternal { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DnsQueryable"/> class.
+        /// </summary>
+        /// <param name="client">DNS client.</param>
+        /// <param name="names">Domain names to resolve.</param>
+        /// <param name="type">Record type.</param>
+        public DnsQueryable(ClientX client, IEnumerable<string> names, DnsRecordType type) {
+            ProviderInternal = new DnsQueryProvider(client, names, type);
+            Expression = Expression.Constant(this);
+        }
+
+        internal DnsQueryable(DnsQueryProvider provider, Expression expression) {
+            ProviderInternal = provider;
+            Expression = expression;
+        }
+
+        /// <inheritdoc />
+        public Type ElementType => typeof(DnsAnswer);
+
+        /// <inheritdoc />
+        public Expression Expression { get; }
+
+        /// <inheritdoc />
+        public IQueryProvider Provider => ProviderInternal;
+
+        /// <inheritdoc />
+        public IEnumerator<DnsAnswer> GetEnumerator() =>
+            Provider.Execute<IEnumerable<DnsAnswer>>(Expression).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Executes the query asynchronously.
+        /// </summary>
+        /// <returns>Query result as a list.</returns>
+        public Task<List<DnsAnswer>> ToListAsync() =>
+            ProviderInternal.ExecuteAsync<List<DnsAnswer>>(Expression);
+    }
+}

--- a/DnsClientX/Linq/DnsQueryableExtensions.cs
+++ b/DnsClientX/Linq/DnsQueryableExtensions.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Linq {
+    /// <summary>
+    /// Helper extension methods for <see cref="DnsQueryable"/>.
+    /// </summary>
+    public static class DnsQueryableExtensions {
+        /// <summary>
+        /// Creates a DNS LINQ query for the specified domains and record type.
+        /// </summary>
+        /// <param name="client">DNS client.</param>
+        /// <param name="names">Domain names.</param>
+        /// <param name="type">Record type.</param>
+        public static DnsQueryable AsQueryable(this ClientX client, IEnumerable<string> names, DnsRecordType type) =>
+            new(client, names, type);
+
+        /// <summary>
+        /// Executes the query asynchronously and returns a list of answers.
+        /// </summary>
+        /// <param name="source">Queryable source.</param>
+        /// <returns>List of answers.</returns>
+        public static Task<List<DnsAnswer>> ToListAsync(this IQueryable<DnsAnswer> source) =>
+            source is DnsQueryable dns ? dns.ToListAsync() : Task.FromResult(source.ToList());
+    }
+}

--- a/DnsClientX/Linq/ExpressionTreeModifier.cs
+++ b/DnsClientX/Linq/ExpressionTreeModifier.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace DnsClientX.Linq {
+    internal class ExpressionTreeModifier : ExpressionVisitor {
+        private readonly IQueryable<DnsAnswer> _queryable;
+
+        public ExpressionTreeModifier(IQueryable<DnsAnswer> queryable) => _queryable = queryable;
+
+        protected override Expression VisitConstant(ConstantExpression node) {
+            return node.Type == typeof(DnsQueryable)
+                ? Expression.Constant(_queryable)
+                : base.VisitConstant(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move `DnsQueryable` implementation into `DnsClientX` project
- remove the extra `DnsClientX.Linq` project
- update examples and tests to reference the core project

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: 141, passes: 371)*

------
https://chatgpt.com/codex/tasks/task_e_686d38fc1404832e9b8bae09e87de51c