### PR TITLE
Fix unstable TCP cleanup test

### DIFF
--- a/DnsClientX.Tests/TcpCleanupRegressionTests.cs
+++ b/DnsClientX.Tests/TcpCleanupRegressionTests.cs
@@ -67,6 +67,16 @@ namespace DnsClientX.Tests {
             await Task.Delay(200);
 
             bool hasConnection = await NetstatHasPortAsync(port);
+            if (hasConnection)
+            {
+                // give the OS some time to clean up TIME_WAIT sockets
+                for (int i = 0; i < 20 && hasConnection; i++)
+                {
+                    await Task.Delay(100);
+                    hasConnection = await NetstatHasPortAsync(port);
+                }
+            }
+
             Assert.False(hasConnection);
         }
     }


### PR DESCRIPTION
## Summary
- avoid false failures in TcpCleanupRegressionTests by retrying netstat check

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter FullyQualifiedName~TcpCleanupRegressionTests.TcpFailure_ShouldCloseSocket --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d41a93f60832ebeae87cf677bd6c2