### PR TITLE
Add ExtendedDnsErrorInfo to DnsResponse

### DIFF
--- a/DnsClientX.Tests/DnsResponseTests.cs
+++ b/DnsClientX.Tests/DnsResponseTests.cs
@@ -63,5 +63,21 @@ namespace DnsClientX.Tests {
             string result = JsonSerializer.Deserialize<string>(json, options)!;
             Assert.Equal("a; b", result);
         }
+
+        [Fact]
+        public void ExtendedDnsErrorInfoReflectsErrors() {
+            var response = new DnsResponse {
+                ExtendedDnsErrors = new[] {
+                    new ExtendedDnsError { InfoCode = 10, ExtraText = "one" },
+                    new ExtendedDnsError { InfoCode = 20, ExtraText = "two" }
+                }
+            };
+
+            Assert.Equal(2, response.ExtendedDnsErrorInfo.Length);
+            Assert.Equal(10, response.ExtendedDnsErrorInfo[0].Code);
+            Assert.Equal("one", response.ExtendedDnsErrorInfo[0].Text);
+            Assert.Equal(20, response.ExtendedDnsErrorInfo[1].Code);
+            Assert.Equal("two", response.ExtendedDnsErrorInfo[1].Text);
+        }
     }
 }

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -117,11 +117,14 @@ namespace DnsClientX {
         [JsonPropertyName("extended_dns_errors")]
         public ExtendedDnsError[] ExtendedDnsErrors { get; set; }
 
+        [JsonIgnore]
+        private ExtendedDnsErrorInfo[]? _extendedDnsErrorInfo;
+
         /// <summary>
         /// Gets the extended DNS error information in a simplified form.
         /// </summary>
         [JsonIgnore]
-        public ExtendedDnsErrorInfo[] ExtendedDnsErrorInfo =>
+        public ExtendedDnsErrorInfo[] ExtendedDnsErrorInfo => _extendedDnsErrorInfo ??=
             ExtendedDnsErrors == null
                 ? Array.Empty<ExtendedDnsErrorInfo>()
                 : ExtendedDnsErrors

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -117,6 +117,17 @@ namespace DnsClientX {
         [JsonPropertyName("extended_dns_errors")]
         public ExtendedDnsError[] ExtendedDnsErrors { get; set; }
 
+        /// <summary>
+        /// Gets the extended DNS error information in a simplified form.
+        /// </summary>
+        [JsonIgnore]
+        public ExtendedDnsErrorInfo[] ExtendedDnsErrorInfo =>
+            ExtendedDnsErrors == null
+                ? Array.Empty<ExtendedDnsErrorInfo>()
+                : ExtendedDnsErrors
+                    .Select(e => new ExtendedDnsErrorInfo { Code = e.InfoCode, Text = e.ExtraText })
+                    .ToArray();
+
 
         /// <summary>
         /// The client subnet information that the DNS server used to generate the response.

--- a/DnsClientX/Definitions/ExtendedDnsErrorInfo.cs
+++ b/DnsClientX/Definitions/ExtendedDnsErrorInfo.cs
@@ -1,0 +1,16 @@
+namespace DnsClientX {
+    /// <summary>
+    /// Provides extended DNS error information as defined by RFC 8914.
+    /// </summary>
+    public class ExtendedDnsErrorInfo {
+        /// <summary>
+        /// Gets or sets the extended DNS error code.
+        /// </summary>
+        public int Code { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional text describing the error.
+        /// </summary>
+        public string Text { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ExtendedDnsErrorInfo` type
- expose `ExtendedDnsErrorInfo` on `DnsResponse`
- test new property

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~ExtendedDnsErrorInfoReflectsErrors -v minimal`
- `dotnet build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6873758d0468832eb6cf4c6485bf1efb