### PR TITLE
Add cancellation tokens to ResolveFirst callers

### DIFF
--- a/DnsClientX.Examples/DemoResolveFirst.cs
+++ b/DnsClientX.Examples/DemoResolveFirst.cs
@@ -60,7 +60,7 @@ namespace DnsClientX.Examples {
                     foreach (var domain in domains) {
                         foreach (var recordType in recordTypes) {
                             HelpersSpectre.AddLine("ResolveFirst", domain, recordType, endpoint);
-                            var response = await client.ResolveFirst(domain);
+                            var response = await client.ResolveFirst(domain, cancellationToken: CancellationToken.None);
                             response?.DisplayTable();
                         }
                     }

--- a/DnsClientX.Examples/DemoResolveFirst.cs
+++ b/DnsClientX.Examples/DemoResolveFirst.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DnsClientX.Examples {

--- a/DnsClientX.Tests/ResolveFirst.cs
+++ b/DnsClientX.Tests/ResolveFirst.cs
@@ -19,7 +19,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
-            var answer = await Client.ResolveFirst("github.com", DnsRecordType.TXT);
+            var answer = await Client.ResolveFirst("github.com", DnsRecordType.TXT, cancellationToken: CancellationToken.None);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "github.com");
             Assert.True(answer.Value.Type == DnsRecordType.TXT);
@@ -45,7 +45,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
-            var answer = await Client.ResolveFirst("evotec.pl", DnsRecordType.A);
+            var answer = await Client.ResolveFirst("evotec.pl", DnsRecordType.A, cancellationToken: CancellationToken.None);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "evotec.pl");
             Assert.True(answer.Value.Type == DnsRecordType.A);
@@ -70,7 +70,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForTXT_Sync(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
-            var answer = Client.ResolveFirstSync("github.com", DnsRecordType.TXT);
+            var answer = Client.ResolveFirstSync("github.com", DnsRecordType.TXT, cancellationToken: CancellationToken.None);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "github.com");
             Assert.True(answer.Value.Type == DnsRecordType.TXT);
@@ -96,7 +96,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForA_Sync(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
-            var answer = Client.ResolveFirstSync("evotec.pl", DnsRecordType.A);
+            var answer = Client.ResolveFirstSync("evotec.pl", DnsRecordType.A, cancellationToken: CancellationToken.None);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "evotec.pl");
             Assert.True(answer.Value.Type == DnsRecordType.A);

--- a/DnsClientX.Tests/ResolveSync.cs
+++ b/DnsClientX.Tests/ResolveSync.cs
@@ -255,7 +255,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForFirstSyncA(DnsEndpoint endpoint) {
             using var client = new ClientX(endpoint);
-            var answer = client.ResolveFirstSync("evotec.pl", DnsRecordType.A);
+            var answer = client.ResolveFirstSync("evotec.pl", DnsRecordType.A, cancellationToken: CancellationToken.None);
             Assert.True(answer != null);
             Assert.True(answer.Value.Name == "evotec.pl");
             Assert.True(answer.Value.Type == DnsRecordType.A);


### PR DESCRIPTION
## Summary
- pass `CancellationToken.None` to `ClientX.ResolveFirst` and `ResolveFirstSync` calls in tests and demo

## Testing
- `dotnet test` *(fails: Failed:   141, Passed:   393, Skipped:    18)*

------
https://chatgpt.com/codex/tasks/task_e_686e88809d40832eb855dc612a68112c