### PR TITLE
Implement ClientXBuilder fluent configuration

### DIFF
--- a/DnsClientX.Examples/DemoBuilder.cs
+++ b/DnsClientX.Examples/DemoBuilder.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    internal class DemoBuilder {
+        public static async Task Example() {
+            using var client = new ClientXBuilder()
+                .WithHostname("1.1.1.1", DnsRequestFormat.DnsOverHttps)
+                .WithSelectionStrategy(DnsSelectionStrategy.First)
+                .WithTimeout(1500)
+                .WithUserAgent("Example/1.0")
+                .Build();
+
+            var response = await client.Resolve("example.com", DnsRecordType.A);
+            response?.DisplayTable();
+        }
+    }
+}

--- a/DnsClientX.Tests/ClientXBuilderTests.cs
+++ b/DnsClientX.Tests/ClientXBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Reflection;
 using System.Collections.Generic;
@@ -69,6 +70,38 @@ namespace DnsClientX.Tests {
         [Fact]
         public void WithEndpointCustom_ShouldThrowImmediately() {
             Assert.Throws<ArgumentException>(() => new ClientXBuilder().WithEndpoint(DnsEndpoint.Custom));
+        }
+
+        [Fact]
+        public void BuildShouldApplyAdvancedSettings() {
+            var version = new Version(2, 0);
+
+            using var client = new ClientXBuilder()
+                .WithEndpoint(DnsEndpoint.Google)
+                .WithSelectionStrategy(DnsSelectionStrategy.Random)
+                .WithUserAgent("UnitTest")
+                .WithHttpVersion(version)
+                .WithIgnoreCertificateErrors()
+                .WithEnableCache()
+                .WithUseTcpFallback(false)
+                .Build();
+
+            Assert.Equal(DnsSelectionStrategy.Random, client.EndpointConfiguration.SelectionStrategy);
+            Assert.Equal("UnitTest", client.EndpointConfiguration.UserAgent);
+            Assert.Equal(version, client.EndpointConfiguration.HttpVersion);
+            Assert.True(client.IgnoreCertificateErrors);
+            Assert.True(client.CacheEnabled);
+            Assert.False(client.EndpointConfiguration.UseTcpFallback);
+        }
+
+        [Fact]
+        public void BuildWithHostname_ShouldConfigureCustomEndpoint() {
+            using var client = new ClientXBuilder()
+                .WithHostname("1.1.1.1", DnsRequestFormat.DnsOverHttps)
+                .Build();
+
+            Assert.Equal("1.1.1.1", client.EndpointConfiguration.Hostname);
+            Assert.Equal(DnsRequestFormat.DnsOverHttps, client.EndpointConfiguration.RequestFormat);
         }
     }
 }

--- a/DnsClientX/ClientXBuilder.cs
+++ b/DnsClientX/ClientXBuilder.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Net;
 using System.Collections.Generic;
+using System.Net;
 using System.Reflection;
 using System.Security.Cryptography;
 
@@ -155,6 +155,7 @@ namespace DnsClientX {
             } else {
                 client = new ClientX(_endpoint, _strategy, _timeout, _userAgent, _httpVersion, _ignoreCertificateErrors, _enableCache, _useTcpFallback, _proxy);
             }
+            client.EndpointConfiguration.SelectHostNameStrategy();
             if (_ednsOptions != null) {
                 client.EndpointConfiguration.EdnsOptions = _ednsOptions;
             }

