### PR TITLE
Add helper classes for composing EDNS options

### DIFF
--- a/DnsClientX.Examples/DemoEdnsOptions.cs
+++ b/DnsClientX.Examples/DemoEdnsOptions.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples;
+
+/// <summary>
+/// Demonstrates composing EDNS options using helper classes.
+/// </summary>
+internal class DemoEdnsOptions {
+    /// <summary>Runs the example.</summary>
+    public static async Task Example() {
+        using var client = new ClientX(DnsEndpoint.Quad9) {
+            EndpointConfiguration = {
+                EdnsOptions = new EdnsOptions { EnableEdns = true }
+            }
+        };
+        client.EndpointConfiguration.EdnsOptions!.Options.Add(new NsidOption());
+        client.EndpointConfiguration.EdnsOptions.Options.Add(new EcsOption("192.0.2.1/24"));
+        var response = await client.Resolve("example.com", DnsRecordType.A);
+        response?.DisplayTable();
+    }
+}

--- a/DnsClientX.Tests/NsidOptionTests.cs
+++ b/DnsClientX.Tests/NsidOptionTests.cs
@@ -1,0 +1,34 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for composing the NSID EDNS option.
+    /// </summary>
+    public class NsidOptionTests {
+        [Fact]
+        public void SerializeDnsWireFormat_ShouldIncludeNsidOption() {
+            var option = new NsidOption();
+            var message = new DnsMessage("example.com", DnsRecordType.A, false, true, 4096, null, false, null, new[] { option });
+            byte[] data = message.SerializeDnsWireFormat();
+
+            int offset = 12;
+            foreach (var label in "example.com".Split('.')) {
+                offset += 1 + label.Length;
+            }
+            offset += 1 + 2 + 2;
+
+            Assert.Equal(1, (data[10] << 8) | data[11]);
+            Assert.Equal(0, data[offset]);
+            ushort type = (ushort)((data[offset + 1] << 8) | data[offset + 2]);
+            Assert.Equal((ushort)DnsRecordType.OPT, type);
+            offset += 1 + 2 + 2 + 4;
+            ushort rdlen = (ushort)((data[offset] << 8) | data[offset + 1]);
+            Assert.True(rdlen > 0);
+            offset += 2;
+            ushort optionCode = (ushort)((data[offset] << 8) | data[offset + 1]);
+            Assert.Equal(3, optionCode);
+            ushort optionLen = (ushort)((data[offset + 2] << 8) | data[offset + 3]);
+            Assert.Equal<ushort>(0, optionLen);
+        }
+    }
+}

--- a/DnsClientX/Edns/EcsOption.cs
+++ b/DnsClientX/Edns/EcsOption.cs
@@ -1,0 +1,52 @@
+namespace DnsClientX;
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+/// <summary>
+/// Implements the EDNS Client Subnet option (ECS) as defined in RFC 7871.
+/// </summary>
+public sealed class EcsOption : EdnsOption {
+    /// <summary>
+    /// Gets the subnet in CIDR notation.
+    /// </summary>
+    public string Subnet { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EcsOption"/> class.
+    /// </summary>
+    /// <param name="subnet">Subnet in CIDR notation.</param>
+    public EcsOption(string subnet) : base(8) => Subnet = subnet;
+
+    /// <inheritdoc/>
+    protected override byte[] GetData() {
+        string[] parts = Subnet.Split('/');
+        if (!IPAddress.TryParse(parts[0], out var ip)) {
+            throw new ArgumentException("Invalid subnet", nameof(Subnet));
+        }
+        int prefixLength = parts.Length > 1 ? int.Parse(parts[1]) : (ip.AddressFamily == AddressFamily.InterNetwork ? 32 : 128);
+
+        ushort family = ip.AddressFamily == AddressFamily.InterNetwork ? (ushort)1 : (ushort)2;
+        byte[] addressBytes = ip.GetAddressBytes();
+        int addressBits = prefixLength;
+        int addressBytesLen = (addressBits + 7) / 8;
+        if (addressBytesLen > addressBytes.Length) addressBytesLen = addressBytes.Length;
+        byte[] truncated = new byte[addressBytesLen];
+        Array.Copy(addressBytes, truncated, addressBytesLen);
+        int unusedBits = addressBytesLen * 8 - addressBits;
+        if (unusedBits > 0 && addressBytesLen > 0) {
+            truncated[addressBytesLen - 1] &= (byte)(0xFF << unusedBits);
+        }
+
+        using var ms = new MemoryStream();
+        void WriteUInt16(ushort value) => ms.Write(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)value)), 0, 2);
+
+        WriteUInt16(family);
+        ms.WriteByte((byte)prefixLength);
+        ms.WriteByte(0); // scope prefix length
+        ms.Write(truncated, 0, truncated.Length);
+        return ms.ToArray();
+    }
+}

