### PR TITLE
Add early cancellation to ResolveInternal

### DIFF
--- a/DnsClientX.Examples/DemoResolveCancellation.cs
+++ b/DnsClientX.Examples/DemoResolveCancellation.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates cancelling a resolve operation.
+    /// </summary>
+    internal class DemoResolveCancellation {
+        /// <summary>Runs the demo.</summary>
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+            try {
+                HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.A, DnsEndpoint.Cloudflare);
+                var response = await client.Resolve("github.com", cancellationToken: cts.Token);
+                response.DisplayTable();
+            } catch (TaskCanceledException) {
+                Console.WriteLine("Resolve operation canceled.");
+            }
+        }
+    }
+}

--- a/DnsClientX.Examples/DemoResolveCancellation.cs
+++ b/DnsClientX.Examples/DemoResolveCancellation.cs
@@ -16,7 +16,7 @@ namespace DnsClientX.Examples {
                 HelpersSpectre.AddLine("Resolve", "github.com", DnsRecordType.A, DnsEndpoint.Cloudflare);
                 var response = await client.Resolve("github.com", cancellationToken: cts.Token);
                 response.DisplayTable();
-            } catch (TaskCanceledException) {
+            } catch (OperationCanceledException) {
                 Console.WriteLine("Resolve operation canceled.");
             }
         }

--- a/DnsClientX.Tests/CancellationTests.cs
+++ b/DnsClientX.Tests/CancellationTests.cs
@@ -75,7 +75,7 @@ namespace DnsClientX.Tests {
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            await Assert.ThrowsAsync<TaskCanceledException>(() => client.Resolve("example.com", DnsRecordType.A, cancellationToken: cts.Token));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => client.Resolve("example.com", DnsRecordType.A, cancellationToken: cts.Token));
         }
     }
 }

--- a/DnsClientX.Tests/CancellationTests.cs
+++ b/DnsClientX.Tests/CancellationTests.cs
@@ -68,5 +68,14 @@ namespace DnsClientX.Tests {
 
             Assert.Equal(1, ClientX.DisposalCount);
         }
+
+        [Fact]
+        public async Task Resolve_AlreadyCancelledToken_ShouldThrow() {
+            using var client = new ClientX("1.1.1.1", DnsRequestFormat.DnsOverHttps);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => client.Resolve("example.com", DnsRecordType.A, cancellationToken: cts.Token));
+        }
     }
 }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -62,6 +62,8 @@ namespace DnsClientX {
         }
 
         private async Task<DnsResponse> ResolveInternal(string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool returnAllTypes, int maxRetries, int retryDelayMs, bool typedRecords, CancellationToken cancellationToken) {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
             bool originalCd = EndpointConfiguration.CheckingDisabled;


### PR DESCRIPTION
## Summary
- ensure `ResolveInternal` aborts promptly when `CancellationToken` is canceled
- demonstrate cancellation usage in a new example
- cover the new behaviour with a unit test

## Testing
- `dotnet test` *(fails: Failed:   142, Passed:   423, Skipped:    18, Total:   583)*

------
https://chatgpt.com/codex/tasks/task_e_68755129b3b4832eb1462aadfc81b7e8