### PR TITLE
Refactor FindClosingBrace

### DIFF
--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -647,16 +647,19 @@ namespace DnsClientX {
         }
 
         private static int FindClosingBrace(string pattern, int openIndex) {
-            int depth = 0;
-            for (int i = openIndex; i < pattern.Length; i++) {
-                if (pattern[i] == '{') {
+            int depth = pattern[openIndex] == '{' ? 1 : 0;
+            for (int i = openIndex + 1; i < pattern.Length; i++) {
+                char c = pattern[i];
+                if (c == '{') {
                     depth++;
-                } else if (pattern[i] == '}') {
+                } else if (c == '}') {
                     depth--;
-                    if (depth == 0) return i;
+                    if (depth == 0) {
+                        return i;
+                    }
                 }
             }
+
             return -1;
         }
-    }
-}
+    }}


### PR DESCRIPTION
## Summary
- optimize `FindClosingBrace` by scanning with a for-loop

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: DNS tests require network)*
- `dotnet run -c Release --project DnsClientX.Benchmarks/DnsClientX.Benchmarks.csproj --no-build` *(partial run)*

------
https://chatgpt.com/codex/tasks/task_e_686e884f780c832ea74b819c2533dfc0