### PR TITLE
Add latency measurement helper

### DIFF
--- a/DnsClientX.Examples/DemoMeasureLatency.cs
+++ b/DnsClientX.Examples/DemoMeasureLatency.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    internal class DemoMeasureLatency {
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var latency = await client.MeasureLatencyAsync();
+            Console.WriteLine($"Latency: {latency.TotalMilliseconds} ms");
+        }
+    }
+}

--- a/DnsClientX.Tests/MeasureLatencyTests.cs
+++ b/DnsClientX.Tests/MeasureLatencyTests.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class MeasureLatencyTests {
+        [Fact]
+        public async Task MeasureLatency_ReturnsPositiveTime() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var latency = await client.MeasureLatencyAsync();
+            Assert.True(latency > TimeSpan.Zero);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.MeasureLatency.cs
+++ b/DnsClientX/DnsClientX.MeasureLatency.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Partial <see cref="ClientX"/> class providing latency measurement helper.
+    /// </summary>
+    public partial class ClientX {
+        /// <summary>
+        /// Sends a simple DNS query and returns the round-trip time.
+        /// </summary>
+        /// <param name="name">Domain name to query. Defaults to <c>example.com</c>.</param>
+        /// <param name="type">DNS record type to query. Defaults to <see cref="DnsRecordType.A"/>.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>Latency measured for the DNS query.</returns>
+        public async Task<TimeSpan> MeasureLatencyAsync(string name = "example.com", DnsRecordType type = DnsRecordType.A, CancellationToken cancellationToken = default) {
+            var sw = Stopwatch.StartNew();
+            await Resolve(name, type, cancellationToken: cancellationToken).ConfigureAwait(false);
+            sw.Stop();
+            return sw.Elapsed;
+        }
+
+        /// <summary>
+        /// Sends a simple DNS query and returns the round-trip time. Synchronous version.
+        /// </summary>
+        /// <param name="name">Domain name to query. Defaults to <c>example.com</c>.</param>
+        /// <param name="type">DNS record type to query. Defaults to <see cref="DnsRecordType.A"/>.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>Latency measured for the DNS query.</returns>
+        public TimeSpan MeasureLatency(string name = "example.com", DnsRecordType type = DnsRecordType.A, CancellationToken cancellationToken = default) {
+            return MeasureLatencyAsync(name, type, cancellationToken).RunSync(cancellationToken);
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.MeasureLatency.cs
+++ b/DnsClientX/DnsClientX.MeasureLatency.cs
@@ -17,8 +17,11 @@ namespace DnsClientX {
         /// <returns>Latency measured for the DNS query.</returns>
         public async Task<TimeSpan> MeasureLatencyAsync(string name = "example.com", DnsRecordType type = DnsRecordType.A, CancellationToken cancellationToken = default) {
             var sw = Stopwatch.StartNew();
-            await Resolve(name, type, cancellationToken: cancellationToken).ConfigureAwait(false);
-            sw.Stop();
+            try {
+                await Resolve(name, type, retryOnTransient: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+            } finally {
+                sw.Stop();
+            }
             return sw.Elapsed;
         }
 


### PR DESCRIPTION
## Summary
- add ClientX.MeasureLatency to measure DNS query round trip time
- provide example usage
- add regression test for the helper

## Testing
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6871719a4c44832eb95bebea30141a2d