### PR TITLE
Handle CLI invalid switches gracefully

### DIFF
--- a/DnsClientX.Cli/Program.cs
+++ b/DnsClientX.Cli/Program.cs
@@ -1,5 +1,6 @@
 using DnsClientX;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,6 +25,8 @@ namespace DnsClientX.Cli {
             string? updateName = null;
             string? updateData = null;
             int ttl = 300;
+
+            var invalidSwitches = new List<string>();
 
             using var cts = new CancellationTokenSource();
             Console.CancelKeyPress += (_, e) => {
@@ -77,14 +80,21 @@ namespace DnsClientX.Cli {
                         ttl = int.Parse(args[++i]);
                         break;
                     default:
-                        if (domain is null) {
+                        if (domain is null && !args[i].StartsWith("-", StringComparison.Ordinal)) {
                             domain = args[i];
                         } else {
-                            Console.Error.WriteLine($"Unknown argument: {args[i]}");
-                            return 1;
+                            invalidSwitches.Add(args[i]);
                         }
                         break;
                 }
+            }
+
+            if (invalidSwitches.Count > 0) {
+                foreach (string invalid in invalidSwitches) {
+                    Console.Error.WriteLine($"Unknown argument: {invalid}");
+                }
+                ShowHelp();
+                return 1;
             }
 
             if (doUpdate) {

--- a/DnsClientX.Tests/CliArgumentValidationTests.cs
+++ b/DnsClientX.Tests/CliArgumentValidationTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    [Collection("NoParallel")]
+    public class CliArgumentValidationTests {
+        [Fact]
+        public async Task UnknownOption_ShowsHelpAndReturnsError() {
+            var assembly = Assembly.Load("DnsClientX.Cli");
+            Type programType = assembly.GetType("DnsClientX.Cli.Program")!;
+            MethodInfo main = programType.GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+            TextWriter originalOut = Console.Out;
+            TextWriter originalError = Console.Error;
+            try {
+                Console.SetOut(output);
+                Console.SetError(error);
+                Task<int> task = (Task<int>)main.Invoke(null, new object[] { new[] { "--unknown" } })!;
+                int exitCode = await task;
+                Assert.Equal(1, exitCode);
+                string combined = output.ToString() + error.ToString();
+                Assert.Contains("Unknown argument: --unknown", combined);
+                Assert.Contains("Usage: DnsClientX.Cli", combined);
+            } finally {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- gather unknown CLI options in Program.Main
- report these options and show help
- test CliArgumentValidationTests for unknown switch handling

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `dotnet test --filter FullyQualifiedName~CliArgumentValidationTests DnsClientX.Tests/DnsClientX.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686e881b97cc832e953214ca9363f8e9