### PR TITLE
Fix empty JSON body handling

### DIFF
--- a/DnsClientX.Tests/DnsJsonDeserializeTests.cs
+++ b/DnsClientX.Tests/DnsJsonDeserializeTests.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using DnsClientX;
+
+namespace DnsClientX.Tests {
+    public class DnsJsonDeserializeTests {
+        [Fact]
+        public async Task Deserialize_ContentLengthZero_ThrowsException() {
+            using var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(Array.Empty<byte>())
+            };
+            var ex = await Assert.ThrowsAsync<DnsClientException>(
+                () => response.Deserialize<object>());
+            Assert.Contains("Response content is empty", ex.Message);
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsJson/DnsJson.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJson.cs
@@ -24,8 +24,9 @@ namespace DnsClientX {
         /// <param name="response">The HTTP response message with JSON as a body.</param>
         /// <param name="debug">Whether to print the JSON data to the console.</param>
         internal static async Task<T> Deserialize<T>(this HttpResponseMessage response, bool debug = false) {
+            if (response.Content.Headers.ContentLength.GetValueOrDefault() == 0)
+                throw new DnsClientException("Response content is empty, can't parse as JSON.");
             using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-            if (stream.Length == 0) throw new DnsClientException("Response content is empty, can't parse as JSON.");
             try {
                 if (debug) {
                     // Read the stream as a string


### PR DESCRIPTION
## Summary
- validate HTTP response body using `ContentLength`
- add unit test for zero-length content

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: SocketException)*

------
https://chatgpt.com/codex/tasks/task_e_687550f9955c832eaee7fa816f9e83c4