### PR TITLE
Introduce ZoneTransferResult for zone transfer operations

### DIFF
--- a/DnsClientX.Examples/DemoZoneTransfer.cs
+++ b/DnsClientX.Examples/DemoZoneTransfer.cs
@@ -13,7 +13,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = 5353 } };
             var records = await client.ZoneTransferAsync("example.com");
             foreach (var rrset in records) {
-                Console.WriteLine(string.Join(", ", rrset.Records));
+                Console.WriteLine($"Chunk {rrset.Index} (opening: {rrset.IsOpening}, closing: {rrset.IsClosing}): {string.Join(", ", rrset.Records)}");
             }
         }
     }

--- a/DnsClientX.Examples/DemoZoneTransfer.cs
+++ b/DnsClientX.Examples/DemoZoneTransfer.cs
@@ -13,7 +13,7 @@ namespace DnsClientX.Examples {
             using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = 5353 } };
             var records = await client.ZoneTransferAsync("example.com");
             foreach (var rrset in records) {
-                Console.WriteLine(string.Join(", ", rrset));
+                Console.WriteLine(string.Join(", ", rrset.Records));
             }
         }
     }

--- a/DnsClientX.Examples/DemoZoneTransferStream.cs
+++ b/DnsClientX.Examples/DemoZoneTransferStream.cs
@@ -12,7 +12,7 @@ namespace DnsClientX.Examples {
         public static async Task Example() {
             using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = 5353 } };
             await foreach (var rrset in client.ZoneTransferStreamAsync("example.com")) {
-                Console.WriteLine(string.Join(", ", rrset));
+                Console.WriteLine(string.Join(", ", rrset.Records));
             }
         }
     }

--- a/DnsClientX.Examples/DemoZoneTransferStream.cs
+++ b/DnsClientX.Examples/DemoZoneTransferStream.cs
@@ -12,7 +12,7 @@ namespace DnsClientX.Examples {
         public static async Task Example() {
             using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = 5353 } };
             await foreach (var rrset in client.ZoneTransferStreamAsync("example.com")) {
-                Console.WriteLine(string.Join(", ", rrset.Records));
+                Console.WriteLine($"Chunk {rrset.Index} (opening: {rrset.IsOpening}, closing: {rrset.IsClosing}): {string.Join(", ", rrset.Records)}");
             }
         }
     }

--- a/DnsClientX.Tests/ZoneTransferDisposalTests.cs
+++ b/DnsClientX.Tests/ZoneTransferDisposalTests.cs
@@ -22,7 +22,7 @@ namespace DnsClientX.Tests {
 
             using var cts = new CancellationTokenSource(500);
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port };
-            var enumerable = (IAsyncEnumerable<DnsAnswer[]>)method.Invoke(null, new object[] { new byte[] { 0, 0 }, "127.0.0.1", port, 200, false, config, cts.Token })!;
+            var enumerable = (IAsyncEnumerable<ZoneTransferResult>)method.Invoke(null, new object[] { new byte[] { 0, 0 }, "127.0.0.1", port, 200, false, config, cts.Token })!;
             var callTask = Task.Run(async () => {
                 await foreach (var _ in enumerable) { }
             });

--- a/DnsClientX.Tests/ZoneTransferTests.cs
+++ b/DnsClientX.Tests/ZoneTransferTests.cs
@@ -144,9 +144,12 @@ namespace DnsClientX.Tests {
             await server.Task;
 
             Assert.Equal(3, recordSets.Length);
-            Assert.Equal(DnsRecordType.SOA, recordSets[0][0].Type);
-            Assert.Equal(DnsRecordType.A, recordSets[1][0].Type);
-            Assert.Equal(DnsRecordType.SOA, recordSets[2][0].Type);
+            Assert.True(recordSets[0].IsOpening);
+            Assert.Equal(DnsRecordType.SOA, recordSets[0].Records[0].Type);
+            Assert.False(recordSets[1].IsOpening);
+            Assert.Equal(DnsRecordType.A, recordSets[1].Records[0].Type);
+            Assert.True(recordSets[2].IsClosing);
+            Assert.Equal(DnsRecordType.SOA, recordSets[2].Records[0].Type);
         }
 
         [Fact]
@@ -367,16 +370,18 @@ namespace DnsClientX.Tests {
             var server = RunAxfrServerAsync(new[] { m1, m2, m3 }, cts.Token);
 
             using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP) { EndpointConfiguration = { Port = server.Port } };
-            var results = new System.Collections.Generic.List<DnsAnswer[]>();
+            var results = new System.Collections.Generic.List<ZoneTransferResult>();
             await foreach (var rrset in client.ZoneTransferStreamAsync("example.com")) {
                 results.Add(rrset);
             }
             await server.Task;
 
             Assert.Equal(3, results.Count);
-            Assert.Equal(DnsRecordType.SOA, results[0][0].Type);
-            Assert.Equal(DnsRecordType.A, results[1][0].Type);
-            Assert.Equal(DnsRecordType.SOA, results[2][0].Type);
+            Assert.True(results[0].IsOpening);
+            Assert.Equal(DnsRecordType.SOA, results[0].Records[0].Type);
+            Assert.Equal(DnsRecordType.A, results[1].Records[0].Type);
+            Assert.True(results[2].IsClosing);
+            Assert.Equal(DnsRecordType.SOA, results[2].Records[0].Type);
         }
 
         [Fact]

--- a/DnsClientX/ZoneTransferResult.cs
+++ b/DnsClientX/ZoneTransferResult.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Represents a chunk of records returned during a zone transfer.
+    /// </summary>
+    public readonly struct ZoneTransferResult {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ZoneTransferResult"/> struct.
+        /// </summary>
+        public ZoneTransferResult(DnsAnswer[] records, bool isOpening, bool isClosing, int index) {
+            Records = records;
+            IsOpening = isOpening;
+            IsClosing = isClosing;
+            Index = index;
+        }
+
+        /// <summary>Records contained in this chunk.</summary>
+        public DnsAnswer[] Records { get; }
+
+        /// <summary>True if the chunk contains the opening SOA record.</summary>
+        public bool IsOpening { get; }
+
+        /// <summary>True if the chunk contains the closing SOA record.</summary>
+        public bool IsClosing { get; }
+
+        /// <summary>Zero-based sequence number of this chunk.</summary>
+        public int Index { get; }
+
+        /// <summary>
+        /// Gets the SOA record when <see cref="IsOpening"/> or <see cref="IsClosing"/> is true; otherwise, <c>null</c>.
+        /// </summary>
+        public DnsAnswer? SoaRecord => (IsOpening || IsClosing) && Records.Length > 0 ? Records[0] : null;
+    }
+}

--- a/DnsClientX/ZoneTransferResult.cs
+++ b/DnsClientX/ZoneTransferResult.cs
@@ -4,7 +4,7 @@ namespace DnsClientX {
     /// <summary>
     /// Represents a chunk of records returned during a zone transfer.
     /// </summary>
-    public readonly struct ZoneTransferResult {
+    public readonly record struct ZoneTransferResult {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZoneTransferResult"/> struct.
         /// </summary>


### PR DESCRIPTION
## Summary
- return structured ZoneTransferResult objects from zone transfer APIs
- add ZoneTransferResult struct
- adjust examples and tests

## Testing
- `dotnet test --verbosity normal` *(fails: The argument ... invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687171540f0c832eaf3d40f5da2a995d