### PR TITLE
Fix cache TTL zero handling

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -164,11 +164,15 @@ namespace DnsClientX {
                 TimeSpan ttl = CacheExpiration;
                 if (response.Answers != null && response.Answers.Length > 0) {
                     int minTtl = response.Answers.Min(a => a.TTL);
-                    ttl = TimeSpan.FromSeconds(minTtl);
+                    ttl = minTtl == 0 ? TimeSpan.Zero : TimeSpan.FromSeconds(minTtl);
                 }
-                if (ttl < MinCacheTtl) ttl = MinCacheTtl;
+
+                if (ttl != TimeSpan.Zero && ttl < MinCacheTtl) ttl = MinCacheTtl;
                 if (ttl > MaxCacheTtl) ttl = MaxCacheTtl;
-                _cache.Set(cacheKey, response, ttl);
+
+                if (ttl > TimeSpan.Zero) {
+                    _cache.Set(cacheKey, response, ttl);
+                }
             }
 
 


### PR DESCRIPTION
## Summary
- respect 0 TTLs when clamping cache TTL
- add regression test for zero TTL caching

## Testing
- `dotnet test -v minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d798cbb50832e86527d01ef0635c3