### PR TITLE
Add disposed handler tracking

### DIFF
--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -192,7 +192,7 @@ namespace DnsClientX.Tests {
 
             clientX.Dispose();
 
-            var field = typeof(ClientX).GetField("_disposedClients", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var field = typeof(ClientX).GetField("_disposedResources", BindingFlags.NonPublic | BindingFlags.Instance)!;
             var disposedClients = (HashSet<object>)field.GetValue(clientX)!;
             Assert.Empty(disposedClients);
         }

--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -192,7 +192,7 @@ namespace DnsClientX.Tests {
 
             clientX.Dispose();
 
-            var field = typeof(ClientX).GetField("_disposedResources", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var field = typeof(ClientX).GetField("_disposedClients", BindingFlags.NonPublic | BindingFlags.Instance)!;
             var disposedClients = (HashSet<object>)field.GetValue(clientX)!;
             Assert.Empty(disposedClients);
         }

--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -49,6 +49,7 @@ namespace DnsClientX.Tests {
             clientField.SetValue(clientX, customClient);
             var handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
             handlerField.SetValue(clientX, handler);
+            typeof(ClientX).GetField("_handlerOwnedByClient", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(clientX, false);
             Assert.Same(handler, handlerField.GetValue(clientX));
 
             clientX.Dispose();
@@ -68,6 +69,7 @@ namespace DnsClientX.Tests {
             clientField.SetValue(clientX, customClient);
             var handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
             handlerField.SetValue(clientX, handler);
+            typeof(ClientX).GetField("_handlerOwnedByClient", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(clientX, true);
 
             clientX.Dispose();
 
@@ -84,6 +86,7 @@ namespace DnsClientX.Tests {
             clients[clientX.EndpointConfiguration.SelectionStrategy] = customClient;
             var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
             clientField.SetValue(clientX, customClient);
+            typeof(ClientX).GetField("_handlerOwnedByClient", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(clientX, true);
 
             await clientX.DisposeAsync();
 
@@ -102,6 +105,7 @@ namespace DnsClientX.Tests {
             clientField.SetValue(clientX, customClient);
             var handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
             handlerField.SetValue(clientX, handler);
+            typeof(ClientX).GetField("_handlerOwnedByClient", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(clientX, true);
 
             await clientX.DisposeAsync();
 
@@ -118,6 +122,7 @@ namespace DnsClientX.Tests {
             clients[clientX.EndpointConfiguration.SelectionStrategy] = customClient;
             var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
             clientField.SetValue(clientX, customClient);
+            typeof(ClientX).GetField("_handlerOwnedByClient", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(clientX, true);
 
             var tasks = new List<Task>();
             for (int i = 0; i < 5; i++) {
@@ -138,6 +143,7 @@ namespace DnsClientX.Tests {
             clients[clientX.EndpointConfiguration.SelectionStrategy] = customClient;
             var clientField = typeof(ClientX).GetField("Client", BindingFlags.NonPublic | BindingFlags.Instance)!;
             clientField.SetValue(clientX, customClient);
+            typeof(ClientX).GetField("_handlerOwnedByClient", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(clientX, true);
 
             var tasks = new List<Task>();
             for (int i = 0; i < 5; i++) {
@@ -171,6 +177,7 @@ namespace DnsClientX.Tests {
             clientField.SetValue(clientX, customClient);
             var handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
             handlerField.SetValue(clientX, handler);
+            typeof(ClientX).GetField("_handlerOwnedByClient", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(clientX, false);
 
             await clientX.DisposeAsync();
 

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -13,8 +13,8 @@ namespace DnsClientX {
         private readonly HashSet<object> _disposedClients = new();
         private static int _disposalCount;
         internal static int DisposalCount {
-            get => _disposalCount;
-            set => _disposalCount = value;
+            get => System.Threading.Interlocked.CompareExchange(ref _disposalCount, 0, 0);
+            set => System.Threading.Interlocked.Exchange(ref _disposalCount, value);
         }
 
         private bool TryAddDisposedClient(object client) {

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -10,12 +10,16 @@ namespace DnsClientX {
     /// </summary>
     public partial class ClientX : IDisposable, IAsyncDisposable {
         private bool _disposed;
-        private readonly HashSet<object> _disposedResources = new();
-        internal static int DisposalCount;
+        private readonly HashSet<object> _disposedClients = new();
+        private static readonly System.Threading.AsyncLocal<int> _disposalCount = new();
+        internal static int DisposalCount {
+            get => _disposalCount.Value;
+            set => _disposalCount.Value = value;
+        }
 
-        private bool TryAddDisposedResource(object client) {
+        private bool TryAddDisposedClient(object client) {
             lock (_lock) {
-                return _disposedResources.Add(client);
+                return _disposedClients.Add(client);
             }
         }
 
@@ -51,28 +55,28 @@ namespace DnsClientX {
                 }
                 if (disposing) {
                     foreach (HttpClient client in clients) {
-                        if (TryAddDisposedResource(client)) {
+                        if (TryAddDisposedClient(client)) {
                             client.Dispose();
                         }
                     }
 
-                    if (mainClient != null && TryAddDisposedResource(mainClient)) {
+                    if (mainClient != null && TryAddDisposedClient(mainClient)) {
                         mainClient.Dispose();
                         if (_handlerOwnedByClient && handlerLocal != null) {
-                            TryAddDisposedResource(handlerLocal);
+                            TryAddDisposedClient(handlerLocal);
                         }
                     }
 
-                    if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedResource(handlerLocal)) {
+                    if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedClient(handlerLocal)) {
                         handlerLocal.Dispose();
                     }
 
                     lock (_lock) {
-                        _disposedResources.Clear();
+                        _disposedClients.Clear();
                     }
                 }
 
-                System.Threading.Interlocked.Increment(ref DisposalCount);
+                DisposalCount++;
             }
         }
 
@@ -113,7 +117,7 @@ namespace DnsClientX {
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
                 foreach (HttpClient client in clients) {
-                    if (TryAddDisposedResource(client)) {
+                    if (TryAddDisposedClient(client)) {
                         if (client is IAsyncDisposable asyncClient) {
                             await asyncClient.DisposeAsync().ConfigureAwait(false);
                         } else {
@@ -123,34 +127,34 @@ namespace DnsClientX {
                 }
 #else
                 foreach (HttpClient client in clients) {
-                    if (TryAddDisposedResource(client)) {
+                    if (TryAddDisposedClient(client)) {
                         client.Dispose();
                     }
                 }
 #endif
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-                if (mainClient != null && TryAddDisposedResource(mainClient)) {
+                if (mainClient != null && TryAddDisposedClient(mainClient)) {
                     if (mainClient is IAsyncDisposable asyncClient) {
                         await asyncClient.DisposeAsync().ConfigureAwait(false);
                     } else {
                         mainClient.Dispose();
                     }
                     if (_handlerOwnedByClient && handlerLocal != null) {
-                        TryAddDisposedResource(handlerLocal);
+                        TryAddDisposedClient(handlerLocal);
                     }
                 }
 #else
-                if (mainClient != null && TryAddDisposedResource(mainClient)) {
+                if (mainClient != null && TryAddDisposedClient(mainClient)) {
                     mainClient.Dispose();
                     if (_handlerOwnedByClient && handlerLocal != null) {
-                        TryAddDisposedResource(handlerLocal);
+                        TryAddDisposedClient(handlerLocal);
                     }
                 }
 #endif
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-                if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedResource(handlerLocal)) {
+                if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedClient(handlerLocal)) {
                     if (handlerLocal is IAsyncDisposable asyncHandler) {
                         await asyncHandler.DisposeAsync().ConfigureAwait(false);
                     } else {
@@ -158,17 +162,17 @@ namespace DnsClientX {
                     }
                 }
 #else
-                if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedResource(handlerLocal)) {
+                if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedClient(handlerLocal)) {
                     handlerLocal.Dispose();
                 }
 #endif
 
                 lock (_lock) {
-                    _disposedResources.Clear();
+                    _disposedClients.Clear();
                 }
 
                 _disposed = true;
-                System.Threading.Interlocked.Increment(ref DisposalCount);
+                DisposalCount++;
             }
         }
 

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -10,12 +10,12 @@ namespace DnsClientX {
     /// </summary>
     public partial class ClientX : IDisposable, IAsyncDisposable {
         private bool _disposed;
-        private readonly HashSet<object> _disposedClients = new();
+        private readonly HashSet<object> _disposedResources = new();
         internal static int DisposalCount;
 
-        private bool TryAddDisposedClient(object client) {
+        private bool TryAddDisposedResource(object client) {
             lock (_lock) {
-                return _disposedClients.Add(client);
+                return _disposedResources.Add(client);
             }
         }
 
@@ -51,24 +51,24 @@ namespace DnsClientX {
                 }
                 if (disposing) {
                     foreach (HttpClient client in clients) {
-                        if (TryAddDisposedClient(client)) {
+                        if (TryAddDisposedResource(client)) {
                             client.Dispose();
                         }
                     }
 
-                    if (mainClient != null && TryAddDisposedClient(mainClient)) {
+                    if (mainClient != null && TryAddDisposedResource(mainClient)) {
                         mainClient.Dispose();
                         if (_handlerOwnedByClient && handlerLocal != null) {
-                            TryAddDisposedClient(handlerLocal);
+                            TryAddDisposedResource(handlerLocal);
                         }
                     }
 
-                    if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedClient(handlerLocal)) {
+                    if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedResource(handlerLocal)) {
                         handlerLocal.Dispose();
                     }
 
                     lock (_lock) {
-                        _disposedClients.Clear();
+                        _disposedResources.Clear();
                     }
                 }
 
@@ -113,7 +113,7 @@ namespace DnsClientX {
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
                 foreach (HttpClient client in clients) {
-                    if (TryAddDisposedClient(client)) {
+                    if (TryAddDisposedResource(client)) {
                         if (client is IAsyncDisposable asyncClient) {
                             await asyncClient.DisposeAsync().ConfigureAwait(false);
                         } else {
@@ -123,34 +123,34 @@ namespace DnsClientX {
                 }
 #else
                 foreach (HttpClient client in clients) {
-                    if (TryAddDisposedClient(client)) {
+                    if (TryAddDisposedResource(client)) {
                         client.Dispose();
                     }
                 }
 #endif
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-                if (mainClient != null && TryAddDisposedClient(mainClient)) {
+                if (mainClient != null && TryAddDisposedResource(mainClient)) {
                     if (mainClient is IAsyncDisposable asyncClient) {
                         await asyncClient.DisposeAsync().ConfigureAwait(false);
                     } else {
                         mainClient.Dispose();
                     }
                     if (_handlerOwnedByClient && handlerLocal != null) {
-                        TryAddDisposedClient(handlerLocal);
+                        TryAddDisposedResource(handlerLocal);
                     }
                 }
 #else
-                if (mainClient != null && TryAddDisposedClient(mainClient)) {
+                if (mainClient != null && TryAddDisposedResource(mainClient)) {
                     mainClient.Dispose();
                     if (_handlerOwnedByClient && handlerLocal != null) {
-                        TryAddDisposedClient(handlerLocal);
+                        TryAddDisposedResource(handlerLocal);
                     }
                 }
 #endif
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-                if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedClient(handlerLocal)) {
+                if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedResource(handlerLocal)) {
                     if (handlerLocal is IAsyncDisposable asyncHandler) {
                         await asyncHandler.DisposeAsync().ConfigureAwait(false);
                     } else {
@@ -158,13 +158,13 @@ namespace DnsClientX {
                     }
                 }
 #else
-                if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedClient(handlerLocal)) {
+                if (!_handlerOwnedByClient && handlerLocal != null && TryAddDisposedResource(handlerLocal)) {
                     handlerLocal.Dispose();
                 }
 #endif
 
                 lock (_lock) {
-                    _disposedClients.Clear();
+                    _disposedResources.Clear();
                 }
 
                 _disposed = true;

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -53,17 +53,11 @@ namespace DnsClientX {
                     foreach (HttpClient client in clients) {
                         if (TryAddDisposedClient(client)) {
                             client.Dispose();
-                            if (ReferenceEquals(client, mainClient) && handlerLocal != null) {
-                                TryAddDisposedClient(handlerLocal);
-                            }
                         }
                     }
 
                     if (mainClient != null && TryAddDisposedClient(mainClient)) {
                         mainClient.Dispose();
-                        if (handlerLocal != null) {
-                            TryAddDisposedClient(handlerLocal);
-                        }
                     }
 
                     if (handlerLocal != null && TryAddDisposedClient(handlerLocal)) {
@@ -125,9 +119,6 @@ namespace DnsClientX {
 #else
                         client.Dispose();
 #endif
-                        if (ReferenceEquals(client, mainClient) && handlerLocal != null) {
-                            TryAddDisposedClient(handlerLocal);
-                        }
                     }
                 }
 
@@ -141,9 +132,6 @@ namespace DnsClientX {
 #else
                     mainClient.Dispose();
 #endif
-                    if (handlerLocal != null) {
-                        TryAddDisposedClient(handlerLocal);
-                    }
                 }
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER

--- a/DnsClientX/DnsClientX.Dispose.cs
+++ b/DnsClientX/DnsClientX.Dispose.cs
@@ -11,10 +11,10 @@ namespace DnsClientX {
     public partial class ClientX : IDisposable, IAsyncDisposable {
         private bool _disposed;
         private readonly HashSet<object> _disposedClients = new();
-        private static readonly System.Threading.AsyncLocal<int> _disposalCount = new();
+        private static int _disposalCount;
         internal static int DisposalCount {
-            get => _disposalCount.Value;
-            set => _disposalCount.Value = value;
+            get => _disposalCount;
+            set => _disposalCount = value;
         }
 
         private bool TryAddDisposedClient(object client) {
@@ -76,7 +76,7 @@ namespace DnsClientX {
                     }
                 }
 
-                DisposalCount++;
+                System.Threading.Interlocked.Increment(ref _disposalCount);
             }
         }
 
@@ -172,7 +172,7 @@ namespace DnsClientX {
                 }
 
                 _disposed = true;
-                DisposalCount++;
+                System.Threading.Interlocked.Increment(ref _disposalCount);
             }
         }
 

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -317,6 +317,9 @@ namespace DnsClientX {
             lock (_lock) {
                 if (Client != null && TryAddDisposedClient(Client)) {
                     Client.Dispose();
+                    if (handler != null) {
+                        TryAddDisposedClient(handler);
+                    }
                 }
                 if (handler != null && TryAddDisposedClient(handler)) {
                     handler.Dispose();
@@ -350,8 +353,8 @@ namespace DnsClientX {
                     if (kv.Key != strategy && TryAddDisposedClient(kv.Value)) {
                         kv.Value.Dispose();
                         if (ReferenceEquals(kv.Value, Client)) {
-                            if (handler != null && TryAddDisposedClient(handler)) {
-                                handler.Dispose();
+                            if (handler != null) {
+                                TryAddDisposedClient(handler);
                             }
                             handler = null;
                         }
@@ -363,6 +366,9 @@ namespace DnsClientX {
                 // dispose the currently assigned client and handler if present
                 if (Client != null && TryAddDisposedClient(Client)) {
                     Client.Dispose();
+                    if (handler != null) {
+                        TryAddDisposedClient(handler);
+                    }
                     if (handler != null && TryAddDisposedClient(handler)) {
                         handler.Dispose();
                     }

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -318,13 +318,13 @@ namespace DnsClientX {
         /// </summary>
         private void ConfigureClient() {
             lock (_lock) {
-                if (Client != null && TryAddDisposedClient(Client)) {
+                if (Client != null && TryAddDisposedResource(Client)) {
                     Client.Dispose();
                     if (_handlerOwnedByClient && handler != null) {
-                        TryAddDisposedClient(handler);
+                        TryAddDisposedResource(handler);
                     }
                 }
-                if (!_handlerOwnedByClient && handler != null && TryAddDisposedClient(handler)) {
+                if (!_handlerOwnedByClient && handler != null && TryAddDisposedResource(handler)) {
                     handler.Dispose();
                 }
 
@@ -353,14 +353,14 @@ namespace DnsClientX {
 
                 // dispose any clients created for other strategies
                 foreach (KeyValuePair<DnsSelectionStrategy, HttpClient> kv in _clients) {
-                    if (kv.Key != strategy && TryAddDisposedClient(kv.Value)) {
+                    if (kv.Key != strategy && TryAddDisposedResource(kv.Value)) {
                         kv.Value.Dispose();
                         if (ReferenceEquals(kv.Value, Client)) {
-                            if (!_handlerOwnedByClient && handler != null && TryAddDisposedClient(handler)) {
+                            if (!_handlerOwnedByClient && handler != null && TryAddDisposedResource(handler)) {
                                 handler.Dispose();
                             }
                             if (_handlerOwnedByClient && handler != null) {
-                                TryAddDisposedClient(handler);
+                                TryAddDisposedResource(handler);
                             }
                             handler = null;
                         }
@@ -370,12 +370,12 @@ namespace DnsClientX {
                 _clients.Clear();
 
                 // dispose the currently assigned client and handler if present
-                if (Client != null && TryAddDisposedClient(Client)) {
+                if (Client != null && TryAddDisposedResource(Client)) {
                     Client.Dispose();
                     if (_handlerOwnedByClient && handler != null) {
-                        TryAddDisposedClient(handler);
+                        TryAddDisposedResource(handler);
                     }
-                    if (!_handlerOwnedByClient && handler != null && TryAddDisposedClient(handler)) {
+                    if (!_handlerOwnedByClient && handler != null && TryAddDisposedResource(handler)) {
                         handler.Dispose();
                     }
                     handler = null;

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -364,7 +364,7 @@ namespace DnsClientX {
                             }
                             handler = null;
                         }
-                        DisposalCount++;
+                        System.Threading.Interlocked.Increment(ref _disposalCount);
                     }
                 }
                 _clients.Clear();
@@ -379,7 +379,7 @@ namespace DnsClientX {
                         handler.Dispose();
                     }
                     handler = null;
-                    DisposalCount++;
+                    System.Threading.Interlocked.Increment(ref _disposalCount);
                 }
 
                 client = CreateOptimizedHttpClient();

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -315,8 +315,12 @@ namespace DnsClientX {
         /// </summary>
         private void ConfigureClient() {
             lock (_lock) {
-                Client?.Dispose();
-                handler?.Dispose();
+                if (Client != null && TryAddDisposedClient(Client)) {
+                    Client.Dispose();
+                }
+                if (handler != null && TryAddDisposedClient(handler)) {
+                    handler.Dispose();
+                }
 
                 Client = CreateOptimizedHttpClient();
                 _clients[EndpointConfiguration.SelectionStrategy] = Client;
@@ -346,7 +350,9 @@ namespace DnsClientX {
                     if (kv.Key != strategy && TryAddDisposedClient(kv.Value)) {
                         kv.Value.Dispose();
                         if (ReferenceEquals(kv.Value, Client)) {
-                            handler?.Dispose();
+                            if (handler != null && TryAddDisposedClient(handler)) {
+                                handler.Dispose();
+                            }
                             handler = null;
                         }
                         System.Threading.Interlocked.Increment(ref DisposalCount);
@@ -357,7 +363,9 @@ namespace DnsClientX {
                 // dispose the currently assigned client and handler if present
                 if (Client != null && TryAddDisposedClient(Client)) {
                     Client.Dispose();
-                    handler?.Dispose();
+                    if (handler != null && TryAddDisposedClient(handler)) {
+                        handler.Dispose();
+                    }
                     handler = null;
                     System.Threading.Interlocked.Increment(ref DisposalCount);
                 }

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -318,13 +318,13 @@ namespace DnsClientX {
         /// </summary>
         private void ConfigureClient() {
             lock (_lock) {
-                if (Client != null && TryAddDisposedResource(Client)) {
+                if (Client != null && TryAddDisposedClient(Client)) {
                     Client.Dispose();
                     if (_handlerOwnedByClient && handler != null) {
-                        TryAddDisposedResource(handler);
+                        TryAddDisposedClient(handler);
                     }
                 }
-                if (!_handlerOwnedByClient && handler != null && TryAddDisposedResource(handler)) {
+                if (!_handlerOwnedByClient && handler != null && TryAddDisposedClient(handler)) {
                     handler.Dispose();
                 }
 
@@ -353,33 +353,33 @@ namespace DnsClientX {
 
                 // dispose any clients created for other strategies
                 foreach (KeyValuePair<DnsSelectionStrategy, HttpClient> kv in _clients) {
-                    if (kv.Key != strategy && TryAddDisposedResource(kv.Value)) {
+                    if (kv.Key != strategy && TryAddDisposedClient(kv.Value)) {
                         kv.Value.Dispose();
                         if (ReferenceEquals(kv.Value, Client)) {
-                            if (!_handlerOwnedByClient && handler != null && TryAddDisposedResource(handler)) {
+                            if (!_handlerOwnedByClient && handler != null && TryAddDisposedClient(handler)) {
                                 handler.Dispose();
                             }
                             if (_handlerOwnedByClient && handler != null) {
-                                TryAddDisposedResource(handler);
+                                TryAddDisposedClient(handler);
                             }
                             handler = null;
                         }
-                        System.Threading.Interlocked.Increment(ref DisposalCount);
+                        DisposalCount++;
                     }
                 }
                 _clients.Clear();
 
                 // dispose the currently assigned client and handler if present
-                if (Client != null && TryAddDisposedResource(Client)) {
+                if (Client != null && TryAddDisposedClient(Client)) {
                     Client.Dispose();
                     if (_handlerOwnedByClient && handler != null) {
-                        TryAddDisposedResource(handler);
+                        TryAddDisposedClient(handler);
                     }
-                    if (!_handlerOwnedByClient && handler != null && TryAddDisposedResource(handler)) {
+                    if (!_handlerOwnedByClient && handler != null && TryAddDisposedClient(handler)) {
                         handler.Dispose();
                     }
                     handler = null;
-                    System.Threading.Interlocked.Increment(ref DisposalCount);
+                    DisposalCount++;
                 }
 
                 client = CreateOptimizedHttpClient();


### PR DESCRIPTION
## Summary
- keep record of disposed handlers
- avoid double-disposing when handler or client disposed
- test disposal of handlers

## Testing
- `dotnet test`
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686e882c2674832e830e5c03dc4b38a8