### PR TITLE
Ensure DoT port preserved when BaseUri changes

### DIFF
--- a/DnsClientX.Tests/CustomDotPortTests.cs
+++ b/DnsClientX.Tests/CustomDotPortTests.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class CustomDotPortTests {
+        [Fact]
+        public void SelectHostNameStrategy_ShouldKeepCustomPort() {
+            var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTLS) { Port = 8443 };
+            config.SelectHostNameStrategy();
+            Assert.Equal(8443, config.Port);
+            Assert.NotNull(config.BaseUri);
+            Assert.Equal(8443, config.BaseUri!.Port);
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -149,6 +149,13 @@ namespace DnsClientX {
         /// </value>
         public int Port { get; set; }
 
+        private void ApplyPortToBaseUri() {
+            if ((RequestFormat == DnsRequestFormat.DnsOverTLS || RequestFormat == DnsRequestFormat.DnsOverQuic) && BaseUri != null && BaseUri.Port != Port) {
+                var builder = new UriBuilder(BaseUri) { Port = Port };
+                BaseUri = builder.Uri;
+            }
+        }
+
         internal void AdvanceToNextHostname() {
             if (hostnames.Count <= 1) {
                 return;
@@ -191,6 +198,7 @@ namespace DnsClientX {
             } else {
                 Port = 443;
             }
+            ApplyPortToBaseUri();
         }
 
         /// <summary>
@@ -212,6 +220,7 @@ namespace DnsClientX {
             } else {
                 Port = 443;
             }
+            ApplyPortToBaseUri();
         }
 
         /// <summary>
@@ -222,6 +231,7 @@ namespace DnsClientX {
                 Hostname = hostnames[0];
                 if (baseUriFormat != null) {
                     BaseUri = new Uri(string.Format(baseUriFormat, Hostname));
+                    ApplyPortToBaseUri();
                 }
             } else if (hostnames.Count == 0) {
                 // use BaseUri as is
@@ -252,6 +262,7 @@ namespace DnsClientX {
                 }
 
                 BaseUri = new Uri(string.Format(baseUriFormat, Hostname));
+                ApplyPortToBaseUri();
             }
         }
 
@@ -437,6 +448,7 @@ namespace DnsClientX {
 
             if (baseUriFormat != null && !string.IsNullOrEmpty(Hostname)) {
                 BaseUri = new Uri(string.Format(baseUriFormat, Hostname));
+                ApplyPortToBaseUri();
             }
         }
     }


### PR DESCRIPTION
## Summary
- preserve configured TLS port when changing `BaseUri`
- cover custom DoT port scenario with integration test

## Testing
- `dotnet test --verbosity minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d79ad8a8c832eb3596af1a23371f3