### PR TITLE
Add gRPC transport

### DIFF
--- a/DnsClientX.Examples/DemoResolveGrpc.cs
+++ b/DnsClientX.Examples/DemoResolveGrpc.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Example illustrating DNS resolution over gRPC transport.
+    /// </summary>
+    internal static class DemoResolveGrpc {
+        public static async Task Example() {
+            using var client = new ClientX("localhost", DnsRequestFormat.DnsOverGrpc) {
+                EndpointConfiguration = { Port = 50051 }
+            };
+
+            HelpersSpectre.AddLine("Resolve", "example.com", DnsRecordType.A, "localhost", DnsRequestFormat.DnsOverGrpc);
+            var response = await client.Resolve("example.com", DnsRecordType.A);
+            response.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Tests/CliIntegrationTests.cs
+++ b/DnsClientX.Tests/CliIntegrationTests.cs
@@ -30,6 +30,7 @@ namespace DnsClientX.Tests {
             int exitCode = await task;
             Assert.Equal(0, exitCode);
             Assert.Equal(1, ClientX.DisposalCount);
+            ClientX.DisposalCount = 0;
         }
 
         [Fact]

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -25,13 +25,13 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="System.Net.Http" Version="4.3.4"
-            Condition="'$(TargetFramework)' == 'net472'" />
-    </ItemGroup>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.4"
+        Condition="'$(TargetFramework)' == 'net472'" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\DnsClientX\DnsClientX.csproj" />

--- a/DnsClientX.Tests/DnsWireResolveGrpcTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveGrpcTests.cs
@@ -1,0 +1,48 @@
+#if NET8_0_OR_GREATER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsWireResolveGrpcTests {
+        [Fact]
+        public async Task ResolveWireFormatGrpc_ReturnsServerFailure_OnException() {
+            var prevFactory = DnsWireResolveGrpc.ClientFactory;
+            try {
+                DnsWireResolveGrpc.ClientFactory = _ => throw new InvalidOperationException("boom");
+                var config = new Configuration("dummy", DnsRequestFormat.DnsOverGrpc);
+                var response = await DnsWireResolveGrpc.ResolveWireFormatGrpc("dummy", 443, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None);
+                Assert.Equal(DnsResponseCode.ServerFailure, response.Status);
+                Assert.Contains("boom", response.Error);
+            } finally {
+                DnsWireResolveGrpc.ClientFactory = prevFactory;
+            }
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatGrpc_UsesProvidedCallFunc() {
+            var prevClient = DnsWireResolveGrpc.ClientFactory;
+            var prevSend = DnsWireResolveGrpc.SendAsync;
+            try {
+                byte[]? captured = null;
+                DnsWireResolveGrpc.ClientFactory = _ => new HttpClient();
+                DnsWireResolveGrpc.SendAsync = (_, request, _) => {
+                    captured = request.Content?.ReadAsByteArrayAsync().Result;
+                    var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK) {
+                        Content = new ByteArrayContent(new byte[] { 0,0,0,0,12,0x00,0x01,0x81,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 })
+                    };
+                    return Task.FromResult(response);
+                };
+                var config = new Configuration("dummy", DnsRequestFormat.DnsOverGrpc);
+                var response = await DnsWireResolveGrpc.ResolveWireFormatGrpc("dummy", 443, "example.com", DnsRecordType.A, false, false, false, config, CancellationToken.None);
+                Assert.Equal(DnsResponseCode.NoError, response.Status);
+                Assert.NotNull(captured);
+            } finally {
+                DnsWireResolveGrpc.ClientFactory = prevClient;
+                DnsWireResolveGrpc.SendAsync = prevSend;
+            }
+        }
+    }
+}
+#endif

