### PR TITLE
Implement ZoneTransfer streaming

### DIFF
--- a/DnsClientX.Examples/DemoZoneTransfer.cs
+++ b/DnsClientX.Examples/DemoZoneTransfer.cs
@@ -11,8 +11,7 @@ namespace DnsClientX.Examples {
         /// </summary>
         public static async Task Example() {
             using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = 5353 } };
-            var records = await client.ZoneTransferAsync("example.com");
-            foreach (var rrset in records) {
+            await foreach (var rrset in client.ZoneTransferStreamAsync("example.com")) {
                 Console.WriteLine(string.Join(", ", rrset));
             }
         }

--- a/DnsClientX.PowerShell/CmdletDnsZoneTransfer.cs
+++ b/DnsClientX.PowerShell/CmdletDnsZoneTransfer.cs
@@ -30,7 +30,8 @@ public sealed class CmdletDnsZoneTransfer : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         using var client = new ClientX(Server, DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = Port } };
-        var records = await client.ZoneTransferAsync(Zone);
-        WriteObject(records, true);
+        await foreach (var rrset in client.ZoneTransferStreamAsync(Zone, cancellationToken: CancelToken)) {
+            WriteObject(rrset);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `ZoneTransferStreamAsync` to stream RRsets
- update ZoneTransfer PowerShell cmdlet to output streamed results
- adjust zone transfer example
- test streaming zone transfer

## Testing
- `dotnet test` *(fails: failed 141, passed 373, skipped 17)*

------
https://chatgpt.com/codex/tasks/task_e_686d38c7f430832e811c38fb56e275dc