### PR TITLE
Add DnsOverHttpsWirePost resolver

### DIFF
--- a/DnsClientX.Cli/Program.cs
+++ b/DnsClientX.Cli/Program.cs
@@ -98,9 +98,14 @@ namespace DnsClientX.Cli {
             }
 
             try {
-                await using var client = wirePost
-                    ? new ClientX(new Configuration(endpoint).BaseUri!, DnsRequestFormat.DnsOverHttpsWirePost)
-                    : new ClientX(endpoint);
+                await using var client = new ClientX(endpoint);
+                if (wirePost &&
+                    (client.EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps ||
+                     client.EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||
+                     client.EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSON ||
+                     client.EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSONPOST)) {
+                    client.EndpointConfiguration.RequestFormat = DnsRequestFormat.DnsOverHttpsWirePost;
+                }
                 if (doUpdate) {
                     var response = await client.UpdateRecordAsync(zone!, updateName!, recordType, updateData!, ttl, cts.Token);
                     Console.WriteLine($"Update status: {response.Status}");
@@ -130,7 +135,7 @@ namespace DnsClientX.Cli {
             Console.WriteLine("  -e, --endpoint <name>    DNS endpoint name (default System)");
             Console.WriteLine("      --dnssec             Request DNSSEC records");
             Console.WriteLine("      --validate-dnssec    Validate DNSSEC records");
-            Console.WriteLine("      --wire-post          Use DNS over HTTPS wire POST");
+            Console.WriteLine("      --wire-post          Use DNS over HTTPS wire POST (when supported)");
             Console.WriteLine("      --update <zone> <name> <type> <data>  Send dynamic update");
             Console.WriteLine("      --ttl <seconds>       TTL for update (default 300)");
             Console.WriteLine();

--- a/DnsClientX.Cli/Program.cs
+++ b/DnsClientX.Cli/Program.cs
@@ -18,6 +18,7 @@ namespace DnsClientX.Cli {
             DnsEndpoint endpoint = DnsEndpoint.System;
             bool requestDnsSec = false;
             bool validateDnsSec = false;
+            bool wirePost = false;
             bool doUpdate = false;
             string? zone = null;
             string? updateName = null;
@@ -53,6 +54,9 @@ namespace DnsClientX.Cli {
                         break;
                     case var opt when opt.Equals("--validate-dnssec", StringComparison.OrdinalIgnoreCase):
                         validateDnsSec = true;
+                        break;
+                    case var opt when opt.Equals("--wire-post", StringComparison.OrdinalIgnoreCase):
+                        wirePost = true;
                         break;
                     case var opt when opt.Equals("--update", StringComparison.OrdinalIgnoreCase):
                         if (i + 4 >= args.Length) {
@@ -94,7 +98,9 @@ namespace DnsClientX.Cli {
             }
 
             try {
-                await using var client = new ClientX(endpoint);
+                await using var client = wirePost
+                    ? new ClientX(new Configuration(endpoint).BaseUri!, DnsRequestFormat.DnsOverHttpsWirePost)
+                    : new ClientX(endpoint);
                 if (doUpdate) {
                     var response = await client.UpdateRecordAsync(zone!, updateName!, recordType, updateData!, ttl, cts.Token);
                     Console.WriteLine($"Update status: {response.Status}");
@@ -124,6 +130,7 @@ namespace DnsClientX.Cli {
             Console.WriteLine("  -e, --endpoint <name>    DNS endpoint name (default System)");
             Console.WriteLine("      --dnssec             Request DNSSEC records");
             Console.WriteLine("      --validate-dnssec    Validate DNSSEC records");
+            Console.WriteLine("      --wire-post          Use DNS over HTTPS wire POST");
             Console.WriteLine("      --update <zone> <name> <type> <data>  Send dynamic update");
             Console.WriteLine("      --ttl <seconds>       TTL for update (default 300)");
             Console.WriteLine();

--- a/DnsClientX.Examples/DemoByManualUrl.cs
+++ b/DnsClientX.Examples/DemoByManualUrl.cs
@@ -68,6 +68,16 @@ namespace DnsClientX.Examples {
         }
 
         /// <summary>
+        /// Demonstrates querying using wire format over HTTP POST.
+        /// </summary>
+        public static async Task ExampleTestingWirePost() {
+            HelpersSpectre.AddLine("Resolve", "www.example.com", DnsRecordType.A, new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsWirePost);
+            using var client = new ClientX(new Uri("https://1.1.1.1/dns-query"), DnsRequestFormat.DnsOverHttpsWirePost) { Debug = false };
+            var data = await client.Resolve("www.example.com", DnsRecordType.A);
+            data.DisplayTable();
+        }
+
+        /// <summary>
         /// Demonstrates querying via UDP transport.
         /// </summary>
         public static async Task ExampleTestingUdp() {

--- a/DnsClientX.Examples/Program.cs
+++ b/DnsClientX.Examples/Program.cs
@@ -33,6 +33,7 @@ namespace DnsClientX.Examples {
             // await DemoQuery.ExampleTesting();
             // await DemoByManualUrl.ExampleTesting();
             // await DemoByManualUrl.ExampleTestingHttpOverPost();
+            // await DemoByManualUrl.ExampleTestingWirePost();
             // await DemoByManualUrl.ExampleTestingUdp();
             // await DemoByManualUrl.ExampleTestingTcp();
             // await DemoByManualUrl.ExampleGoogle();

--- a/DnsClientX.Tests/CliIntegrationTests.cs
+++ b/DnsClientX.Tests/CliIntegrationTests.cs
@@ -31,5 +31,17 @@ namespace DnsClientX.Tests {
             Assert.Equal(0, exitCode);
             Assert.Equal(1, ClientX.DisposalCount);
         }
+
+        [Fact]
+        public async Task WirePostOption_Executes() {
+            ClientX.DisposalCount = 0;
+            var assembly = Assembly.Load("DnsClientX.Cli");
+            Type programType = assembly.GetType("DnsClientX.Cli.Program")!;
+            MethodInfo main = programType.GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
+            Task<int> task = (Task<int>)main.Invoke(null, new object[] { new[] { "--wire-post", "localhost" } })!;
+            int exitCode = await task;
+            Assert.Equal(0, exitCode);
+            Assert.True(ClientX.DisposalCount >= 1);
+        }
     }
 }

--- a/DnsClientX.Tests/QueryDnsWirePost.cs
+++ b/DnsClientX.Tests/QueryDnsWirePost.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class QueryDnsWirePost {
+        private class WirePostHandler : HttpMessageHandler {
+            public HttpRequestMessage? Request { get; private set; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                Request = request;
+                byte[] responseBytes = { 0x00, 0x01, 0x81, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+                var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(responseBytes) };
+                return Task.FromResult(response);
+            }
+        }
+
+        private static void InjectClient(ClientX client, HttpClient httpClient) {
+            var clientsField = typeof(ClientX).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var clients = (Dictionary<DnsSelectionStrategy, HttpClient>)clientsField.GetValue(client)!;
+            clients[client.EndpointConfiguration.SelectionStrategy] = httpClient;
+            var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            clientField.SetValue(client, httpClient);
+        }
+
+        [Theory]
+        [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
+        [InlineData(DnsEndpoint.GoogleWireFormatPost)]
+        public async Task ShouldPostWire(DnsEndpoint endpoint) {
+            var handler = new WirePostHandler();
+            using var clientX = new ClientX(endpoint);
+            var httpClient = new HttpClient(handler) { BaseAddress = clientX.EndpointConfiguration.BaseUri };
+            InjectClient(clientX, httpClient);
+
+            var response = await clientX.Resolve("evotec.pl", DnsRecordType.A, retryOnTransient: false);
+
+            Assert.Equal(HttpMethod.Post, handler.Request?.Method);
+            Assert.Equal("application/dns-message", handler.Request?.Content?.Headers.ContentType?.MediaType);
+            Assert.NotNull(response);
+        }
+    }
+}

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -301,7 +301,7 @@ namespace DnsClientX {
                     break;
                 case DnsEndpoint.CloudflareWireFormatPost:
                     hostnames = new List<string> { "1.1.1.1", "1.0.0.1" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsPOST;
+                    RequestFormat = DnsRequestFormat.DnsOverHttpsWirePost;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.CloudflareJsonPost:
@@ -346,7 +346,7 @@ namespace DnsClientX {
                     break;
                 case DnsEndpoint.GoogleWireFormatPost:
                     hostnames = new List<string> { "8.8.8.8", "8.8.4.4" };
-                    RequestFormat = DnsRequestFormat.DnsOverHttpsPOST;
+                    RequestFormat = DnsRequestFormat.DnsOverHttpsWirePost;
                     baseUriFormat = "https://{0}/dns-query";
                     break;
                 case DnsEndpoint.GoogleJsonPost:

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -18,6 +18,12 @@ namespace DnsClientX {
         /// </summary>
         DnsOverHttpsPOST,
         /// <summary>
+        /// Wire format over HTTPS using POST request, identical to
+        /// <see cref="DnsOverHttpsPOST"/> but with an explicit name to
+        /// distinguish wire protocol POST usage.
+        /// </summary>
+        DnsOverHttpsWirePost,
+        /// <summary>
         /// JSON format for DNS requests sent using POST method.
         /// </summary>
         DnsOverHttpsJSONPOST,

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -18,9 +18,8 @@ namespace DnsClientX {
         /// </summary>
         DnsOverHttpsPOST,
         /// <summary>
-        /// Wire format over HTTPS using POST request, identical to
-        /// <see cref="DnsOverHttpsPOST"/> but with an explicit name to
-        /// distinguish wire protocol POST usage.
+        /// Wire format over HTTPS using POST request.
+        /// Alias for <see cref="DnsOverHttpsPOST"/> with an explicit name.
         /// </summary>
         DnsOverHttpsWirePost,
         /// <summary>

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -94,7 +94,8 @@ namespace DnsClientX {
                     response = await Client.ResolveJsonFormat(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps) {
                     response = await Client.ResolveWireFormatGet(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
-                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST) {
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||
+                           EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsWirePost) {
                     response = await Client.ResolveWireFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSONPOST) {
                     response = await Client.ResolveJsonFormatPost(name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -295,6 +295,7 @@ namespace DnsClientX {
             // Set the accept header based on the request format, which is required for proper processing
             if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||
+                EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsWirePost ||
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp2 ||
 #if NET8_0_OR_GREATER
                 EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttp3 ||


### PR DESCRIPTION
## Summary
- extend `DnsRequestFormat` enum with `DnsOverHttpsWirePost`
- handle new format in ClientX resolve logic and HTTP client headers
- support `--wire-post` option in CLI
- show new POST usage in example project
- add unit tests for wire POST and CLI option

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Assert.Equal() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_686e449a2e84832eb9dc862363c10a7c