### PR TITLE
Fix exponential backoff delays

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -240,7 +240,9 @@ namespace DnsClientX {
                         }
 
                         beforeRetry?.Invoke();
-                        int exponentialDelay = delayMs * (int)Math.Pow(2, attempt - 1);
+                        int exponentialDelay = delayMs <= 0
+                            ? 0
+                            : (int)Math.Min((long)delayMs << (attempt - 1), int.MaxValue);
                         int jitter = useJitter ? GetJitter(delayMs) : 0;
                         await Task.Delay(exponentialDelay + jitter, cancellationToken).ConfigureAwait(false);
                         continue;
@@ -260,7 +262,9 @@ namespace DnsClientX {
                     }
 
                     beforeRetry?.Invoke();
-                    int exponentialDelay = delayMs * (int)Math.Pow(2, attempt - 1);
+                    int exponentialDelay = delayMs <= 0
+                        ? 0
+                        : (int)Math.Min((long)delayMs << (attempt - 1), int.MaxValue);
                     int jitter = useJitter ? GetJitter(delayMs) : 0;
                     await Task.Delay(exponentialDelay + jitter, cancellationToken).ConfigureAwait(false);
                     continue;


### PR DESCRIPTION
## Summary
- ensure exponential backoff calculation uses integer shifting
- cap computed delay to avoid overflow

## Testing
- `dotnet format DnsClientX.sln --include DnsClientX/DnsClientX.Resolve.cs --no-restore` *(failed: required references did not load)*
- `dotnet test DnsClientX.sln -c Release` *(failed: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d54dad310832e862adb55d19ecec0