### PR TITLE
Add TTL ValidateRange check

### DIFF
--- a/DnsClientX.PowerShell/CmdletDnsUpdate.cs
+++ b/DnsClientX.PowerShell/CmdletDnsUpdate.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Management.Automation;
 using System.Threading.Tasks;
 
@@ -40,6 +41,7 @@ public sealed class CmdletDnsUpdate : AsyncPSCmdlet {
 
     /// <summary>TTL for the new record. Defaults to 300 seconds.</summary>
     [Parameter]
+    [ValidateRange(1, int.MaxValue)]
     public int Ttl { get; set; } = 300;
 
     /// <summary>If specified, the record is removed instead of added.</summary>

--- a/Module/Tests/InvokeDnsUpdate.Tests.ps1
+++ b/Module/Tests/InvokeDnsUpdate.Tests.ps1
@@ -8,4 +8,8 @@ Describe 'Invoke-DnsUpdate cmdlet' {
     It 'Fails when server is unreachable' {
         { Invoke-DnsUpdate -Zone 'example.com' -Server '127.0.0.1' -Name 'www' -Type A -Data '1.1.1.1' -Port 1 -ErrorAction Stop } | Should -Throw
     }
+
+    It 'Fails when Ttl is less than or equal to zero' {
+        { Invoke-DnsUpdate -Zone 'example.com' -Server '127.0.0.1' -Name 'www' -Type A -Data '1.1.1.1' -Ttl 0 -ErrorAction Stop } | Should -Throw -ExceptionType System.Management.Automation.ParameterBindingException
+    }
 }


### PR DESCRIPTION
## Summary
- validate `Ttl` parameter with `[ValidateRange(1, int.MaxValue)]`
- adjust Pester test to expect a parameter binding error

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet build DnsClientX.PowerShell/DnsClientX.PowerShell.csproj -c Debug`
- `pwsh -f Module/DnsClientX.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6873760a4360832e9e7bcec367497fef