### PR TITLE
Stream zone transfer records

### DIFF
--- a/DnsClientX/DnsClientX.ZoneTransfer.cs
+++ b/DnsClientX/DnsClientX.ZoneTransfer.cs
@@ -37,69 +37,12 @@ namespace DnsClientX {
                 return await Task.FromCanceled<DnsAnswer[][]>(cancellationToken).ConfigureAwait(false);
             }
 
-            EndpointConfiguration.SelectHostNameStrategy();
-
-            var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize, null, EndpointConfiguration.CheckingDisabled, EndpointConfiguration.SigningKey);
-            var queryBytes = query.SerializeDnsWireFormat();
-
-            async Task<List<byte[]>> Execute() => await SendAxfrOverTcp(queryBytes, EndpointConfiguration.Hostname, EndpointConfiguration.Port, EndpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
-
-            List<byte[]> responses;
-            try {
-                responses = retryOnTransient && maxRetries > 1
-                    ? await RetryAsync(
-                        Execute,
-                        maxRetries,
-                        retryDelayMs,
-                        EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover ? EndpointConfiguration.AdvanceToNextHostname : null).ConfigureAwait(false)
-                    : await Execute().ConfigureAwait(false);
-            } catch (DnsClientException) {
-                throw;
-            } catch (OperationCanceledException) {
-                throw;
-            } catch (Exception ex) {
-                throw new DnsClientException($"Zone transfer failed: {ex.Message}");
+            var results = new List<DnsAnswer[]>();
+            await foreach (var rrset in ZoneTransferStreamAsync(zone, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false)) {
+                results.Add(rrset);
             }
 
-            var records = new List<DnsAnswer>();
-            int soaCount = 0;
-            foreach (var buffer in responses) {
-                var response = await DnsWire.DeserializeDnsWireFormat(null, Debug, buffer).ConfigureAwait(false);
-                response.AddServerDetails(EndpointConfiguration);
-                if (response.Status != DnsResponseCode.NoError) {
-                    throw new DnsClientException($"Zone transfer failed with {response.Status}", response);
-                }
-                if (response.Answers != null) {
-                    records.AddRange(response.Answers);
-                    soaCount += response.Answers.Count(a => a.Type == DnsRecordType.SOA);
-                    if (soaCount >= 2) break;
-                }
-            }
-
-            if (soaCount == 0) {
-                return Array.Empty<DnsAnswer[]>();
-            }
-
-            if (soaCount < 2) {
-                throw new DnsClientException("Zone transfer incomplete: closing SOA record missing.");
-            }
-
-            var lastResponse = await DnsWire.DeserializeDnsWireFormat(null, Debug, responses[responses.Count - 1]).ConfigureAwait(false);
-            lastResponse.AddServerDetails(EndpointConfiguration);
-            if (lastResponse.Answers == null || lastResponse.Answers.Length == 0 || lastResponse.Answers[lastResponse.Answers.Length - 1].Type != DnsRecordType.SOA) {
-                throw new DnsClientException("Zone transfer incomplete: closing SOA record missing.");
-            }
-
-            var recordSets = new List<List<DnsAnswer>>();
-            foreach (var rec in records) {
-                if (recordSets.Count == 0 || recordSets[recordSets.Count - 1][0].Name != rec.Name || recordSets[recordSets.Count - 1][0].Type != rec.Type) {
-                    recordSets.Add(new List<DnsAnswer> { rec });
-                } else {
-                    recordSets[recordSets.Count - 1].Add(rec);
-                }
-            }
-
-            return recordSets.Select(r => r.ToArray()).ToArray();
+            return results.ToArray();
         }
 
         /// <summary>
@@ -135,13 +78,63 @@ namespace DnsClientX {
             int maxRetries = 3,
             int retryDelayMs = 100,
             [EnumeratorCancellation] CancellationToken cancellationToken = default) {
-            var recordSets = await ZoneTransferAsync(zone, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).ConfigureAwait(false);
-            foreach (var rrset in recordSets) {
-                yield return rrset;
+            if (string.IsNullOrEmpty(zone)) {
+                throw new ArgumentNullException(nameof(zone));
+            }
+
+            EndpointConfiguration.SelectHostNameStrategy();
+
+            var query = new DnsMessage(zone, DnsRecordType.AXFR, requestDnsSec: false, enableEdns: false, EndpointConfiguration.UdpBufferSize, null, EndpointConfiguration.CheckingDisabled, EndpointConfiguration.SigningKey);
+            var queryBytes = query.SerializeDnsWireFormat();
+
+            for (int attempt = 0; attempt < maxRetries; attempt++) {
+                cancellationToken.ThrowIfCancellationRequested();
+                await using var enumerator = SendAxfrOverTcp(queryBytes, EndpointConfiguration.Hostname!, EndpointConfiguration.Port, EndpointConfiguration.TimeOut, Debug, EndpointConfiguration, cancellationToken).GetAsyncEnumerator(cancellationToken);
+                Exception? iterationException = null;
+
+                while (true) {
+                    bool moved;
+                    try {
+                        moved = await enumerator.MoveNextAsync();
+                    } catch (Exception ex) {
+                        iterationException = ex;
+                        break;
+                    }
+
+                    if (!moved) {
+                        iterationException = null;
+                        break;
+                    }
+
+                    yield return enumerator.Current;
+                }
+
+                if (iterationException == null) {
+                    yield break;
+                }
+
+                if (!(retryOnTransient && attempt < maxRetries - 1 && IsTransient(iterationException))) {
+                    throw iterationException;
+                }
+
+                if (EndpointConfiguration.SelectionStrategy == DnsSelectionStrategy.Failover) {
+                    EndpointConfiguration.AdvanceToNextHostname();
+                }
+
+                int exponentialDelay = retryDelayMs <= 0 ? 0 : (int)Math.Min((long)retryDelayMs << attempt, int.MaxValue);
+                int jitter = GetJitter(retryDelayMs);
+                await Task.Delay(exponentialDelay + jitter, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private static async Task<List<byte[]>> SendAxfrOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
+        private static async IAsyncEnumerable<DnsAnswer[]> SendAxfrOverTcp(
+            byte[] query,
+            string dnsServer,
+            int port,
+            int timeoutMilliseconds,
+            bool debug,
+            Configuration configuration,
+            [EnumeratorCancellation] CancellationToken cancellationToken) {
             TcpClient tcpClient = new();
             try {
                 await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
@@ -166,26 +159,84 @@ namespace DnsClientX {
                     }
                     await writeTask.ConfigureAwait(false);
 
-                    var responses = new List<byte[]>();
                     var lenBuf = new byte[2];
+                    var current = new List<DnsAnswer>();
+                    int soaCount = 0;
+                    bool sawClosing = false;
+                    bool extraAfterClosing = false;
+                    bool received = false;
+                    DnsAnswer? lastRecord = null;
+
                     while (true) {
                         try {
                             await ReadExactWithTimeoutAsync(stream, lenBuf, 0, 2, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
-                        } catch (EndOfStreamException) when (responses.Count == 0) {
+                        } catch (EndOfStreamException) when (!received) {
                             throw new DnsClientException("Connection closed during zone transfer.");
                         } catch (EndOfStreamException) {
                             break;
                         }
+
+                        received = true;
                         if (BitConverter.IsLittleEndian) {
                             Array.Reverse(lenBuf);
                         }
                         int length = BitConverter.ToUInt16(lenBuf, 0);
                         var responseBuffer = new byte[length];
                         await ReadExactWithTimeoutAsync(stream, responseBuffer, 0, length, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
-                        responses.Add(responseBuffer);
+
+                        var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
+                        response.AddServerDetails(configuration);
+                        if (response.Status != DnsResponseCode.NoError) {
+                            throw new DnsClientException($"Zone transfer failed with {response.Status}", response);
+                        }
+
+                        var answers = response.Answers;
+                        if (sawClosing) {
+                            if (answers != null && answers.Length > 0) {
+                                throw new DnsClientException("Zone transfer incomplete: closing SOA record not last.");
+                            }
+                            extraAfterClosing = true;
+                            continue;
+                        }
+
+                        if (answers == null) {
+                            continue;
+                        }
+
+                        foreach (var rec in answers) {
+                            if (soaCount >= 2) {
+                                throw new DnsClientException("Zone transfer incomplete: closing SOA record not last.");
+                            }
+
+                            if (current.Count == 0 || (current[0].Name == rec.Name && current[0].Type == rec.Type)) {
+                                current.Add(rec);
+                            } else {
+                                yield return current.ToArray();
+                                current.Clear();
+                                current.Add(rec);
+                            }
+
+                            lastRecord = rec;
+                            if (rec.Type == DnsRecordType.SOA) {
+                                soaCount++;
+                                if (soaCount == 2) {
+                                    sawClosing = true;
+                                }
+                            }
+                        }
                     }
 
-                    return responses;
+                    if (current.Count > 0) {
+                        yield return current.ToArray();
+                    }
+
+                    if (soaCount == 0) {
+                        yield break;
+                    }
+
+                    if (soaCount < 2 || extraAfterClosing || lastRecord == null || lastRecord.Value.Type != DnsRecordType.SOA) {
+                        throw new DnsClientException("Zone transfer incomplete: closing SOA record missing.");
+                    }
                 } finally {
                     stream.Close();
                     stream.Dispose();


### PR DESCRIPTION
## Summary
- refactor SendAxfrOverTcp to stream RRsets as they are read
- return streamed results directly from ZoneTransferStreamAsync
- update ZoneTransferAsync to gather records from ZoneTransferStreamAsync
- adjust SendAxfrOverTcp disposal test for new API

## Testing
- `dotnet test --no-build --filter ZoneTransfer` *(fails: System.Net.Sockets.SocketException)*

------
https://chatgpt.com/codex/tasks/task_e_6870f8427358832eab9445ae5d533fef