### PR TITLE
Handle host cooldown in selection

### DIFF
--- a/DnsClientX.Examples/DemoUnavailableCooldown.cs
+++ b/DnsClientX.Examples/DemoUnavailableCooldown.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates skipping endpoints marked as unavailable for a cooldown period.
+    /// </summary>
+    internal static class DemoUnavailableCooldown {
+        public static void Example() {
+            var config = new Configuration(DnsEndpoint.Cloudflare, DnsSelectionStrategy.Failover) {
+                UnavailableCooldown = TimeSpan.FromSeconds(30)
+            };
+
+            config.MarkCurrentHostnameUnavailable();
+            config.SelectHostNameStrategy();
+            Console.WriteLine($"Using {config.Hostname}");
+        }
+    }
+}

--- a/DnsClientX.Tests/UnavailableCooldownTests.cs
+++ b/DnsClientX.Tests/UnavailableCooldownTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class UnavailableCooldownTests {
+        [Fact]
+        public async Task SelectHostNameStrategy_ShouldSkipUnavailableUntilCooldownExpires() {
+            var config = new Configuration(DnsEndpoint.Cloudflare, DnsSelectionStrategy.Failover) {
+                UnavailableCooldown = System.TimeSpan.FromMilliseconds(100)
+            };
+
+            config.MarkCurrentHostnameUnavailable();
+            config.SelectHostNameStrategy();
+            Assert.Equal("1.0.0.1", config.Hostname);
+
+            await Task.Delay(150);
+
+            typeof(Configuration).GetMethod("AdvanceToNextHostname", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(config, null);
+            config.SelectHostNameStrategy();
+            Assert.Equal("1.1.1.1", config.Hostname);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- skip unavailable hosts for a configurable cooldown
- add `MarkHostnameUnavailable` API
- example demonstrating cooldown usage
- tests for cooldown logic

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build -v minimal` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6872b6202e30832eab25fe9bc0db079b