--- a/DnsClientX/Definitions/DnsRequestFormat.cs
+++ b/DnsClientX/Definitions/DnsRequestFormat.cs
@@ -63,6 +63,10 @@ namespace DnsClientX {
         /// </summary>
         ObliviousDnsOverHttps,
         /// <summary>
+        /// DNS over gRPC using wire format.
+        /// </summary>
+        DnsOverGrpc,
+        /// <summary>
         /// DNS over UDP multicast (mDNS on port 5353).
         /// </summary>
         Multicast,

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -109,6 +109,12 @@ namespace DnsClientX {
 #else
                     throw new DnsClientException("DNS over HTTP/3 is not supported on this platform.");
 #endif
+                } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverGrpc) {
+#if NET8_0_OR_GREATER
+                    response = await DnsWireResolveGrpc.ResolveWireFormatGrpc(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, cancellationToken).ConfigureAwait(false);
+#else
+                    throw new DnsClientException("DNS over gRPC is not supported on this platform.");
+#endif
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverTLS) {
                     response = await DnsWireResolveDot.ResolveWireFormatDoT(EndpointConfiguration.Hostname, EndpointConfiguration.Port, name, type, requestDnsSec, validateDnsSec, Debug, EndpointConfiguration, IgnoreCertificateErrors, cancellationToken).ConfigureAwait(false);
                 } else if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverQuic) {

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -54,11 +54,12 @@
         <Content Include="DnsClientX.ico" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    </ItemGroup>
+  </ItemGroup>
+
 
     <ItemGroup Condition="'$(TargetFramework)'=='net472' OR '$(TargetFramework)'=='net48'">
         <Reference Include="System.Net.Http" />

--- a/DnsClientX/ProtocolDnsGrpc/DnsWireResolveGrpc.cs
+++ b/DnsClientX/ProtocolDnsGrpc/DnsWireResolveGrpc.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Helper methods for resolving DNS queries over gRPC transport.
+    /// </summary>
+    internal static class DnsWireResolveGrpc {
+        /// <summary>Factory for creating HTTP clients used for gRPC calls. Can be overridden in tests.</summary>
+        internal static Func<Uri, HttpClient> ClientFactory { get; set; } = uri => new HttpClient {
+            BaseAddress = uri,
+            DefaultRequestVersion = HttpVersion.Version20,
+            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
+        };
+        /// <summary>Delegate used to send the HTTP request. Can be overridden in tests.</summary>
+        internal static Func<HttpClient, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> SendAsync { get; set; } =
+            (client, request, token) => client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
+
+        /// <summary>
+        /// Executes a DNS-over-gRPC query and deserializes the response.
+        /// </summary>
+        internal static async Task<DnsResponse> ResolveWireFormatGrpc(string dnsServer, int port, string name, DnsRecordType type,
+            bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
+
+            var edns = endpointConfiguration.EdnsOptions;
+            bool enableEdns = endpointConfiguration.EnableEdns;
+            int udpSize = endpointConfiguration.UdpBufferSize;
+            string? subnet = endpointConfiguration.Subnet;
+            if (edns != null) {
+                enableEdns = edns.EnableEdns;
+                udpSize = edns.UdpBufferSize;
+                subnet = edns.Subnet;
+            }
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var queryBytes = query.SerializeDnsWireFormat();
+
+            if (debug) {
+                Settings.Logger.WriteDebug($"Query Name: {name} type: {type}");
+                Settings.Logger.WriteDebug($"Sending query: {BitConverter.ToString(queryBytes)}");
+            }
+
+            Uri uri = new($"https://{dnsServer}:{port}");
+            try {
+                using var client = ClientFactory(uri);
+                using var request = new HttpRequestMessage(HttpMethod.Post, "/DnsResolver/QueryDns") {
+                    Version = HttpVersion.Version20,
+                    VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
+                    Content = new ByteArrayContent(CreateGrpcPayload(queryBytes))
+                };
+                request.Headers.Add("TE", "trailers");
+                request.Content!.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/grpc");
+                using var responseMsg = await SendAsync(client, request, cancellationToken).ConfigureAwait(false);
+                byte[] responseBytes = await responseMsg.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+                var payload = ParseGrpcPayload(responseBytes);
+                var response = await DnsWire.DeserializeDnsWireFormat(null, debug, payload).ConfigureAwait(false);
+                response.AddServerDetails(endpointConfiguration);
+                return response;
+            } catch (Exception ex) {
+                var response = new DnsResponse {
+                    Questions = [ new DnsQuestion { Name = name, RequestFormat = DnsRequestFormat.DnsOverGrpc, Type = type, OriginalName = name } ],
+                    Status = DnsResponseCode.ServerFailure
+                };
+                response.AddServerDetails(endpointConfiguration);
+                response.Error = $"Failed to query type {type} of \"{name}\" => {ex.Message}";
+                return response;
+            }
+        }
+
+        private static byte[] CreateGrpcPayload(byte[] data) {
+            var payload = new byte[data.Length + 5];
+            payload[0] = 0; // uncompressed
+            payload[1] = (byte)((data.Length >> 24) & 0xFF);
+            payload[2] = (byte)((data.Length >> 16) & 0xFF);
+            payload[3] = (byte)((data.Length >> 8) & 0xFF);
+            payload[4] = (byte)(data.Length & 0xFF);
+            Buffer.BlockCopy(data, 0, payload, 5, data.Length);
+            return payload;
+        }
+
+        private static byte[] ParseGrpcPayload(byte[] responseBytes) {
+            if (responseBytes.Length < 5) {
+                return Array.Empty<byte>();
+            }
+            int len = (responseBytes[1] << 24) | (responseBytes[2] << 16) | (responseBytes[3] << 8) | responseBytes[4];
+            if (len <= 0 || responseBytes.Length - 5 < len) {
+                len = responseBytes.Length - 5;
+            }
+            var payload = new byte[len];
+            Buffer.BlockCopy(responseBytes, 5, payload, 0, len);
+            return payload;
+        }
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- add gRPC resolver implementation
- support new `DnsOverGrpc` request format
- example usage via `DemoResolveGrpc`
- include unit tests for gRPC resolver
- remove dependency on Grpc.Net.Client and implement HTTP/2 logic manually

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687170854ecc832e810ad3238a11598d