### PR TITLE
Fix AnswersMinimal null handling

### DIFF
--- a/DnsClientX.Tests/DnsResponseTests.cs
+++ b/DnsClientX.Tests/DnsResponseTests.cs
@@ -79,5 +79,12 @@ namespace DnsClientX.Tests {
             Assert.Equal(20, response.ExtendedDnsErrorInfo[1].Code);
             Assert.Equal("two", response.ExtendedDnsErrorInfo[1].Text);
         }
+
+        [Fact]
+        public void AnswersMinimalReturnsEmptyWhenAnswersNull() {
+            var response = new DnsResponse();
+
+            Assert.Empty(response.AnswersMinimal);
+        }
     }
 }

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -90,7 +90,11 @@ namespace DnsClientX {
         /// Gets the answers in their minimal form.
         /// </summary>
         [JsonIgnore]
-        public DnsAnswerMinimal[] AnswersMinimal => _answersMinimal ?? Answers.Select(answer => (DnsAnswerMinimal)answer).ToArray();
+        public DnsAnswerMinimal[] AnswersMinimal =>
+            _answersMinimal ??
+            (Answers == null
+                ? Array.Empty<DnsAnswerMinimal>()
+                : Answers.Select(answer => (DnsAnswerMinimal)answer).ToArray());
 
         /// <summary>
         /// The authority records provided by the DNS server.


### PR DESCRIPTION
## Summary
- prevent `AnswersMinimal` from throwing when `Answers` is `null`
- add unit test verifying the empty array result

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Failed: 141, Passed: 424, Skipped: 18)*

------
https://chatgpt.com/codex/tasks/task_e_6875511aa918832e96d023e1c78a1c1d