### PR TITLE
Add signing support to DnsMessage

### DIFF
--- a/DnsClientX.Examples/DemoSignedQuery.cs
+++ b/DnsClientX.Examples/DemoSignedQuery.cs
@@ -1,0 +1,16 @@
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    internal class DemoSignedQuery {
+        public static async Task Example() {
+            using RSA rsa = RSA.Create();
+            var client = new ClientXBuilder()
+                .WithSigningKey(rsa)
+                .Build();
+
+            var response = await client.Resolve("example.com", DnsRecordType.A);
+            response?.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Tests/CdBitTests.cs
+++ b/DnsClientX.Tests/CdBitTests.cs
@@ -123,14 +123,14 @@ namespace DnsClientX.Tests {
 
         [Fact]
         public void DotRequest_ShouldIncludeCdBit_WhenConfigured() {
-            var message = new DnsMessage("example.com", DnsRecordType.A, false, true, 4096, null, true);
+            var message = new DnsMessage("example.com", DnsRecordType.A, false, true, 4096, null, true, null);
             byte[] data = message.SerializeDnsWireFormat();
             AssertCdBit(data, "example.com", 0x10u);
         }
 
         [Fact]
         public void DoqRequest_ShouldIncludeCdBit_WhenConfigured() {
-            var message = new DnsMessage("example.com", DnsRecordType.A, false, true, 4096, null, true);
+            var message = new DnsMessage("example.com", DnsRecordType.A, false, true, 4096, null, true, null);
             byte[] data = message.SerializeDnsWireFormat();
             AssertCdBit(data, "example.com", 0x10u);
         }

--- a/DnsClientX.Tests/ClientXBuilderTests.cs
+++ b/DnsClientX.Tests/ClientXBuilderTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Xunit;
 
 namespace DnsClientX.Tests {
@@ -32,6 +33,16 @@ namespace DnsClientX.Tests {
                 .Build();
 
             Assert.Same(options, client.EndpointConfiguration.EdnsOptions);
+        }
+
+        [Fact]
+        public void BuildShouldApplySigningKey() {
+            using var rsa = RSA.Create();
+            using var client = new ClientXBuilder()
+                .WithSigningKey(rsa)
+                .Build();
+
+            Assert.Same(rsa, client.EndpointConfiguration.SigningKey);
         }
 
         [Fact]

--- a/DnsClientX.Tests/DnsMessageSigningTests.cs
+++ b/DnsClientX.Tests/DnsMessageSigningTests.cs
@@ -1,0 +1,37 @@
+using System.Security.Cryptography;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsMessageSigningTests {
+        private const string RsaXml = "<RSAKeyValue><Modulus>53YFIke7QJ+BflZmkvTPuUtScT97JPn4N0Lvek6ukY3IOPYkOndVFXLvJSUYcI6b0RvLjaIx1wcGPcJW7+V0nUCiqnxi85roJp1NVyIPMWs/JIS5WYcv9bPbqBsAJuxGMM2m49CjlDqVlggw49Rh431e2sDeZ729AqOOlm6qV4k=</Modulus><Exponent>AQAB</Exponent><P>/DCmdjyqUn8axK4tQqzq60McH/UoDTa+1LCxfmn9aewPIkMhRidQaxwp0MdadvTDkEbKX6J9ucwO/PIHtSp4nQ==</P><Q>6vUzLeLIuypxL+vIKZr+je+7tbFlDyGFEko24F18zE1RE8kxOQ4k9BdstQchm3O/edknXEuAyvL3+kSeUf+Y3Q==</Q><DP>Ra83wAIhWixO/DvYu8zGGP3xPo9iYsxWzLSKRxEIegVFZUVBY34nhYFBuLPtNmOJyksVTnm63eUZ2yERqiizLQ==</DP><DQ>C4ecy1OlpgmfJErdt6zzcOOiwnfCDcwHS654ounzhdMFd4MX90TKa2/61adT7tzvOHt/gvfxigQCRzW2zy9LwQ==</DQ><InverseQ>rFiNryKWal8UiXOsuW46IgUGOHQGZ9IoRof5jvk428nGfrYBdKfVS5l1hU5i3Y8FTsC4NyRo3njx806i+0ZZiw==</InverseQ><D>VDqdiakC2nRxIjF86FOQWASx/qY0QPN6QVnpXd/OJQesahYgfuo4GzMVFbZXG3a5+zGbNHJmorJashTLoEcm1PWOt01L2zcLJiroBFGrMGJD2ZAITj0/OuOskfmDwk4Jgcr5o5I3eaEqG1ouR0XOYyvtI8z5U8E6o+BGrCRuCJE=</D></RSAKeyValue>";
+
+        [Fact]
+        public void SerializeDnsWireFormat_ShouldIncludeSignature() {
+            using RSA rsa = RSA.Create();
+            rsa.FromXmlString(RsaXml);
+            var message = new DnsMessage("example.com", DnsRecordType.A, false, false, 4096, null, false, rsa);
+            byte[] data = message.SerializeDnsWireFormat();
+
+            // calculate offsets
+            int offset = 12;
+            foreach (var label in "example.com".Split('.')) {
+                offset += 1 + label.Length;
+            }
+            offset += 1 + 2 + 2;
+            Assert.True(data.Length > offset);
+
+            Assert.Equal(1, (data[10] << 8) | data[11]);
+            Assert.Equal(0, data[offset]);
+            ushort type = (ushort)((data[offset + 1] << 8) | data[offset + 2]);
+            Assert.Equal((ushort)DnsRecordType.SIG, type);
+            ushort rdlen = (ushort)((data[offset + 9] << 8) | data[offset + 10]);
+            byte[] signature = new byte[rdlen];
+            System.Buffer.BlockCopy(data, offset + 11, signature, 0, rdlen);
+
+            byte[] signedPortion = new byte[offset];
+            System.Buffer.BlockCopy(data, 0, signedPortion, 0, offset);
+            byte[] expected = rsa.SignData(signedPortion, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            Assert.Equal(expected, signature);
+        }
+    }
+}

--- a/DnsClientX/ClientXBuilder.cs
+++ b/DnsClientX/ClientXBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Security.Cryptography;
 
 namespace DnsClientX {
     /// <summary>
@@ -12,6 +13,7 @@ namespace DnsClientX {
         private int _timeout = Configuration.DefaultTimeout;
         private IWebProxy? _proxy;
         private EdnsOptions? _ednsOptions;
+        private AsymmetricAlgorithm? _signingKey;
 
         /// <summary>
         /// Sets the DNS endpoint to use.
@@ -50,12 +52,24 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Supplies a key used to sign DNS messages.
+        /// </summary>
+        /// <param name="key">Asymmetric key pair.</param>
+        public ClientXBuilder WithSigningKey(AsymmetricAlgorithm key) {
+            _signingKey = key;
+            return this;
+        }
+
+        /// <summary>
         /// Builds and returns a configured <see cref="ClientX"/> instance.
         /// </summary>
         public ClientX Build() {
             var client = new ClientX(_endpoint, DnsSelectionStrategy.First, _timeout, webProxy: _proxy);
             if (_ednsOptions != null) {
                 client.EndpointConfiguration.EdnsOptions = _ednsOptions;
+            }
+            if (_signingKey != null) {
+                client.EndpointConfiguration.SigningKey = _signingKey;
             }
 
             var field = typeof(Configuration).GetField("hostnames", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography;
 
 namespace DnsClientX {
     /// <summary>
@@ -83,6 +84,11 @@ namespace DnsClientX {
         /// Determines whether to fall back to TCP when a UDP response is truncated.
         /// </summary>
         public bool UseTcpFallback { get; set; } = true;
+
+        /// <summary>
+        /// Optional key used to sign outgoing DNS messages.
+        /// </summary>
+        public AsymmetricAlgorithm? SigningKey { get; set; }
 
         /// <summary>
         /// Gets or sets the UDP buffer size used when sending EDNS queries.

--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -38,7 +38,7 @@ namespace DnsClientX {
 
             EndpointConfiguration.SelectHostNameStrategy();
 
-            var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize, null, EndpointConfiguration.CheckingDisabled);
+            var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize, null, EndpointConfiguration.CheckingDisabled, EndpointConfiguration.SigningKey);
             var queryBytes = query.SerializeDnsWireFormat();
 
             async Task<List<byte[]>> Execute() => await SendAxfrOverTcp(queryBytes, EndpointConfiguration.Hostname, EndpointConfiguration.Port, EndpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);

--- a/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
+++ b/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
@@ -25,7 +25,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatHttp2(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet, endpointConfiguration.CheckingDisabled);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -29,7 +29,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -52,7 +52,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var queryBytes = query.SerializeDnsWireFormat();
 
             var lengthPrefix = BitConverter.GetBytes((ushort)queryBytes.Length);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -37,7 +37,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var queryBytes = query.SerializeDnsWireFormat();
 
             // Calculate the length prefix for the query

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
@@ -13,7 +13,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
             bool enableEdns = edns?.EnableEdns ?? endpointConfiguration.EnableEdns;
             int udpSize = edns?.UdpBufferSize ?? endpointConfiguration.UdpBufferSize;
             string? subnet = edns?.Subnet ?? endpointConfiguration.Subnet;
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {


### PR DESCRIPTION
## Summary
- implement optional signing for `DnsMessage`
- surface signing configuration in `ClientXBuilder` and `Configuration`
- include signing key in DNS wire serializers
- add example demonstrating signed queries
- add unit tests for signing and update existing tests

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: Failed: 141, Passed: 373, Skipped: 17)*

------
https://chatgpt.com/codex/tasks/task_e_686d38cf72a0832e9116c0fc385bc43c