### PR TITLE
Dispose UdpClient on early exception

### DIFF
--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -74,7 +74,7 @@ namespace DnsClientX {
             Exception lastException = null;
             for (int attempt = 1; attempt <= Math.Max(1, maxRetries); attempt++) {
                 try {
-                    var udpClient = new UdpClient(address.AddressFamily);
+                    using var udpClient = new UdpClient(address.AddressFamily);
                     var responseBuffer = await SendQueryOverUdp(udpClient, queryBytes, address, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
 
                     var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- wrap UdpClient in `using` inside `ResolveWireFormatUdp`

## Testing
- `dotnet test DnsClientX.sln -v minimal` *(fails: ConnectFailure)*

------
https://chatgpt.com/codex/tasks/task_e_6875510d1108832eb88a2982d7c3e9ce