### PR TITLE
Implement HTTP JSON update and CLI option

### DIFF
--- a/DnsClientX.Tests/DnsJsonUpdateTests.cs
+++ b/DnsClientX.Tests/DnsJsonUpdateTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsJsonUpdateTests {
+        private class JsonUpdateHandler : HttpMessageHandler {
+            public HttpRequestMessage? Request { get; private set; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                Request = request;
+                var json = "{\"Status\":0}";
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+                return Task.FromResult(response);
+            }
+        }
+
+        private static void InjectClient(ClientX client, HttpClient httpClient) {
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(client)!;
+            clients[client.EndpointConfiguration.SelectionStrategy] = httpClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(client, httpClient);
+        }
+
+        [Fact]
+        public async Task UpdateRecordJsonPost_Add() {
+            var handler = new JsonUpdateHandler();
+            using var clientX = new ClientX(DnsEndpoint.CloudflareJsonPost);
+            var httpClient = new HttpClient(handler) { BaseAddress = clientX.EndpointConfiguration.BaseUri };
+            InjectClient(clientX, httpClient);
+
+            var response = await clientX.UpdateRecordAsync("example.com", "www.example.com", DnsRecordType.A, "1.2.3.4");
+
+            Assert.Equal(HttpMethod.Post, handler.Request?.Method);
+            Assert.Equal("application/json", handler.Request?.Content?.Headers.ContentType?.MediaType);
+            Assert.Equal(DnsResponseCode.NoError, response.Status);
+        }
+
+        [Fact]
+        public async Task DeleteRecordJsonPost_Delete() {
+            var handler = new JsonUpdateHandler();
+            using var clientX = new ClientX(DnsEndpoint.CloudflareJsonPost);
+            var httpClient = new HttpClient(handler) { BaseAddress = clientX.EndpointConfiguration.BaseUri };
+            InjectClient(clientX, httpClient);
+
+            var response = await clientX.DeleteRecordAsync("example.com", "www.example.com", DnsRecordType.A);
+
+            Assert.Equal(HttpMethod.Post, handler.Request?.Method);
+            Assert.Equal("application/json", handler.Request?.Content?.Headers.ContentType?.MediaType);
+            Assert.Equal(DnsResponseCode.NoError, response.Status);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.Update.cs
+++ b/DnsClientX/DnsClientX.Update.cs
@@ -22,7 +22,12 @@ namespace DnsClientX {
             if (string.IsNullOrEmpty(zone)) throw new ArgumentNullException(nameof(zone));
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
             EndpointConfiguration.SelectHostNameStrategy();
-            var response = await DnsWireUpdateTcp.UpdateRecordAsync(EndpointConfiguration.Hostname, EndpointConfiguration.Port, zone, name, type, data, ttl, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            DnsResponse response;
+            if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSONPOST) {
+                response = await Client.UpdateJsonFormatPost(zone, name, type, data, ttl, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            } else {
+                response = await DnsWireUpdateTcp.UpdateRecordAsync(EndpointConfiguration.Hostname, EndpointConfiguration.Port, zone, name, type, data, ttl, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            }
             if (response.Status != DnsResponseCode.NoError) {
                 throw new DnsClientException($"DNS update failed with {response.Status}", response);
             }
@@ -42,7 +47,12 @@ namespace DnsClientX {
             if (string.IsNullOrEmpty(zone)) throw new ArgumentNullException(nameof(zone));
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
             EndpointConfiguration.SelectHostNameStrategy();
-            var response = await DnsWireUpdateTcp.DeleteRecordAsync(EndpointConfiguration.Hostname, EndpointConfiguration.Port, zone, name, type, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            DnsResponse response;
+            if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSONPOST) {
+                response = await Client.DeleteJsonFormatPost(zone, name, type, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            } else {
+                response = await DnsWireUpdateTcp.DeleteRecordAsync(EndpointConfiguration.Hostname, EndpointConfiguration.Port, zone, name, type, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+            }
             if (response.Status != DnsResponseCode.NoError) {
                 throw new DnsClientException($"DNS update failed with {response.Status}", response);
             }

--- a/DnsClientX/ProtocolDnsJson/DnsJsonUpdate.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJsonUpdate.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json;
+
+namespace DnsClientX {
+    internal static class DnsJsonUpdate {
+        internal static async Task<DnsResponse> UpdateJsonFormatPost(this HttpClient client, string zone, string name,
+            DnsRecordType type, string data, int ttl, bool debug, Configuration configuration, CancellationToken cancellationToken) {
+            var payload = new Dictionary<string, object?> {
+                ["zone"] = zone,
+                ["name"] = name,
+                ["type"] = type.ToString(),
+                ["data"] = data,
+                ["ttl"] = ttl
+            };
+            string json = JsonSerializer.Serialize(payload, DnsJson.JsonOptions);
+            using HttpRequestMessage req = new(HttpMethod.Post, string.Empty) { Content = new StringContent(json) };
+            req.Content!.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+            using HttpResponseMessage res = await client.SendAsync(req, cancellationToken).ConfigureAwait(false);
+            DnsResponse response = await res.Deserialize<DnsResponse>(debug).ConfigureAwait(false);
+            response.AddServerDetails(configuration);
+            return response;
+        }
+
+        internal static async Task<DnsResponse> DeleteJsonFormatPost(this HttpClient client, string zone, string name,
+            DnsRecordType type, bool debug, Configuration configuration, CancellationToken cancellationToken) {
+            var payload = new Dictionary<string, object?> {
+                ["zone"] = zone,
+                ["name"] = name,
+                ["type"] = type.ToString(),
+                ["delete"] = true
+            };
+            string json = JsonSerializer.Serialize(payload, DnsJson.JsonOptions);
+            using HttpRequestMessage req = new(HttpMethod.Post, string.Empty) { Content = new StringContent(json) };
+            req.Content!.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+            using HttpResponseMessage res = await client.SendAsync(req, cancellationToken).ConfigureAwait(false);
+            DnsResponse response = await res.Deserialize<DnsResponse>(debug).ConfigureAwait(false);
+            response.AddServerDetails(configuration);
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement HTTP JSON endpoints for DNS updates
- extend client to use JSON updates when format is JSON POST
- support dynamic updates in CLI via `--update`
- add tests for the JSON update feature

## Testing
- `dotnet test` *(fails: Network is unreachable)*
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686d7bc81d98832e9604267e309dea39