### PR TITLE
Add configurable MaxConnectionsPerServer

### DIFF
--- a/DnsClientX.Examples/DemoResolve.cs
+++ b/DnsClientX.Examples/DemoResolve.cs
@@ -54,6 +54,7 @@ namespace DnsClientX.Examples {
 
                 // Create a new client for each endpoint
                 using (var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
+                       // Limit the number of simultaneous connections per DNS provider
                        EndpointConfiguration = { MaxConnectionsPerServer = 20 },
                        Debug = false
                    }) {

--- a/DnsClientX.Examples/DemoResolve.cs
+++ b/DnsClientX.Examples/DemoResolve.cs
@@ -53,9 +53,10 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using (var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
-                       // Limit the number of simultaneous connections per DNS provider
-                       EndpointConfiguration = { MaxConnectionsPerServer = 20 },
+                using (var client = new ClientX(
+                           endpoint,
+                           DnsSelectionStrategy.Random,
+                           maxConnectionsPerServer: 20) {
                        Debug = false
                    }) {
                     foreach (var domain in domains) {

--- a/DnsClientX.Examples/DemoResolve.cs
+++ b/DnsClientX.Examples/DemoResolve.cs
@@ -54,6 +54,7 @@ namespace DnsClientX.Examples {
 
                 // Create a new client for each endpoint
                 using (var client = new ClientX(endpoint, DnsSelectionStrategy.Random) {
+                       EndpointConfiguration = { MaxConnectionsPerServer = 20 },
                        Debug = false
                    }) {
                     foreach (var domain in domains) {

--- a/DnsClientX.Examples/DemoResolveParallel.cs
+++ b/DnsClientX.Examples/DemoResolveParallel.cs
@@ -57,6 +57,8 @@ namespace DnsClientX.Examples {
 
                 // Create a new client for each endpoint
                 using (var client = new ClientX(endpoint) {
+                       // Allow multiple outgoing requests per provider
+                       EndpointConfiguration = { MaxConnectionsPerServer = 20 },
                        Debug = false
                    }) {
                     foreach (var domain in domains) {

--- a/DnsClientX.Examples/DemoResolveParallel.cs
+++ b/DnsClientX.Examples/DemoResolveParallel.cs
@@ -56,9 +56,9 @@ namespace DnsClientX.Examples {
                 }
 
                 // Create a new client for each endpoint
-                using (var client = new ClientX(endpoint) {
-                       // Allow multiple outgoing requests per provider
-                       EndpointConfiguration = { MaxConnectionsPerServer = 20 },
+                using (var client = new ClientX(
+                           endpoint,
+                           maxConnectionsPerServer: 20) {
                        Debug = false
                    }) {
                     foreach (var domain in domains) {

--- a/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
+++ b/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
@@ -6,9 +6,9 @@ namespace DnsClientX.Tests {
     public class MaxConnectionsPerServerTests {
         [Fact]
         public void HandlerUsesConfigurationValue() {
-            using var client = new ClientX(DnsEndpoint.Cloudflare);
-            var handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
-            var handler = (HttpClientHandler)handlerField.GetValue(client)!;
+            using ClientX client = new ClientX(DnsEndpoint.Cloudflare);
+            FieldInfo handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            HttpClientHandler handler = (HttpClientHandler)handlerField.GetValue(client)!;
             Assert.Equal(client.EndpointConfiguration.MaxConnectionsPerServer, handler.MaxConnectionsPerServer);
         }
     }

--- a/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
+++ b/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
@@ -6,9 +6,9 @@ namespace DnsClientX.Tests {
     public class MaxConnectionsPerServerTests {
         [Fact]
         public void HandlerUsesConfigurationValue() {
-            using ClientX client = new ClientX(DnsEndpoint.Cloudflare) {
-                EndpointConfiguration = { MaxConnectionsPerServer = 5 }
-            };
+            using ClientX client = new ClientX(
+                DnsEndpoint.Cloudflare,
+                maxConnectionsPerServer: 5);
 
             FieldInfo handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
             HttpClientHandler handler = (HttpClientHandler)handlerField.GetValue(client)!;

--- a/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
+++ b/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
@@ -1,0 +1,15 @@
+using System.Net.Http;
+using System.Reflection;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class MaxConnectionsPerServerTests {
+        [Fact]
+        public void HandlerUsesConfigurationValue() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var handler = (HttpClientHandler)handlerField.GetValue(client)!;
+            Assert.Equal(client.EndpointConfiguration.MaxConnectionsPerServer, handler.MaxConnectionsPerServer);
+        }
+    }
+}

--- a/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
+++ b/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
@@ -6,10 +6,14 @@ namespace DnsClientX.Tests {
     public class MaxConnectionsPerServerTests {
         [Fact]
         public void HandlerUsesConfigurationValue() {
-            using ClientX client = new ClientX(DnsEndpoint.Cloudflare);
+            using ClientX client = new ClientX(DnsEndpoint.Cloudflare) {
+                EndpointConfiguration = { MaxConnectionsPerServer = 5 }
+            };
+
             FieldInfo handlerField = typeof(ClientX).GetField("handler", BindingFlags.NonPublic | BindingFlags.Instance)!;
             HttpClientHandler handler = (HttpClientHandler)handlerField.GetValue(client)!;
-            Assert.Equal(client.EndpointConfiguration.MaxConnectionsPerServer, handler.MaxConnectionsPerServer);
+
+            Assert.Equal(5, handler.MaxConnectionsPerServer);
         }
     }
 }

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -56,6 +56,11 @@ namespace DnsClientX {
         public const int DefaultTimeout = 1000;
 
         /// <summary>
+        /// Default connection limit per server for HTTP requests.
+        /// </summary>
+        public const int DefaultMaxConnectionsPerServer = 10;
+
+        /// <summary>
         /// Gets or sets the HTTP version used when communicating with the DNS provider.
         /// </summary>
         public Version HttpVersion { get; set; } = DefaultHttpVersion;
@@ -88,7 +93,7 @@ namespace DnsClientX {
         /// <summary>
         /// Gets or sets the maximum number of HTTP connections allowed per server.
         /// </summary>
-        public int MaxConnectionsPerServer { get; set; } = 10;
+        public int MaxConnectionsPerServer { get; set; } = DefaultMaxConnectionsPerServer;
 
         /// <summary>
         /// Optional key used to sign outgoing DNS messages.

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -86,6 +86,11 @@ namespace DnsClientX {
         public bool UseTcpFallback { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the maximum number of HTTP connections allowed per server.
+        /// </summary>
+        public int MaxConnectionsPerServer { get; set; } = 10;
+
+        /// <summary>
         /// Optional key used to sign outgoing DNS messages.
         /// </summary>
         public AsymmetricAlgorithm? SigningKey { get; set; }

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -274,7 +274,7 @@ namespace DnsClientX {
             }
 
             // Optimize connection settings for DNS workloads
-            handler.MaxConnectionsPerServer = 10; // Allow multiple connections for parallel requests
+            handler.MaxConnectionsPerServer = EndpointConfiguration.MaxConnectionsPerServer;
             handler.UseCookies = false; // DNS doesn't need cookies
 
             var client = new HttpClient(handler) {

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -150,9 +150,11 @@ namespace DnsClientX {
             bool ignoreCertificateErrors = false,
             bool enableCache = false,
             bool useTcpFallback = true,
-            IWebProxy? webProxy = null) {
+            IWebProxy? webProxy = null,
+            int maxConnectionsPerServer = Configuration.DefaultMaxConnectionsPerServer) {
             EndpointConfiguration = new Configuration(endpoint, dnsSelectionStrategy) {
-                TimeOut = timeOutMilliseconds
+                TimeOut = timeOutMilliseconds,
+                MaxConnectionsPerServer = maxConnectionsPerServer
             };
             if (userAgent != null) {
                 EndpointConfiguration.UserAgent = userAgent;
@@ -188,9 +190,11 @@ namespace DnsClientX {
             bool ignoreCertificateErrors = false,
             bool enableCache = false,
             bool useTcpFallback = true,
-            IWebProxy? webProxy = null) {
+            IWebProxy? webProxy = null,
+            int maxConnectionsPerServer = Configuration.DefaultMaxConnectionsPerServer) {
             EndpointConfiguration = new Configuration(hostname, requestFormat) {
-                TimeOut = timeOutMilliseconds
+                TimeOut = timeOutMilliseconds,
+                MaxConnectionsPerServer = maxConnectionsPerServer
             };
             if (userAgent != null) {
                 EndpointConfiguration.UserAgent = userAgent;
@@ -226,9 +230,11 @@ namespace DnsClientX {
             bool ignoreCertificateErrors = false,
             bool enableCache = false,
             bool useTcpFallback = true,
-            IWebProxy? webProxy = null) {
+            IWebProxy? webProxy = null,
+            int maxConnectionsPerServer = Configuration.DefaultMaxConnectionsPerServer) {
             EndpointConfiguration = new Configuration(baseUri, requestFormat) {
-                TimeOut = timeOutMilliseconds
+                TimeOut = timeOutMilliseconds,
+                MaxConnectionsPerServer = maxConnectionsPerServer
             };
             if (userAgent != null) {
                 EndpointConfiguration.UserAgent = userAgent;


### PR DESCRIPTION
## Summary
- add MaxConnectionsPerServer option in `Configuration`
- honor this option when creating `HttpClientHandler`
- add unit test for the option
- illustrate setting MaxConnectionsPerServer in DemoResolve example

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~MaxConnectionsPerServerTests` *(fails: Cannot access a disposed object)*

------
https://chatgpt.com/codex/tasks/task_e_6870f8509e10832e8b8d0024cc91c207