--- a/DnsClientX/Edns/EdnsOption.cs
+++ b/DnsClientX/Edns/EdnsOption.cs
@@ -1,0 +1,43 @@
+namespace DnsClientX;
+
+using System;
+using System.IO;
+using System.Net;
+
+/// <summary>
+/// Base class for EDNS options.
+/// </summary>
+public abstract class EdnsOption {
+    /// <summary>
+    /// Gets the option code as defined in RFC 6891.
+    /// </summary>
+    public ushort Code { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EdnsOption"/> class.
+    /// </summary>
+    /// <param name="code">EDNS option code.</param>
+    protected EdnsOption(ushort code) => Code = code;
+
+    /// <summary>
+    /// Serializes the option to a byte array.
+    /// </summary>
+    /// <returns>Byte array containing the serialized option.</returns>
+    internal byte[] ToByteArray() {
+        byte[] data = GetData();
+        using var ms = new MemoryStream();
+        void WriteUInt16(ushort value) => ms.Write(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)value)), 0, 2);
+        WriteUInt16(Code);
+        WriteUInt16((ushort)data.Length);
+        if (data.Length > 0) {
+            ms.Write(data, 0, data.Length);
+        }
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Retrieves the option data portion.
+    /// </summary>
+    /// <returns>Raw option data without the code and length.</returns>
+    protected abstract byte[] GetData();
+}

--- a/DnsClientX/Edns/NsidOption.cs
+++ b/DnsClientX/Edns/NsidOption.cs
@@ -1,0 +1,22 @@
+namespace DnsClientX;
+
+using System;
+
+/// <summary>
+/// Implements the NSID option defined in RFC 5001.
+/// </summary>
+public sealed class NsidOption : EdnsOption {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NsidOption"/> class.
+    /// </summary>
+    /// <param name="data">Optional NSID data. When null an empty request is sent.</param>
+    public NsidOption(byte[]? data = null) : base(3) => Data = data ?? Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets the data contained in the option.
+    /// </summary>
+    public byte[] Data { get; }
+
+    /// <inheritdoc/>
+    protected override byte[] GetData() => Data;
+}

--- a/DnsClientX/EdnsOptions.cs
+++ b/DnsClientX/EdnsOptions.cs
@@ -17,5 +17,10 @@ namespace DnsClientX {
         /// Gets or sets the EDNS Client Subnet (ECS) in CIDR notation.
         /// </summary>
         public string? Subnet { get; set; }
+
+        /// <summary>
+        /// Gets the additional EDNS options to include in the OPT record.
+        /// </summary>
+        public System.Collections.Generic.List<EdnsOption> Options { get; } = [];
     }
 }

--- a/DnsClientX/ProtocolDnsGrpc/DnsWireResolveGrpc.cs
+++ b/DnsClientX/ProtocolDnsGrpc/DnsWireResolveGrpc.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -31,12 +32,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                options = edns.Options;
             }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
+++ b/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
@@ -25,7 +26,8 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatHttp2(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = endpointConfiguration.EdnsOptions?.Options;
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
@@ -29,12 +30,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                options = edns.Options;
             }
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -6,6 +6,7 @@ using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -52,12 +53,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? ednsOptions = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                ednsOptions = edns.Options;
             }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, ednsOptions);
             var queryBytes = query.SerializeDnsWireFormat();
 
             var lengthPrefix = BitConverter.GetBytes((ushort)queryBytes.Length);

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
 
 namespace DnsClientX {
     internal static class DnsWireResolve {
@@ -27,12 +28,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                options = edns.Options;
             }
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -37,12 +37,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                options = edns.Options;
             }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var queryBytes = query.SerializeDnsWireFormat();
 
             // Calculate the length prefix for the query

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,12 +14,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                options = edns.Options;
             }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Http.Headers;
 using System.Net.Http;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,12 +28,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                options = edns.Options;
             }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -27,12 +28,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                options = edns.Options;
             }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Sockets;
 using System.Net;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -27,12 +28,14 @@ namespace DnsClientX {
             bool enableEdns = endpointConfiguration.EnableEdns;
             int udpSize = endpointConfiguration.UdpBufferSize;
             string? subnet = endpointConfiguration.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
             if (edns != null) {
                 enableEdns = edns.EnableEdns;
                 udpSize = edns.UdpBufferSize;
                 subnet = edns.Subnet;
+                options = edns.Options;
             }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey);
+            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {


### PR DESCRIPTION
## Summary
- introduce `EdnsOption` base class with `EcsOption` and `NsidOption`
- extend `EdnsOptions` with a collection of extra options
- update DNS message builder to compose EDNS options via helper classes
- include demo example and unit test for `NsidOption`

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: many network tests unable to connect)*

------
https://chatgpt.com/codex/tasks/task_e_6872b5eb6268832e86836c15b1e48830