### PR TITLE
Add DNS wire POST option

### DIFF
--- a/DnsClientX.Examples/DemoByManualUrl.cs
+++ b/DnsClientX.Examples/DemoByManualUrl.cs
@@ -58,8 +58,8 @@ namespace DnsClientX.Examples {
         /// Demonstrates querying using HTTP POST.
         /// </summary>
         public static async Task ExampleTestingHttpOverPost() {
-            HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST);
-            using (var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsPOST) {
+            HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsWirePost);
+            using (var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsWirePost) {
                    Debug = false
                }) {
                 var data = await client.Resolve("www.example.com", DnsRecordType.A);

--- a/DnsClientX.Examples/DemoCliDnsSecValidation.cs
+++ b/DnsClientX.Examples/DemoCliDnsSecValidation.cs
@@ -10,7 +10,7 @@ namespace DnsClientX.Examples {
             var assembly = Assembly.Load("DnsClientX.Cli");
             var programType = assembly.GetType("DnsClientX.Cli.Program")!;
             var main = programType.GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
-            await (Task<int>)main.Invoke(null, new object[] { new[] { "--dnssec", "--validate-dnssec", "evotec.pl" } })!;
+            await (Task<int>)main.Invoke(null, new object[] { new[] { "--dnssec", "--validate-dnssec", "--wire-post", "evotec.pl" } })!;
         }
     }
 }

--- a/DnsClientX.Examples/DemoQuery.cs
+++ b/DnsClientX.Examples/DemoQuery.cs
@@ -65,9 +65,9 @@ namespace DnsClientX.Examples {
 
         public static async Task ExampleHttpsOverPost() {
             HelpersSpectre.AddLine("QueryDns", "evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"),
-                DnsRequestFormat.DnsOverHttpsPOST);
+                DnsRequestFormat.DnsOverHttpsWirePost);
             var data = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"),
-                DnsRequestFormat.DnsOverHttpsPOST);
+                DnsRequestFormat.DnsOverHttpsWirePost);
             data.Answers.DisplayTable();
         }
 

--- a/DnsClientX.Tests/CliIntegrationTests.cs
+++ b/DnsClientX.Tests/CliIntegrationTests.cs
@@ -12,7 +12,7 @@ namespace DnsClientX.Tests {
             var assembly = Assembly.Load("DnsClientX.Cli");
             Type programType = assembly.GetType("DnsClientX.Cli.Program")!;
             MethodInfo main = programType.GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
-            Task<int> task = (Task<int>)main.Invoke(null, new object[] { new[] { "localhost" } })!;
+            Task<int> task = (Task<int>)main.Invoke(null, new object[] { new[] { "--wire-post", "localhost" } })!;
             int exitCode = await task;
             Assert.Equal(0, exitCode);
             Assert.Equal(1, ClientX.DisposalCount);

--- a/DnsClientX.Tests/QueryDnsByUri.cs
+++ b/DnsClientX.Tests/QueryDnsByUri.cs
@@ -5,6 +5,7 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsWirePost)]
         //[InlineData("https://9.9.9.11/dns-query", DnsRequestFormat.DnsOverHttps)]
         [InlineData("https://208.67.222.123/dns-query", DnsRequestFormat.DnsOverHttps)]
         public async Task ShouldWorkForTXT(string baseUri, DnsRequestFormat requestFormat) {
@@ -20,6 +21,7 @@ namespace DnsClientX.Tests {
         [Theory]
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
+        [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsWirePost)]
         //[InlineData("https://9.9.9.10/dns-query", DnsRequestFormat.DnsOverHttps)]
         [InlineData("https://doh.opendns.com/dns-query", DnsRequestFormat.DnsOverHttps)]
         [InlineData("https://dns.adguard.com/dns-query", DnsRequestFormat.DnsOverHttps)]

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -290,7 +290,7 @@ namespace DnsClientX {
                     break;
                 case DnsEndpoint.CloudflareWireFormatPost:
                     hostnames = new List<string> { "1.1.1.1", "1.0.0.1" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsPOST;
+                    RequestFormat = DnsRequestFormat.DnsOverHttpsWirePost;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.CloudflareJsonPost:
@@ -335,7 +335,7 @@ namespace DnsClientX {
                     break;
                 case DnsEndpoint.GoogleWireFormatPost:
                     hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsPOST;
+                    RequestFormat = DnsRequestFormat.DnsOverHttpsWirePost;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.GoogleJsonPost:

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -58,6 +58,10 @@ namespace DnsClientX {
         /// </summary>
         ObliviousDnsOverHttps,
         /// <summary>
+        /// Wire format using POST method for DNS requests as defined by RFC 8484.
+        /// </summary>
+        DnsOverHttpsWirePost,
+        /// <summary>
         /// DNS over UDP multicast (mDNS on port 5353).
         /// </summary>
         Multicast,

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -94,7 +94,8 @@ namespace DnsClientX {
                     response = await Client.ResolveJsonFormat(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps) {
                     response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||
+                           EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsWirePost) {
                     response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSONPOST) {
                     response = await Client.ResolveJsonFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -295,6 +295,7 @@ namespace DnsClientX {
             // Set the accept header based on the request format, which is required for proper processing
             if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||
+                EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsWirePost ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2 ||
 #if NET8_0_OR_GREATER
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3 ||


### PR DESCRIPTION
## Summary
- add `DnsOverHttpsWirePost` request format
- allow CLI to toggle wire format POST
- update examples and tests for new option
- support wire POST for Cloudflare and Google endpoints

## Testing
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d7bb35d88832eab50385e1f674627