### PR TITLE
Handle invalid UDP server address

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveUdpIPv6Tests.cs
+++ b/DnsClientX.Tests/DnsWireResolveUdpIPv6Tests.cs
@@ -55,5 +55,16 @@ namespace DnsClientX.Tests {
             await udpTask;
             Assert.Equal(DnsResponseCode.NoError, dnsResponse.Status);
         }
+
+        [Fact]
+        public async Task ResolveWireFormatUdp_ShouldReturnServerFailure_ForInvalidServer() {
+            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
+            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var config = new Configuration("invalid", DnsRequestFormat.DnsOverUDP);
+            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "invalid", 53, "example.com", DnsRecordType.A, false, false, false, config, 1, CancellationToken.None })!;
+            DnsResponse response = await task;
+            Assert.Equal(DnsResponseCode.ServerFailure, response.Status);
+            Assert.Contains("invalid dns server", response.Error, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- guard against invalid DNS server address in UDP resolver
- add regression test for invalid server input

## Testing
- `dotnet restore`
- `dotnet test` *(fails: The argument /workspace/DnsClientX/DnsClientX.Tests/bin/Debug/net8.0/DnsClientX.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686e02493f40832ebc5ba4ab3f4f709c