### PR TITLE
Handle InvalidOperationException in HTTP resolvers

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveHttp3Tests.cs
+++ b/DnsClientX.Tests/DnsWireResolveHttp3Tests.cs
@@ -28,6 +28,12 @@ namespace DnsClientX.Tests {
             }
         }
 
+        private class Http3InvalidHandler : HttpMessageHandler {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                throw new InvalidOperationException("invalid op");
+            }
+        }
+
 
         [Fact]
         public async Task ResolveWireFormatHttp3_UsesHttp3() {
@@ -52,6 +58,18 @@ namespace DnsClientX.Tests {
             Assert.Contains("server error", ex.Message);
             Assert.Equal(config.Hostname, ex.Response.Questions[0].HostName);
             Assert.Equal(config.Port, ex.Response.Questions[0].Port);
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatHttp3_ReturnsServerFailureOnInvalidOperation() {
+            var handler = new Http3InvalidHandler();
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com/dns-query") };
+            var config = new Configuration(new Uri("https://example.com/dns-query"), DnsRequestFormat.DnsOverHttp3);
+
+            var response = await DnsWireResolveHttp3.ResolveWireFormatHttp3(client, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None);
+
+            Assert.Equal(DnsResponseCode.ServerFailure, response.Status);
+            Assert.Contains("invalid op", response.Error);
         }
 
     }

--- a/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
+++ b/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
@@ -125,7 +125,24 @@ namespace DnsClientX {
                     Status = responseCode
                 };
                 response.AddServerDetails(endpointConfiguration);
-                response.Error = $"Failed to query type {type} of \"{name}\" =>{ex.Message} {ex.InnerException?.Message}";                
+                response.Error = $"Failed to query type {type} of \"{name}\" =>{ex.Message} {ex.InnerException?.Message}";
+                return response;
+            } catch (InvalidOperationException ex) {
+                DnsResponse response = new DnsResponse {
+                    Questions = [
+                        new DnsQuestion {
+                            Name = name,
+                            RequestFormat = DnsRequestFormat.DnsOverHttp2,
+                            HostName = client.BaseAddress.Host,
+                            Port = client.BaseAddress.Port,
+                            Type = type,
+                            OriginalName = name
+                        }
+                    ],
+                    Status = DnsResponseCode.ServerFailure
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" =>{ex.Message}";
                 return response;
             }
         }

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -131,6 +131,23 @@ namespace DnsClientX {
                 response.AddServerDetails(endpointConfiguration);
                 response.Error = $"Failed to query type {type} of \"{name}\" =>{ex.Message} {ex.InnerException?.Message}";
                 return response;
+            } catch (InvalidOperationException ex) {
+                DnsResponse response = new DnsResponse {
+                    Questions = [
+                        new DnsQuestion {
+                            Name = name,
+                            RequestFormat = DnsRequestFormat.DnsOverHttp3,
+                            HostName = client.BaseAddress.Host,
+                            Port = client.BaseAddress.Port,
+                            Type = type,
+                            OriginalName = name
+                        }
+                    ],
+                    Status = DnsResponseCode.ServerFailure
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" =>{ex.Message}";
+                return response;
             }
         }
     }


### PR DESCRIPTION
## Summary
- catch InvalidOperationException in HTTP/2 and HTTP/3 resolvers and return ServerFailure
- extend HTTP resolver tests with failing InvalidOperationException scenario

## Testing
- `dotnet test --no-build` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e02a17638832e9348ca8f4da47e44