### PR TITLE
Add XML documentation to public APIs

### DIFF
--- a/DnsClientX.Benchmarks/DomainBenchmark.cs
+++ b/DnsClientX.Benchmarks/DomainBenchmark.cs
@@ -10,40 +10,40 @@ namespace DnsClientX.Benchmarks;
 public class DomainBenchmark {
     private readonly string[] _domains = ["google.com", "github.com", "cloudflare.com"];
 
-    [Benchmark]
     /// <summary>Benchmark querying over UDP.</summary>
+    [Benchmark]
     public async Task Udp() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverUDP);
         }
     }
 
-    [Benchmark]
     /// <summary>Benchmark querying over TCP.</summary>
+    [Benchmark]
     public async Task Tcp() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverTCP);
         }
     }
 
-    [Benchmark]
     /// <summary>Benchmark querying over TLS.</summary>
+    [Benchmark]
     public async Task Dot() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverTLS);
         }
     }
 
-    [Benchmark]
     /// <summary>Benchmark querying over HTTPS.</summary>
+    [Benchmark]
     public async Task Doh() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverHttps);
         }
     }
 
-    [Benchmark]
     /// <summary>Benchmark querying over QUIC.</summary>
+    [Benchmark]
     public async Task Doq() {
         foreach (var domain in _domains) {
             await ClientX.QueryDns(domain, DnsRecordType.A, "1.1.1.1", DnsRequestFormat.DnsOverQuic);

--- a/DnsClientX.Examples/DemoResolveAll.cs
+++ b/DnsClientX.Examples/DemoResolveAll.cs
@@ -69,6 +69,9 @@ namespace DnsClientX.Examples {
             }
         }
 
+        /// <summary>
+        /// Executes a simplified resolve-all example against a single endpoint.
+        /// </summary>
         public static async Task Example2() {
             var dnsEndpoints = new List<DnsEndpoint> {
                 DnsEndpoint.Cloudflare,

--- a/DnsClientX.Examples/DemoResolveParallelDNSBL.cs
+++ b/DnsClientX.Examples/DemoResolveParallelDNSBL.cs
@@ -7,7 +7,11 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace DnsClientX.Examples {
+    /// <summary>
+    /// Demonstrates querying multiple DNS blacklists in parallel.
+    /// </summary>
     public static class DemoResolveParallelBlackList {
+        /// <summary>List of common DNSBL providers.</summary>
         public static List<string> dnsBlacklist { get; } = [
             "all.s5h.net",
             "auth.spamrats.com",
@@ -124,6 +128,9 @@ namespace DnsClientX.Examples {
             "zombie.dnsbl.sorbs.net"
         ];
 
+        /// <summary>
+        /// Queries all configured DNS blacklists in parallel for a single IP address.
+        /// </summary>
         public static async Task Example() {
             var endpoint = DnsEndpoint.OpenDNS;
             string ipAddress = "89.74.48.96";

--- a/DnsClientX.Examples/HelpersSpectre.cs
+++ b/DnsClientX.Examples/HelpersSpectre.cs
@@ -140,12 +140,18 @@ namespace DnsClientX.Examples {
             AnsiConsole.Write(table);
         }
 
+        /// <summary>
+        /// Displays each DNS response in an individual table.
+        /// </summary>
         public static void DisplayTable(this DnsResponse[] responses) {
             foreach (var response in responses) {
                 response.DisplayTable();
             }
         }
 
+        /// <summary>
+        /// Renders a table for a collection of DNS answers.
+        /// </summary>
         public static void DisplayTable(this DnsAnswer[] answers) {
             var table = new Table().Border(TableBorder.Rounded);
             table.AddColumn("Type");
@@ -159,6 +165,9 @@ namespace DnsClientX.Examples {
 
             AnsiConsole.Write(table);
         }
+        /// <summary>
+        /// Renders a table for a single DNS answer.
+        /// </summary>
         public static void DisplayTable(this DnsAnswer answer) {
             var table = new Table().Border(TableBorder.Rounded);
             table.AddColumn("Type");
@@ -171,6 +180,9 @@ namespace DnsClientX.Examples {
             AnsiConsole.Write(table);
         }
 
+        /// <summary>
+        /// Displays a table listing DNS questions that were executed.
+        /// </summary>
         public static void DisplayTable(this DnsQuestion[] questions) {
             var table = new Table().Border(TableBorder.Rounded);
             table.AddColumn("Name");

--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -1,6 +1,9 @@
 using Xunit.Abstractions;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests that compare DNS responses between multiple providers.
+    /// </summary>
     public class CompareProvidersResolve(ITestOutputHelper output) {
         /// <summary>
         /// Compares DNS answers returned by various providers.
@@ -35,6 +38,8 @@ namespace DnsClientX.Tests {
 
         [InlineData("google.com", DnsRecordType.MX, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         /// <summary>
+        /// Performs a comparison of DNS responses across multiple providers.
+        /// </summary>
         [InlineData("108.138.7.68", DnsRecordType.PTR, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("sip2sip.info", DnsRecordType.NAPTR, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         public async Task CompareRecordsImproved(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
@@ -199,8 +204,11 @@ namespace DnsClientX.Tests {
 
         [InlineData("google.com", DnsRecordType.MX)]
         [InlineData("1.1.1.1", DnsRecordType.PTR)]
-[InlineData("108.138.7.68", DnsRecordType.PTR)]
-[InlineData("sip2sip.info", DnsRecordType.NAPTR)]
+        [InlineData("108.138.7.68", DnsRecordType.PTR)]
+        [InlineData("sip2sip.info", DnsRecordType.NAPTR)]
+        /// <summary>
+        /// Legacy implementation used to compare responses between providers.
+        /// </summary>
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -31,6 +31,9 @@ namespace DnsClientX.Tests {
         [InlineData("reddit.com", DnsRecordType.CAA, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("reddit.com", DnsRecordType.SOA, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("github.com", DnsRecordType.TXT, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
+        /// <summary>
+        /// Compares results returned from multiple providers using <see cref="ClientX.ResolveAll"/>.
+        /// </summary>
         [InlineData("microsoft.com", DnsRecordType.MX, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("microsoft.com", DnsRecordType.NS, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("google.com", DnsRecordType.MX, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
@@ -179,6 +182,9 @@ namespace DnsClientX.Tests {
 
         [InlineData("google.com", DnsRecordType.MX)]
         [InlineData("_25._tcp.mail.ietf.org", DnsRecordType.TLSA)]
+        /// <summary>
+        /// Validates that providers return consistent results for the specified record type.
+        /// </summary>
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -228,6 +234,9 @@ namespace DnsClientX.Tests {
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.CloudflareWireFormat)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNSFamily)]
+        /// <summary>
+        /// Compares multiline text records returned by different providers.
+        /// </summary>
         public async Task CompareRecordTextMultiline(string name, DnsRecordType resourceRecordType, DnsEndpoint primaryEndpoint, DnsEndpoint endpointCompare) {
             using var Client = new ClientX(primaryEndpoint);
             DnsAnswer[] aAnswersPrimary = await Client.ResolveAll(name, resourceRecordType);

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -153,6 +153,9 @@ namespace DnsClientX.Tests {
         [InlineData("microsoft.com", DnsRecordType.TXT)]
         [InlineData("disneyplus.com", DnsRecordType.TXT)]
         [InlineData("github.com", DnsRecordType.TXT)]
+        /// <summary>
+        /// Compares provider answers after filtering responses for a specific pattern.
+        /// </summary>
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -249,6 +252,9 @@ namespace DnsClientX.Tests {
 
         [Theory(Skip = "External dependency - unreliable for automated testing")]
         [InlineData(new[] { "evotec.pl", "microsoft.com", "disneyplus.com" }, DnsRecordType.TXT)]
+        /// <summary>
+        /// Executes filtered resolve tests for multiple domains simultaneously.
+        /// </summary>
         public async Task CompareRecordsMulti(string[] names, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             string filter = "v=spf1";
             var primaryEndpoint = DnsEndpoint.Cloudflare;

--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -38,6 +38,9 @@ namespace DnsClientX.Tests {
 #endif
 
         [Fact]
+        /// <summary>
+        /// Ensures that calling <see cref="ClientX.Dispose"/> does not dispose the underlying <see cref="HttpClient"/> twice.
+        /// </summary>
         public void Client_Dispose_ShouldNotDisposeHttpClientTwice() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.com") };
@@ -58,6 +61,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Verifies that disposing <see cref="ClientX"/> does not dispose the HTTP handler multiple times.
+        /// </summary>
         public void Client_Dispose_ShouldNotDisposeHandlerTwice() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -77,6 +83,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Ensures the asynchronous dispose method does not dispose the <see cref="HttpClient"/> twice.
+        /// </summary>
         public async Task Client_DisposeAsync_ShouldNotDisposeHttpClientTwice() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -94,6 +103,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Checks that <see cref="ClientX.DisposeAsync"/> does not dispose the HTTP handler more than once.
+        /// </summary>
         public async Task Client_DisposeAsync_ShouldNotDisposeHandlerTwice() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -113,6 +125,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Ensures that concurrent calls to <see cref="ClientX.Dispose"/> only dispose once.
+        /// </summary>
         public async Task Client_Dispose_CalledConcurrently_ShouldOnlyDisposeOnce() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -134,6 +149,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Ensures concurrent invocations of <see cref="ClientX.DisposeAsync"/> only dispose once.
+        /// </summary>
         public async Task Client_DisposeAsync_CalledConcurrently_ShouldOnlyDisposeOnce() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -155,6 +173,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Validates that the disposal counter is incremented when <see cref="ClientX.DisposeAsync"/> is called.
+        /// </summary>
         public async Task Client_DisposeAsync_ShouldIncrementDisposalCount() {
             ClientX.DisposalCount = 0;
             await using var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
@@ -166,6 +187,9 @@ namespace DnsClientX.Tests {
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         [Fact]
+        /// <summary>
+        /// Tests that asynchronous disposal prefers calling <see cref="IAsyncDisposable.DisposeAsync"/> on the handler when available.
+        /// </summary>
         public async Task Client_DisposeAsync_ShouldPreferAsyncHandlerDisposal() {
             var handler = new TrackingAsyncHandler();
             var customClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.com") };
@@ -187,6 +211,9 @@ namespace DnsClientX.Tests {
 #endif
 
         [Fact]
+        /// <summary>
+        /// Ensures the list tracking disposed clients is cleared upon disposal.
+        /// </summary>
         public void Client_Dispose_ShouldClearDisposedClientsList() {
             var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
 

--- a/DnsClientX.Tests/DmarcTxtRecordTests.cs
+++ b/DnsClientX.Tests/DmarcTxtRecordTests.cs
@@ -1,8 +1,14 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests related to DMARC TXT record handling.
+    /// </summary>
     public class DmarcTxtRecordTests {
         [Fact]
+        /// <summary>
+        /// Ensures that DMARC TXT records remain in a single line when parsed.
+        /// </summary>
         public void DmarcRecord_IsNotSplitIntoMultipleLines() {
             string record = "v=DMARC1; p=reject; rua=mailto:report@dmarc-reports.example.net; adkim=s; aspf=s";
             var answer = new DnsAnswer {

--- a/DnsClientX.Tests/DnameLocRecordTests.cs
+++ b/DnsClientX.Tests/DnameLocRecordTests.cs
@@ -3,6 +3,9 @@ using System.Reflection;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for decoding DNAME and LOC record wire formats.
+    /// </summary>
     public class DnameLocRecordTests {
         private static byte[] EncodeDnsName(string name) {
             name = name.TrimEnd('.');
@@ -18,6 +21,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Verifies that DNAME record wire data is decoded correctly.
+        /// </summary>
         public void ProcessRecordData_DecodesDnameWireFormat() {
             byte[] rdata = EncodeDnsName("target.example.com.");
             Type wireType = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWire")!;
@@ -27,6 +33,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Verifies that LOC record wire data is decoded correctly.
+        /// </summary>
         public void ProcessRecordData_DecodesLocWireFormat() {
             byte[] rdata = new byte[16];
             rdata[0] = 0x00; // version

--- a/DnsClientX.Tests/DnsAnswerBase64Tests.cs
+++ b/DnsClientX.Tests/DnsAnswerBase64Tests.cs
@@ -1,8 +1,14 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Unit tests for base64 parsing of <see cref="DnsAnswer"/> data.
+    /// </summary>
     public class DnsAnswerBase64Tests {
         [Fact]
+        /// <summary>
+        /// Ensures conversion returns an empty string when no raw data is provided.
+        /// </summary>
         public void ConvertData_TlsaEmptyDataRaw_ReturnsEmpty() {
             var answer = new DnsAnswer {
                 Name = "example.com",

--- a/DnsClientX.Tests/DnsAnswerMinimalTests.cs
+++ b/DnsClientX.Tests/DnsAnswerMinimalTests.cs
@@ -1,8 +1,14 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for the lightweight <see cref="DnsAnswerMinimal"/> structure.
+    /// </summary>
     public class DnsAnswerMinimalTests {
         [Fact]
+        /// <summary>
+        /// Verifies that explicit conversion from <see cref="DnsAnswer"/> copies all fields.
+        /// </summary>
         public void ExplicitConversionCopiesFields() {
             var answer = new DnsAnswer {
                 Name = "example.com",
@@ -20,6 +26,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Checks that converting an array of <see cref="DnsAnswer"/> objects to <see cref="DnsAnswerMinimal"/> produces matching elements.
+        /// </summary>
         public void ConvertFromDnsAnswerArrayConvertsAll() {
             var answers = new[] {
                 new DnsAnswer { Name = "a.com", Type = DnsRecordType.A, TTL = 60, DataRaw = "1.1.1.1" },

--- a/DnsClientX.Tests/DnsAnswerParsingTests.cs
+++ b/DnsClientX.Tests/DnsAnswerParsingTests.cs
@@ -3,6 +3,9 @@ using System.Text;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for parsing various DNS answer formats.
+    /// </summary>
     public class DnsAnswerParsingTests {
         private static byte[] PtrBytes => new byte[] {
             3, (byte)'w', (byte)'w', (byte)'w',
@@ -12,12 +15,18 @@ namespace DnsClientX.Tests {
         };
 
         [Fact]
+        /// <summary>
+        /// Validates that PTR records encoded as a DNS name are parsed correctly.
+        /// </summary>
         public void PtrDataFromSpecialFormatIsConverted() {
             var answer = new DnsAnswer { Type = DnsRecordType.PTR, DataRaw = Encoding.UTF8.GetString(PtrBytes) };
             Assert.Equal("www.google.com", answer.Data);
         }
 
         [Fact]
+        /// <summary>
+        /// Ensures that base64-encoded PTR data is converted properly.
+        /// </summary>
         public void PtrDataFromBase64IsConverted() {
             var base64 = Convert.ToBase64String(PtrBytes);
             var answer = new DnsAnswer { Type = DnsRecordType.PTR, DataRaw = base64 };
@@ -25,6 +34,9 @@ namespace DnsClientX.Tests {
         }
 
         [Fact]
+        /// <summary>
+        /// Tests parsing of base64 encoded NAPTR record data.
+        /// </summary>
         public void NaptrDataFromBase64IsParsed() {
             byte[] rdata = {
                 0x00, 0x01, // order = 1

--- a/DnsClientX.Tests/DnsAnswerTests.cs
+++ b/DnsClientX.Tests/DnsAnswerTests.cs
@@ -1,8 +1,14 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for helper methods on <see cref="DnsAnswer"/>.
+    /// </summary>
     public class DnsAnswerTests {
         [Fact]
+        /// <summary>
+        /// Ensures conversion to a string array returns an empty array when data is null.
+        /// </summary>
         public void ConvertToMultiString_NullData_ReturnsEmptyArray() {
             var answer = new DnsAnswer {
                 Name = "example.com",

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -623,6 +623,11 @@ namespace DnsClientX {
             return await Resolve(names, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Expands a pattern containing brace or range expressions into a set of DNS names.
+        /// </summary>
+        /// <param name="pattern">The pattern which may contain brace expressions or numeric ranges.</param>
+        /// <returns>An enumeration of expanded names.</returns>
         public static IEnumerable<string> ExpandPattern(string pattern) {
             if (string.IsNullOrEmpty(pattern)) yield break;
 

--- a/DnsClientX/DnsRecords/CaaRecord.cs
+++ b/DnsClientX/DnsRecords/CaaRecord.cs
@@ -6,10 +6,19 @@ namespace DnsClientX;
 /// The CAA record type is documented in <a href="https://www.rfc-editor.org/rfc/rfc8659">RFC 8659</a>.
 /// </remarks>
 public sealed class CaaRecord {
+    /// <summary>Gets the flag value controlling critical handling.</summary>
     public byte Flags { get; }
+    /// <summary>Gets the property tag defined by the certificate authority.</summary>
     public string Tag { get; }
+    /// <summary>Gets the property value associated with the <see cref="Tag"/>.</summary>
     public string Value { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CaaRecord"/> class.
+    /// </summary>
+    /// <param name="flags">The flags for the record.</param>
+    /// <param name="tag">The property tag.</param>
+    /// <param name="value">The property value.</param>
     public CaaRecord(byte flags, string tag, string value) {
         Flags = flags;
         Tag = tag;

--- a/DnsClientX/DnsRecords/DnameRecord.cs
+++ b/DnsClientX/DnsRecords/DnameRecord.cs
@@ -7,8 +7,13 @@ namespace DnsClientX;
 /// See <a href="https://www.rfc-editor.org/rfc/rfc6672">RFC 6672</a> for details.
 /// </remarks>
 public sealed class DnameRecord {
+    /// <summary>Gets the domain name that the original name is aliased to.</summary>
     public string Target { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DnameRecord"/> class.
+    /// </summary>
+    /// <param name="target">The canonical domain name.</param>
     public DnameRecord(string target) {
         Target = target;
     }

--- a/DnsClientX/DnsRecords/DnsKeyRecord.cs
+++ b/DnsClientX/DnsRecords/DnsKeyRecord.cs
@@ -7,11 +7,22 @@ namespace DnsClientX;
 /// DNSSEC uses this record type for key distribution as specified in <a href="https://www.rfc-editor.org/rfc/rfc4034">RFC 4034</a>.
 /// </remarks>
 public sealed class DnsKeyRecord {
+    /// <summary>Gets the DNSKEY flags.</summary>
     public ushort Flags { get; }
+    /// <summary>Gets the protocol number. This should always be 3.</summary>
     public byte Protocol { get; }
+    /// <summary>Gets the algorithm identifier.</summary>
     public DnsKeyAlgorithm Algorithm { get; }
+    /// <summary>Gets the base64-encoded public key.</summary>
     public string PublicKey { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DnsKeyRecord"/> class.
+    /// </summary>
+    /// <param name="flags">Key flags.</param>
+    /// <param name="protocol">The protocol value, typically 3.</param>
+    /// <param name="algorithm">The signing algorithm.</param>
+    /// <param name="publicKey">The public key data.</param>
     public DnsKeyRecord(ushort flags, byte protocol, DnsKeyAlgorithm algorithm, string publicKey) {
         Flags = flags;
         Protocol = protocol;

--- a/DnsClientX/DnsRecords/DsRecord.cs
+++ b/DnsClientX/DnsRecords/DsRecord.cs
@@ -4,11 +4,22 @@ namespace DnsClientX;
 /// Represents a DS record used for DNSSEC validation.
 /// </summary>
 public sealed class DsRecord {
+    /// <summary>Gets the key tag identifying the DNSKEY record.</summary>
     public ushort KeyTag { get; }
+    /// <summary>Gets the algorithm used by the referenced DNSKEY.</summary>
     public DnsKeyAlgorithm Algorithm { get; }
+    /// <summary>Gets the digest type.</summary>
     public byte DigestType { get; }
+    /// <summary>Gets the digest value in hexadecimal form.</summary>
     public string Digest { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DsRecord"/> class.
+    /// </summary>
+    /// <param name="keyTag">The key tag.</param>
+    /// <param name="algorithm">The DNSSEC algorithm.</param>
+    /// <param name="digestType">The digest type.</param>
+    /// <param name="digest">The digest string.</param>
     public DsRecord(ushort keyTag, DnsKeyAlgorithm algorithm, byte digestType, string digest) {
         KeyTag = keyTag;
         Algorithm = algorithm;

--- a/DnsClientX/DnsRecords/LocRecord.cs
+++ b/DnsClientX/DnsRecords/LocRecord.cs
@@ -9,13 +9,28 @@ namespace DnsClientX;
 /// The format of this record is specified in <a href="https://www.rfc-editor.org/rfc/rfc1876">RFC 1876</a>.
 /// </remarks>
 public sealed class LocRecord {
+    /// <summary>Gets the geographic latitude.</summary>
     public double Latitude { get; }
+    /// <summary>Gets the geographic longitude.</summary>
     public double Longitude { get; }
+    /// <summary>Gets the altitude in meters.</summary>
     public double AltitudeMeters { get; }
+    /// <summary>Gets the size of the location in meters.</summary>
     public double SizeMeters { get; }
+    /// <summary>Gets the horizontal precision in meters.</summary>
     public double HorizontalPrecisionMeters { get; }
+    /// <summary>Gets the vertical precision in meters.</summary>
     public double VerticalPrecisionMeters { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocRecord"/> class.
+    /// </summary>
+    /// <param name="latitude">Latitude.</param>
+    /// <param name="longitude">Longitude.</param>
+    /// <param name="altitudeMeters">Altitude in meters.</param>
+    /// <param name="sizeMeters">Location size in meters.</param>
+    /// <param name="horizontalPrecisionMeters">Horizontal precision in meters.</param>
+    /// <param name="verticalPrecisionMeters">Vertical precision in meters.</param>
     public LocRecord(double latitude, double longitude, double altitudeMeters, double sizeMeters, double horizontalPrecisionMeters, double verticalPrecisionMeters) {
         Latitude = latitude;
         Longitude = longitude;

--- a/DnsClientX/DnsRecords/NaptrRecord.cs
+++ b/DnsClientX/DnsRecords/NaptrRecord.cs
@@ -7,13 +7,28 @@ namespace DnsClientX;
 /// Naming Authority Pointer records are specified in <a href="https://www.rfc-editor.org/rfc/rfc2915">RFC 2915</a>.
 /// </remarks>
 public sealed class NaptrRecord {
+    /// <summary>Gets the order in which records should be processed.</summary>
     public ushort Order { get; }
+    /// <summary>Gets the preference for services with the same order.</summary>
     public ushort Preference { get; }
+    /// <summary>Gets the control flags for the lookup.</summary>
     public string Flags { get; }
+    /// <summary>Gets the service parameters.</summary>
     public string Service { get; }
+    /// <summary>Gets the regular expression used for rewriting.</summary>
     public string RegExp { get; }
+    /// <summary>Gets the replacement domain name.</summary>
     public string Replacement { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NaptrRecord"/> class.
+    /// </summary>
+    /// <param name="order">Order of this record.</param>
+    /// <param name="preference">Preference among equal-order records.</param>
+    /// <param name="flags">Control flags.</param>
+    /// <param name="service">Service parameters.</param>
+    /// <param name="regExp">Rewrite expression.</param>
+    /// <param name="replacement">Replacement domain.</param>
     public NaptrRecord(ushort order, ushort preference, string flags, string service, string regExp, string replacement) {
         Order = order;
         Preference = preference;

--- a/DnsClientX/DnsRecords/SoaRecord.cs
+++ b/DnsClientX/DnsRecords/SoaRecord.cs
@@ -6,12 +6,19 @@ namespace DnsClientX;
 /// Start of Authority records describe global parameters for a DNS zone.
 /// </remarks>
 public sealed class SoaRecord {
+    /// <summary>Gets the primary name server for the zone.</summary>
     public string PrimaryNameServer { get; }
+    /// <summary>Gets the email address of the party responsible for the zone.</summary>
     public string ResponsiblePerson { get; }
+    /// <summary>Gets the zone serial number.</summary>
     public uint Serial { get; }
+    /// <summary>Gets the zone refresh interval in seconds.</summary>
     public uint Refresh { get; }
+    /// <summary>Gets the retry interval in seconds.</summary>
     public uint Retry { get; }
+    /// <summary>Gets the zone expiration time in seconds.</summary>
     public uint Expire { get; }
+    /// <summary>Gets the minimum TTL for records in the zone.</summary>
     public uint Minimum { get; }
 
     /// <summary>Initializes a new instance of the <see cref="SoaRecord"/> class.</summary>

--- a/DnsClientX/DnsRecords/SrvRecord.cs
+++ b/DnsClientX/DnsRecords/SrvRecord.cs
@@ -6,12 +6,22 @@ namespace DnsClientX;
 /// Defined in <a href="https://www.rfc-editor.org/rfc/rfc2782">RFC 2782</a>.
 /// </remarks>
 public sealed class SrvRecord {
+    /// <summary>Gets the priority of the target host.</summary>
     public ushort Priority { get; }
+    /// <summary>Gets the weight used to select between records with the same priority.</summary>
     public ushort Weight { get; }
+    /// <summary>Gets the port on the target host of the service.</summary>
     public ushort Port { get; }
+    /// <summary>Gets the domain name of the target host.</summary>
     public string Target { get; }
 
-    /// <summary>Initializes a new instance of the <see cref="SrvRecord"/> class.</summary>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SrvRecord"/> class.
+    /// </summary>
+    /// <param name="priority">Priority of the target host.</param>
+    /// <param name="weight">Relative weight for records with the same priority.</param>
+    /// <param name="port">Service port.</param>
+    /// <param name="target">Domain name of the target host.</param>
     public SrvRecord(ushort priority, ushort weight, ushort port, string target) {
         Priority = priority;
         Weight = weight;

--- a/DnsClientX/DnsRecords/TlsaRecord.cs
+++ b/DnsClientX/DnsRecords/TlsaRecord.cs
@@ -7,11 +7,22 @@ namespace DnsClientX;
 /// See <a href="https://www.rfc-editor.org/rfc/rfc6698">RFC 6698</a> for the specification.
 /// </remarks>
 public sealed class TlsaRecord {
+    /// <summary>Gets the certificate usage field.</summary>
     public byte CertificateUsage { get; }
+    /// <summary>Gets the selector field specifying which part of the certificate is matched.</summary>
     public byte Selector { get; }
+    /// <summary>Gets the matching type describing how the association data is compared.</summary>
     public byte MatchingType { get; }
+    /// <summary>Gets the certificate association data.</summary>
     public string AssociationData { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TlsaRecord"/> class.
+    /// </summary>
+    /// <param name="certificateUsage">The certificate usage.</param>
+    /// <param name="selector">The certificate selector.</param>
+    /// <param name="matchingType">The matching type.</param>
+    /// <param name="associationData">The association data.</param>
     public TlsaRecord(byte certificateUsage, byte selector, byte matchingType, string associationData) {
         CertificateUsage = certificateUsage;
         Selector = selector;

--- a/DnsClientX/DnsRecords/UnknownRecord.cs
+++ b/DnsClientX/DnsRecords/UnknownRecord.cs
@@ -9,6 +9,10 @@ public sealed class UnknownRecord {
     /// <summary>Gets the raw record data.</summary>
     public string Data { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnknownRecord"/> class.
+    /// </summary>
+    /// <param name="data">The raw record data.</param>
     public UnknownRecord(string data) => Data = data;
 }
 


### PR DESCRIPTION
## Summary
- document `ExpandPattern` and various DNS record classes
- document example helper methods
- add comments for several test classes

## Testing
- `dotnet build DnsClientX.sln -nologo`
- `dotnet test DnsClientX.sln -c Debug -nologo` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68760219d970832e879727556f94a434