### PR TITLE
Add ZoneTransferStreamAsync example

### DIFF
--- a/DnsClientX.Examples/DemoZoneTransferStream.cs
+++ b/DnsClientX.Examples/DemoZoneTransferStream.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates streaming a DNS zone transfer using <see cref="ClientX.ZoneTransferStreamAsync"/>.
+    /// </summary>
+    internal class DemoZoneTransferStream {
+        /// <summary>
+        /// Executes the streaming zone transfer example.
+        /// </summary>
+        public static async Task Example() {
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = 5353 } };
+            await foreach (var rrset in client.ZoneTransferStreamAsync("example.com")) {
+                Console.WriteLine(string.Join(", ", rrset));
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -588,6 +588,17 @@ var zoneRecords = await client.ZoneTransferAsync("example.com");
 Get-DnsZoneTransfer -Zone 'example.com' -Server '127.0.0.1' -Port 5353
 ```
 
+### Zone Transfer Streaming
+
+Process a DNS zone transfer as records arrive:
+
+```csharp
+using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = 5353 } };
+await foreach (var rrset in client.ZoneTransferStreamAsync("example.com")) {
+    Console.WriteLine(string.Join(", ", rrset));
+}
+```
+
 ### Multicast Queries
 
 Query devices advertising mDNS on your local network:


### PR DESCRIPTION
## Summary
- add a new `DemoZoneTransferStream` example showing how to use `ZoneTransferStreamAsync`
- document streaming zone transfer usage in the README

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: ConnectAsync)*

------
https://chatgpt.com/codex/tasks/task_e_686e02ebf070832ea573f95b8eadb282