--- a/DnsClientX/ClientXBuilder.cs
+++ b/DnsClientX/ClientXBuilder.cs
@@ -14,15 +14,24 @@ namespace DnsClientX {
         private IWebProxy? _proxy;
         private EdnsOptions? _ednsOptions;
         private AsymmetricAlgorithm? _signingKey;
+        private DnsSelectionStrategy _strategy = DnsSelectionStrategy.First;
+        private string? _userAgent;
+        private Version? _httpVersion;
+        private bool _ignoreCertificateErrors;
+        private bool _enableCache;
+        private bool _useTcpFallback = true;
+        private string? _hostname;
+        private Uri? _baseUri;
+        private DnsRequestFormat? _requestFormat;
 
         /// <summary>
         /// Sets the DNS endpoint to use.
         /// </summary>
         /// <param name="endpoint">Predefined DNS endpoint.</param>
         public ClientXBuilder WithEndpoint(DnsEndpoint endpoint) {
-            if (endpoint == DnsEndpoint.Custom) {
+            if (endpoint == DnsEndpoint.Custom && _hostname == null && _baseUri == null) {
                 throw new ArgumentException(
-                    "EndpointConfiguration.Hostname must be set before selecting a custom endpoint.",
+                    "EndpointConfiguration.Hostname or BaseUri must be set before selecting a custom endpoint.",
                     nameof(endpoint));
             }
 
@@ -49,6 +58,74 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Sets the DNS server selection strategy.
+        /// </summary>
+        public ClientXBuilder WithSelectionStrategy(DnsSelectionStrategy strategy) {
+            _strategy = strategy;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the User-Agent header for HTTP requests.
+        /// </summary>
+        public ClientXBuilder WithUserAgent(string userAgent) {
+            _userAgent = userAgent;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the preferred HTTP version used for queries.
+        /// </summary>
+        public ClientXBuilder WithHttpVersion(Version version) {
+            _httpVersion = version;
+            return this;
+        }
+
+        /// <summary>
+        /// Allows ignoring certificate validation errors.
+        /// </summary>
+        public ClientXBuilder WithIgnoreCertificateErrors(bool ignore = true) {
+            _ignoreCertificateErrors = ignore;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables or disables response caching.
+        /// </summary>
+        public ClientXBuilder WithEnableCache(bool enable = true) {
+            _enableCache = enable;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures TCP fallback behavior for UDP queries.
+        /// </summary>
+        public ClientXBuilder WithUseTcpFallback(bool useTcpFallback) {
+            _useTcpFallback = useTcpFallback;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures a custom hostname and DNS request format.
+        /// </summary>
+        public ClientXBuilder WithHostname(string hostname, DnsRequestFormat format) {
+            _hostname = hostname;
+            _requestFormat = format;
+            _endpoint = DnsEndpoint.Custom;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures a custom base URI and DNS request format.
+        /// </summary>
+        public ClientXBuilder WithBaseUri(Uri baseUri, DnsRequestFormat format) {
+            _baseUri = baseUri;
+            _requestFormat = format;
+            _endpoint = DnsEndpoint.Custom;
+            return this;
+        }
+
+        /// <summary>
         /// Configures EDNS options for DNS queries.
         /// </summary>
         /// <param name="options">The EDNS options to apply.</param>
@@ -70,7 +147,14 @@ namespace DnsClientX {
         /// Builds and returns a configured <see cref="ClientX"/> instance.
         /// </summary>
         public ClientX Build() {
-            var client = new ClientX(_endpoint, DnsSelectionStrategy.First, _timeout, webProxy: _proxy);
+            ClientX client;
+            if (_baseUri != null && _requestFormat != null) {
+                client = new ClientX(_baseUri, _requestFormat.Value, _timeout, _userAgent, _httpVersion, _ignoreCertificateErrors, _enableCache, _useTcpFallback, _proxy);
+            } else if (_hostname != null && _requestFormat != null) {
+                client = new ClientX(_hostname, _requestFormat.Value, _timeout, _userAgent, _httpVersion, _ignoreCertificateErrors, _enableCache, _useTcpFallback, _proxy);
+            } else {
+                client = new ClientX(_endpoint, _strategy, _timeout, _userAgent, _httpVersion, _ignoreCertificateErrors, _enableCache, _useTcpFallback, _proxy);
+            }
             if (_ednsOptions != null) {
                 client.EndpointConfiguration.EdnsOptions = _ednsOptions;
             }


### PR DESCRIPTION
## Summary
- expand `ClientXBuilder` with fluent configuration methods
- update unit tests for new builder options
- add example demonstrating builder usage

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6872b61847d0832e842d0a9f70bc677e