### PR TITLE
Fix punycode trailing dot handling

### DIFF
--- a/DnsClientX.Tests/ConvertToPunycodeTests.cs
+++ b/DnsClientX.Tests/ConvertToPunycodeTests.cs
@@ -25,5 +25,11 @@ namespace DnsClientX.Tests {
             const string invalidIdn = "\uD83D\uDE00.com";
             Assert.Equal(invalidIdn, Invoke(invalidIdn));
         }
+
+        [Fact]
+        public void PreservesTrailingDot() {
+            const string input = "example.com.";
+            Assert.Equal(input, Invoke(input));
+        }
     }
 }

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -378,7 +378,11 @@ namespace DnsClientX {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 return domainName;
             }
-            foreach (char c in domainName) {
+
+            bool hasTrailingDot = domainName.EndsWith(".", StringComparison.Ordinal);
+            string nameToConvert = hasTrailingDot ? domainName[..^1] : domainName;
+
+            foreach (char c in nameToConvert) {
                 UnicodeCategory cat = char.GetUnicodeCategory(c);
                 if (cat is UnicodeCategory.OtherSymbol
                     or UnicodeCategory.PrivateUse
@@ -389,7 +393,8 @@ namespace DnsClientX {
 
             IdnMapping idn = new IdnMapping();
             try {
-                return idn.GetAscii(domainName);
+                string converted = idn.GetAscii(nameToConvert);
+                return hasTrailingDot ? converted + "." : converted;
             } catch {
                 return domainName;
             }

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -380,7 +380,9 @@ namespace DnsClientX {
             }
 
             bool hasTrailingDot = domainName.EndsWith(".", StringComparison.Ordinal);
-            string nameToConvert = hasTrailingDot ? domainName[..^1] : domainName;
+            string nameToConvert = hasTrailingDot
+                ? domainName.Substring(0, domainName.Length - 1)
+                : domainName;
 
             foreach (char c in nameToConvert) {
                 UnicodeCategory cat = char.GetUnicodeCategory(c);


### PR DESCRIPTION
## Summary
- preserve trailing dots when converting to punycode
- test preserving trailing dot for example.com.

## Testing
- `dotnet build --no-restore --verbosity minimal`
- `dotnet test --no-build --verbosity minimal` *(fails: HttpRequestException)*

------
https://chatgpt.com/codex/tasks/task_e_686d7982d658832eb43e57ba675d128c