### PR TITLE
Remove ServicePointManager in client

### DIFF
--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -122,9 +122,6 @@ namespace DnsClientX {
             get => _securityProtocol;
             set {
                 _securityProtocol = value;
-#if NET472
-                ServicePointManager.SecurityProtocol = value;
-#endif
                 if (handler != null) {
                     handler.SslProtocols = (SslProtocols)value;
                 }


### PR DESCRIPTION
## Summary
- drop ServicePointManager.SecurityProtocol usage
- rely on HttpClientHandler.SslProtocols for TLS settings

## Testing
- `dotnet test --configuration Release --verbosity minimal` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e880f73e4832ead0516d1633c2815