### PR TITLE
Fix cancellation token in retry delay

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -164,7 +164,7 @@ namespace DnsClientX.PowerShell {
                 }
 
                 if (attempt < RetryCount) {
-                    await Task.Delay(RetryDelayMs);
+                    await Task.Delay(RetryDelayMs, CancelToken);
                 }
             }
 

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DnsClientX\DnsClientX.csproj" />
     <ProjectReference Include="..\DnsClientX.Cli\DnsClientX.Cli.csproj" />
+    <ProjectReference Include="..\DnsClientX.PowerShell\DnsClientX.PowerShell.csproj" />
   </ItemGroup>
 
     <ItemGroup>

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -3,8 +3,7 @@
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             net472;net8.0
         </TargetFrameworks>
-        <TargetFrameworks
-            Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
             net8.0
         </TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -16,8 +15,8 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.0"
-            Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0" />
+        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.0" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
         <PackageReference Include="SemanticComparison" Version="4.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
@@ -29,8 +28,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4"
-        Condition="'$(TargetFramework)' == 'net472'" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DnsClientX.Tests/ExecuteWithRetryCancellationTests.cs
+++ b/DnsClientX.Tests/ExecuteWithRetryCancellationTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using DnsClientX.PowerShell;
+using DnsClientX;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class ExecuteWithRetryCancellationTests {
+        [Fact]
+        public async Task DelayShouldHonorCancellation() {
+            var cmdlet = new CmdletResolveDnsQuery {
+                RetryCount = 2,
+                RetryDelayMs = 10000
+            };
+
+            var transientResponse = new DnsResponse {
+                Status = DnsResponseCode.ServerFailure,
+                Error = "network error"
+            };
+
+            Func<Task<DnsResponse[]>> query = () => Task.FromResult(new[] { transientResponse });
+
+            MethodInfo executeWithRetry = typeof(CmdletResolveDnsQuery)
+                .GetMethod("ExecuteWithRetry", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var task = (Task<DnsResponse[]>)executeWithRetry.Invoke(cmdlet, new object[] { query })!;
+
+            await Task.Delay(100);
+
+            MethodInfo stopProcessing = typeof(AsyncPSCmdlet)
+                .GetMethod("StopProcessing", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            stopProcessing.Invoke(cmdlet, null);
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make ExecuteWithRetry support cancellation token in Task.Delay
- reference PowerShell project in tests
- add unit test for cancellation behavior

## Testing
- `dotnet test` *(fails: 142 failed, 423 passed, 18 skipped)*
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68755106411c832ea2c34bbcde998117