### PR TITLE
Log negative TTL directive

### DIFF
--- a/DnsClientX.Tests/BindFileParserTests.cs
+++ b/DnsClientX.Tests/BindFileParserTests.cs
@@ -78,5 +78,20 @@ namespace DnsClientX.Tests {
             Assert.Equal(DnsRecordType.SOA, records[0].Type);
             Assert.Equal("ns.example.com. admin.example.com. 2024010101 7200 3600 1209600 3600", records[0].DataRaw);
         }
+
+        [Fact]
+        public void ParseZoneFile_WarnsOnNegativeTtlDirective() {
+            string file = Path.GetTempFileName();
+            File.WriteAllLines(file, new[] {
+                "$TTL -1",
+                "example.com. IN A 1.1.1.1"
+            });
+
+            var messages = new System.Collections.Generic.List<string>();
+            var records = BindFileParser.ParseZoneFile(file, m => messages.Add(m));
+
+            Assert.Single(records);
+            Assert.Contains(messages, m => m.Contains("negative value"));
+        }
     }
 }

--- a/DnsClientX/BindFileParser.cs
+++ b/DnsClientX/BindFileParser.cs
@@ -166,8 +166,12 @@ namespace DnsClientX {
 
                 if (line.StartsWith("$TTL", StringComparison.OrdinalIgnoreCase)) {
                     var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (parts.Length > 1 && TryParseTtl(parts[1], out int ttlDirective) && ttlDirective >= 0) {
-                        defaultTtl = ttlDirective;
+                    if (parts.Length > 1 && TryParseTtl(parts[1], out int ttlDirective)) {
+                        if (ttlDirective < 0) {
+                            debugPrint?.Invoke($"Skipping TTL directive with negative value: {line}");
+                        } else {
+                            defaultTtl = ttlDirective;
+                        }
                     } else {
                         debugPrint?.Invoke($"Skipping invalid TTL directive: {line}");
                     }


### PR DESCRIPTION
## Summary
- warn when negative TTL directive is encountered
- verify negative TTL directive triggers debug output

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test --no-build --verbosity minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e025fe1f0832e92734681174198f5