### PR TITLE
Handle escaped newlines in TXT records

### DIFF
--- a/DnsClientX.Tests/BindFileParserTests.cs
+++ b/DnsClientX.Tests/BindFileParserTests.cs
@@ -43,6 +43,20 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        public void ParseZoneFile_ReplacesEscapedNewlinesInTxtRecords() {
+            string file = Path.GetTempFileName();
+            File.WriteAllLines(file, new[] {
+                "example.com. IN TXT \"line1\\nline2\""
+            });
+
+            var records = BindFileParser.ParseZoneFile(file);
+
+            Assert.Single(records);
+            Assert.Equal("example.com", records[0].Name);
+            Assert.Equal("line1\nline2", records[0].DataRaw);
+        }
+
+        [Fact]
         public void ParseZoneFile_ParsesTtlSuffixes() {
             string file = Path.GetTempFileName();
             File.WriteAllLines(file, new[] {

--- a/DnsClientX/BindFileParser.cs
+++ b/DnsClientX/BindFileParser.cs
@@ -235,6 +235,8 @@ namespace DnsClientX {
                     if (data.Length > 1 && data.EndsWith("\"")) {
                         data = data.Substring(1, data.Length - 2);
                     }
+
+                    data = data.Replace("\\n", "\n");
                 }
 
                 records.Add(new DnsAnswer {


### PR DESCRIPTION
## Summary
- process `\n` escape sequences when parsing TXT records in `BindFileParser`
- test TXT parsing with escaped newline sequences

## Testing
- `dotnet test --no-build --filter BindFileParserTests`

------
https://chatgpt.com/codex/tasks/task_e_686e88448c18832ea3f4b0a489d226df