### PR TITLE
Fix UDP retry limit test timing

### DIFF
--- a/DnsClientX.Tests/DnsWireUdpRetryLimitTests.cs
+++ b/DnsClientX.Tests/DnsWireUdpRetryLimitTests.cs
@@ -45,8 +45,8 @@ namespace DnsClientX.Tests {
             var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 2, cts.Token })!;
             DnsResponse response = await task;
 
-            cts.Cancel();
             int attempts = await serverTask;
+            cts.Cancel();
 
             Assert.Equal(2, attempts);
             Assert.NotEqual(DnsResponseCode.NoError, response.Status);


### PR DESCRIPTION
## Summary
- adjust DnsWireUdpRetryLimitTests to await server before cancelling

## Testing
- `dotnet test DnsClientX.Tests --filter "DnsWireUdpRetryLimitTests" -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d41f8dae8832ea3faf5f47419be2f