### PR TITLE
Fix UDP retry limit test

### DIFF
--- a/DnsClientX.Tests/DnsWireUdpRetryLimitTests.cs
+++ b/DnsClientX.Tests/DnsWireUdpRetryLimitTests.cs
@@ -20,8 +20,12 @@ namespace DnsClientX.Tests {
             using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
             int count = 0;
             while (count < expected && !token.IsCancellationRequested) {
+#if NET5_0_OR_GREATER
+                var receiveTask = udp.ReceiveAsync(token).AsTask();
+#else
                 var receiveTask = udp.ReceiveAsync();
-                var completed = await Task.WhenAny(receiveTask, Task.Delay(100, token));
+#endif
+                var completed = await Task.WhenAny(receiveTask, Task.Delay(Timeout.Infinite, token));
                 if (completed == receiveTask) {
                     await receiveTask;
                     count++;


### PR DESCRIPTION
## Summary
- tweak timeout in `DnsWireUdpRetryLimitTests`

## Testing
- `dotnet build DnsClientX.sln`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --no-build --filter "FullyQualifiedName~DnsWireUdpRetryLimitTests" -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d549f8ad0832eb4be39c2e03cd704