### PR TITLE
Use OrderedDictionary for deduplication

### DIFF
--- a/DnsClientX.Examples/DemoGetSystemDns.cs
+++ b/DnsClientX.Examples/DemoGetSystemDns.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Example that prints DNS servers discovered on the system.
+    /// </summary>
+    internal static class DemoGetSystemDns {
+        public static void Example() {
+            var servers = SystemInformation.GetDnsFromActiveNetworkCard(refresh: true);
+            Console.WriteLine("System DNS servers:");
+            foreach (var server in servers) {
+                Console.WriteLine($" - {server}");
+            }
+        }
+    }
+}

--- a/DnsClientX.Tests/DeduplicateDnsServersTests.cs
+++ b/DnsClientX.Tests/DeduplicateDnsServersTests.cs
@@ -14,6 +14,14 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        public void DuplicateDnsServers_OrderIsPreserved() {
+            MethodInfo method = typeof(SystemInformation).GetMethod("DeduplicateDnsServers", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var input = new List<string> { "2.2.2.2", "1.1.1.1", "2.2.2.2", "[2001:db8::1]", "1.1.1.1" };
+            var result = (List<string>)method.Invoke(null, new object[] { input })!;
+            Assert.Equal(new[] { "2.2.2.2", "1.1.1.1", "[2001:db8::1]" }, result);
+        }
+
+        [Fact]
         public void GetDnsFromActiveNetworkCard_ReturnsDistinctList() {
             var servers = SystemInformation.GetDnsFromActiveNetworkCard(refresh: true);
             var distinct = servers.Distinct().ToList();

--- a/DnsClientX/SystemInformation.cs
+++ b/DnsClientX/SystemInformation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.IO;
 using System.Net;
@@ -178,16 +179,15 @@ namespace DnsClientX {
         }
 
         private static List<string> DeduplicateDnsServers(IEnumerable<string> servers) {
-            var unique = new HashSet<string>();
-            var result = new List<string>();
+            var unique = new OrderedDictionary(StringComparer.Ordinal);
 
             foreach (var server in servers) {
-                if (unique.Add(server)) {
-                    result.Add(server);
+                if (!unique.Contains(server)) {
+                    unique.Add(server, null);
                 }
             }
 
-            return result;
+            return unique.Keys.Cast<string>().ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- preserve insertion order while deduplicating DNS servers
- test that deduplication keeps order
- add example showing system DNS enumeration

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: 141, passed: 376)*

------
https://chatgpt.com/codex/tasks/task_e_686d7c620c70832e87989d1ea5485b79