### PR TITLE
Add ServerAddress to DnsResponse

### DIFF
--- a/DnsClientX.Tests/DnsResponseTests.cs
+++ b/DnsClientX.Tests/DnsResponseTests.cs
@@ -18,6 +18,7 @@ namespace DnsClientX.Tests {
             Assert.Equal(config.BaseUri, response.Questions[0].BaseUri);
             Assert.Equal(config.RequestFormat, response.Questions[0].RequestFormat);
             Assert.Equal(config.Port, response.Questions[0].Port);
+            Assert.Equal(config.Hostname, response.ServerAddress);
             Assert.Single(response.AnswersMinimal);
             Assert.Equal(config.Port, response.AnswersMinimal[0].Port);
         }
@@ -35,6 +36,7 @@ namespace DnsClientX.Tests {
             Assert.Null(response.Questions[0].BaseUri);
             Assert.Equal(config.RequestFormat, response.Questions[0].RequestFormat);
             Assert.Equal(config.Port, response.Questions[0].Port);
+            Assert.Equal(config.Hostname, response.ServerAddress);
         }
 
         [Fact]
@@ -50,6 +52,7 @@ namespace DnsClientX.Tests {
             Assert.Null(response.Questions[0].BaseUri);
             Assert.Equal(config.RequestFormat, response.Questions[0].RequestFormat);
             Assert.Equal(config.Port, response.Questions[0].Port);
+            Assert.Equal(config.Hostname, response.ServerAddress);
         }
 
         [Fact]

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -69,6 +69,12 @@ namespace DnsClientX {
         private DnsAnswerMinimal[] _answersMinimal;
 
         /// <summary>
+        /// Address of the DNS server that returned this response.
+        /// </summary>
+        [JsonIgnore]
+        public string? ServerAddress { get; private set; }
+
+        /// <summary>
         /// Gets the answers in their minimal form.
         /// </summary>
         [JsonIgnore]
@@ -128,6 +134,8 @@ namespace DnsClientX {
                 Questions[i].RequestFormat = configuration.RequestFormat;
                 Questions[i].Port = configuration.Port;
             }
+
+            ServerAddress = configuration.Hostname;
 
             if (Answers != null) {
                 _answersMinimal = Answers.Select(answer => new DnsAnswerMinimal {


### PR DESCRIPTION
## Summary
- track DNS server address in `DnsResponse`
- verify the value in tests

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: HttpConnectionPool.ConnectAsync)*

------
https://chatgpt.com/codex/tasks/task_e_687170a98898832ea109b27e5bcde932