### PR TITLE
Add Find-DnsService cmdlet

### DIFF
--- a/DnsClientX.PowerShell/CmdletFindDnsService.cs
+++ b/DnsClientX.PowerShell/CmdletFindDnsService.cs
@@ -1,0 +1,26 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DnsClientX.PowerShell {
+    /// <summary>
+    /// <para type="synopsis">Discovers services advertised via DNS Service Discovery.</para>
+    /// <para type="description">Wraps <see cref="ClientX.DiscoverServices"/> to return services under a domain.</para>
+    /// <example>
+    ///   <para>Find HTTP services under example.com</para>
+    ///   <code>Find-DnsService -Domain example.com</code>
+    /// </example>
+    /// </summary>
+    [Cmdlet(VerbsCommon.Find, "DnsService")]
+    public sealed class CmdletFindDnsService : AsyncPSCmdlet {
+        /// <summary>Domain name to search for advertised services.</summary>
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Domain { get; set; } = string.Empty;
+
+        /// <inheritdoc />
+        protected override async Task ProcessRecordAsync() {
+            using var client = new ClientX();
+            var results = await client.DiscoverServices(Domain);
+            WriteObject(results);
+        }
+    }
+}

--- a/Module/DnsClientX.psd1
+++ b/Module/DnsClientX.psd1
@@ -1,7 +1,7 @@
 @{
     AliasesToExport      = @('Get-DnsZoneTransfer', 'Resolve-DnsQuery')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-DnsService', 'Get-DnsZone', 'Resolve-Dns', 'Invoke-DnsUpdate')
+    CmdletsToExport      = @('Get-DnsService', 'Find-DnsService', 'Get-DnsZone', 'Resolve-Dns', 'Invoke-DnsUpdate')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Examples/Example.FindDnsService.ps1
+++ b/Module/Examples/Example.FindDnsService.ps1
@@ -1,0 +1,3 @@
+Import-Module $PSScriptRoot\..\DnsClientX.psd1 -Force
+
+Find-DnsService -Domain 'example.com'

--- a/Module/Tests/FindDnsService.Tests.ps1
+++ b/Module/Tests/FindDnsService.Tests.ps1
@@ -1,0 +1,10 @@
+Import-Module "$PSScriptRoot/../DnsClientX.psd1" -Force
+
+Describe 'Find-DnsService cmdlet' {
+    It 'Returns empty array when no services are discovered' {
+        $result = Find-DnsService -Domain 'example.com'
+        ($null -ne $result) | Should -BeTrue
+        $result.GetType().FullName | Should -Be 'DnsClientX.DnsService[]'
+        $result.Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
## Summary
- add new `Find-DnsService` PowerShell cmdlet that uses `ClientX.DiscoverServices`
- export the cmdlet in the module manifest
- provide example usage
- add Pester tests

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command "./Module/DnsClientX.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_686d7be0fd18832ebc10695df0047dff