### PR TITLE
Add typed TXT parsing option

### DIFF
--- a/DnsClientX.Examples/DemoTypedTxtAsTxt.cs
+++ b/DnsClientX.Examples/DemoTypedTxtAsTxt.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    internal class DemoTypedTxtAsTxt {
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var response = await client.Resolve("_dmarc.google.com", DnsRecordType.TXT, typedRecords: true, typedTxtAsTxt: true);
+            foreach (var txt in response.TypedAnswers!) {
+                Settings.Logger.WriteInformation(txt.GetType().Name);
+            }
+        }
+    }
+}

--- a/DnsClientX.Examples/DemoTypedTxtRecords.cs
+++ b/DnsClientX.Examples/DemoTypedTxtRecords.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace DnsClientX.Examples {
+    internal class DemoTypedTxtRecords {
+        public static async Task Example() {
+            using var client = new ClientX(DnsEndpoint.Cloudflare);
+            var response = await client.Resolve("_dmarc.google.com", DnsRecordType.TXT, typedRecords: true);
+            foreach (var typed in response.TypedAnswers!) {
+                Settings.Logger.WriteInformation(typed.GetType().Name);
+            }
+        }
+    }
+}

--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -99,6 +99,12 @@ namespace DnsClientX.PowerShell {
         [Parameter(Mandatory = false, ParameterSetName = "PatternServerName")]
         public SwitchParameter TypedRecords;
 
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternServerName")]
+        public SwitchParameter TypedTxtAsTxt;
+
         /// <summary>
         /// <para type="description">Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 1000 ms (1 second) as defined by <see cref="Configuration.DefaultTimeout"/>. Increase this value for slow networks or unreliable servers.</para>
         /// </summary>
@@ -225,7 +231,7 @@ namespace DnsClientX.PowerShell {
                     var aggregatedResults = new List<DnsResponse>();
                     foreach (string serverName in serverOrder) {
                         _logger.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, serverName);
-                        var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, serverName, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent));
+                        var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, serverName, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                         aggregatedResults.AddRange(result);
                     }
                     results = aggregatedResults;
@@ -233,7 +239,7 @@ namespace DnsClientX.PowerShell {
                     var aggregatedResults = new List<DnsResponse>();
                     foreach (string serverName in serverOrder) {
                         _logger.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, serverName);
-                        var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, serverName, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent));
+                        var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, serverName, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                         aggregatedResults.AddRange(result);
                         if (aggregatedResults.Any(r => r.Status == DnsResponseCode.NoError)) {
                             break;
@@ -243,7 +249,7 @@ namespace DnsClientX.PowerShell {
                 } else {
                     string myServer = serverOrder.First();
                     _logger.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, myServer);
-                    var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, myServer, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent));
+                    var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, myServer, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                     results = result;
                 }
 
@@ -268,10 +274,10 @@ namespace DnsClientX.PowerShell {
                 DnsResponse[] result;
                 if (DnsProvider == null) {
                     _logger.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, "Default");
-                    result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent));
+                    result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                 } else {
                     _logger.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, DnsProvider.Value);
-                    result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, DnsProvider.Value, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent));
+                    result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, DnsProvider.Value, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                 }
 
                 foreach (var record in result) {

--- a/DnsClientX.Tests/TypedRecordsTests.cs
+++ b/DnsClientX.Tests/TypedRecordsTests.cs
@@ -95,5 +95,47 @@ namespace DnsClientX.Tests {
             Assert.Equal(10000d, typed.HorizontalPrecisionMeters);
             Assert.Equal(10d, typed.VerticalPrecisionMeters);
         }
+
+        [Fact]
+        public void Factory_Parses_Dmarc_Record() {
+            var ans = new DnsAnswer { Type = DnsRecordType.TXT, DataRaw = "v=DMARC1; p=none; rua=mailto:example@example.com" };
+            var typed = DnsRecordFactory.Create(ans) as DmarcRecord;
+            Assert.NotNull(typed);
+            Assert.Equal("DMARC1", typed.Tags["v"]);
+            Assert.Equal("none", typed.Tags["p"]);
+        }
+
+        [Fact]
+        public void Factory_Parses_Dkim_Record() {
+            var ans = new DnsAnswer { Type = DnsRecordType.TXT, DataRaw = "v=DKIM1; k=rsa; p=ABC" };
+            var typed = DnsRecordFactory.Create(ans) as DkimRecord;
+            Assert.NotNull(typed);
+            Assert.Equal("DKIM1", typed.Tags["v"]);
+            Assert.Equal("rsa", typed.Tags["k"]);
+        }
+
+        [Fact]
+        public void Factory_Parses_Spf_Record() {
+            var ans = new DnsAnswer { Type = DnsRecordType.SPF, DataRaw = "v=spf1 include:example.com -all" };
+            var typed = DnsRecordFactory.Create(ans) as SpfRecord;
+            Assert.NotNull(typed);
+            Assert.Contains("include:example.com", typed.Mechanisms);
+        }
+
+        [Fact]
+        public void Factory_Parses_KeyValue_Record() {
+            var ans = new DnsAnswer { Type = DnsRecordType.TXT, DataRaw = "foo=bar baz=qux" };
+            var typed = DnsRecordFactory.Create(ans) as KeyValueTxtRecord;
+            Assert.NotNull(typed);
+            Assert.Equal("bar", typed.Tags["foo"]);
+            Assert.Equal("qux", typed.Tags["baz"]);
+        }
+
+        [Fact]
+        public void Factory_Respects_TypedTxtAsTxt() {
+            var ans = new DnsAnswer { Type = DnsRecordType.TXT, DataRaw = "v=spf1 -all" };
+            var typed = DnsRecordFactory.Create(ans, typedTxtAsTxt: true);
+            Assert.IsType<TxtRecord>(typed);
+        }
     }
 }

--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             if (dnsEndpoint == DnsEndpoint.RootServer) {
                 using var client = new ClientX();
                 if (cancellationToken.IsCancellationRequested) {
@@ -40,7 +40,7 @@ namespace DnsClientX {
                 if (cancellationToken.IsCancellationRequested) {
                     return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
                 }
-                var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, returnAllTypes: false, typedRecords: typedRecords, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, returnAllTypes: false, typedRecords: typedRecords, typedTxtAsTxt: typedTxtAsTxt, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return data;
             }
         }
@@ -59,8 +59,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
-        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, typedTxtAsTxt, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             if (dnsEndpoint == DnsEndpoint.RootServer) {
                 var tasks = name.Select(n => {
                     using var client = new ClientX();
@@ -93,7 +93,7 @@ namespace DnsClientX {
                 if (cancellationToken.IsCancellationRequested) {
                     return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
                 }
-                var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, returnAllTypes: false, typedRecords: typedRecords, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, returnAllTypes: false, typedRecords: typedRecords, typedTxtAsTxt: typedTxtAsTxt, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return data;
             }
         }
@@ -112,8 +112,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
-        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsEndpoint, dnsSelectionStrategy, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, typedTxtAsTxt, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -130,13 +130,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(dnsUri, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, returnAllTypes: false, typedRecords: typedRecords, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, returnAllTypes: false, typedRecords: typedRecords, typedTxtAsTxt: typedTxtAsTxt, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -154,8 +154,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
-        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, typedTxtAsTxt, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -171,13 +171,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(dnsUri, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, typedRecords: typedRecords, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, typedRecords: typedRecords, typedTxtAsTxt: typedTxtAsTxt, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -194,8 +194,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsUri, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, typedTxtAsTxt, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -212,13 +212,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
-        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, typedTxtAsTxt: typedTxtAsTxt, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -236,8 +236,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
-        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedTxtAsTxt, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -253,13 +253,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, typedRecords: typedRecords, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, typedRecords: typedRecords, typedTxtAsTxt: typedTxtAsTxt, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -276,13 +276,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(hostName, requestFormat);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, typedTxtAsTxt: typedTxtAsTxt, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -299,8 +299,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, hostName, requestFormat, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, typedTxtAsTxt, cancellationToken).RunSync(cancellationToken);
         }
 
         /// <summary>
@@ -315,13 +315,13 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             using var client = new ClientX(endpoint: dnsEndpoint);
             client.EndpointConfiguration.TimeOut = timeOutMilliseconds;
             if (cancellationToken.IsCancellationRequested) {
                 return await Task.FromCanceled<DnsResponse[]>(cancellationToken).ConfigureAwait(false);
             }
-            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, typedRecords: typedRecords, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var data = await client.Resolve(name, recordType, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, retryOnTransient: retryOnTransient, maxRetries: maxRetries, retryDelayMs: retryDelayMs, typedRecords: typedRecords, typedTxtAsTxt: typedTxtAsTxt, cancellationToken: cancellationToken).ConfigureAwait(false);
             return data;
         }
 
@@ -338,8 +338,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
-        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, CancellationToken cancellationToken = default) {
-            return QueryDns(name, recordType, dnsEndpoint, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, cancellationToken).RunSync(cancellationToken);
+        public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
+            return QueryDns(name, recordType, dnsEndpoint, timeOutMilliseconds, retryOnTransient, maxRetries, retryDelayMs, requestDnsSec, validateDnsSec, typedRecords, typedTxtAsTxt, cancellationToken).RunSync(cancellationToken);
         }
     }
 }

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -42,6 +42,7 @@ namespace DnsClientX {
             int maxRetries = 3,
             int retryDelayMs = 100,
             bool typedRecords = false,
+            bool typedTxtAsTxt = false,
             CancellationToken cancellationToken = default) {
             if (retryOnTransient) {
                 try {
@@ -50,7 +51,7 @@ namespace DnsClientX {
                         : null;
 
                     return await RetryAsync(
-                        () => ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, maxRetries, retryDelayMs, typedRecords, cancellationToken),
+                        () => ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt, cancellationToken),
                         maxRetries,
                         retryDelayMs,
                         beforeRetry,
@@ -60,11 +61,11 @@ namespace DnsClientX {
                     return ex.Response;
                 }
             } else {
-                return await ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, maxRetries, retryDelayMs, typedRecords, cancellationToken).ConfigureAwait(false);
+                return await ResolveInternal(name, type, requestDnsSec, validateDnsSec, returnAllTypes, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task<DnsResponse> ResolveInternal(string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool returnAllTypes, int maxRetries, int retryDelayMs, bool typedRecords, CancellationToken cancellationToken) {
+        private async Task<DnsResponse> ResolveInternal(string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool returnAllTypes, int maxRetries, int retryDelayMs, bool typedRecords, bool typedTxtAsTxt, CancellationToken cancellationToken) {
             cancellationToken.ThrowIfCancellationRequested();
 
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
@@ -157,7 +158,7 @@ namespace DnsClientX {
 
             if (typedRecords && response.Answers != null) {
                 response.TypedAnswers = response.Answers
-                    .Select(a => DnsRecordFactory.Create(a))
+                    .Select(a => DnsRecordFactory.Create(a, typedTxtAsTxt))
                     .Where(o => o != null)
                     .ToArray()!;
             }
@@ -455,8 +456,8 @@ namespace DnsClientX {
         /// <returns>The DNS response.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
-        public DnsResponse ResolveSync(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, bool typedRecords = false) {
-            return Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords).RunSync();
+        public DnsResponse ResolveSync(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, bool typedRecords = false, bool typedTxtAsTxt = false) {
+            return Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt).RunSync();
         }
 
         /// <summary>
@@ -474,10 +475,10 @@ namespace DnsClientX {
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of DNS responses.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
-        public async Task<DnsResponse[]> Resolve(string name, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public async Task<DnsResponse[]> Resolve(string name, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             Task<DnsResponse>[] tasks = new Task<DnsResponse>[types.Length];
             for (int i = 0; i < tasks.Length; i++) {
-                tasks[i] = Resolve(name, types[i], requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, cancellationToken);
+                tasks[i] = Resolve(name, types[i], requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt, cancellationToken);
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -505,8 +506,8 @@ namespace DnsClientX {
         /// <returns>An array of DNS responses.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
-        public DnsResponse[] ResolveSync(string name, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false) {
-            return Resolve(name, types, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords).RunSync();
+        public DnsResponse[] ResolveSync(string name, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false) {
+            return Resolve(name, types, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt).RunSync();
         }
 
         /// <summary>
@@ -522,12 +523,12 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of DNS responses.</returns>
-        public async Task<DnsResponse[]> Resolve(string[] names, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public async Task<DnsResponse[]> Resolve(string[] names, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             var tasks = new List<Task<DnsResponse>>();
 
             foreach (var name in names) {
                 foreach (var type in types) {
-                    tasks.Add(Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, cancellationToken));
+                    tasks.Add(Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt, cancellationToken));
                 }
             }
 
@@ -548,8 +549,8 @@ namespace DnsClientX {
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>An array of DNS responses.</returns>
-        public DnsResponse[] ResolveSync(string[] names, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false) {
-            return Resolve(names, types, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords).RunSync();
+        public DnsResponse[] ResolveSync(string[] names, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false) {
+            return Resolve(names, types, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt).RunSync();
         }
 
         /// <summary>
@@ -565,11 +566,11 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The array of DNS responses from all queries.</returns>
-        public async Task<DnsResponse[]> Resolve(string[] names, DnsRecordType type, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, CancellationToken cancellationToken = default) {
+        public async Task<DnsResponse[]> Resolve(string[] names, DnsRecordType type, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
             var tasks = new List<Task<DnsResponse>>();
 
             foreach (var name in names) {
-                tasks.Add(Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, cancellationToken));
+                tasks.Add(Resolve(name, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt, cancellationToken));
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -589,8 +590,8 @@ namespace DnsClientX {
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <returns>An array of DNS responses.</returns>
-        public DnsResponse[] ResolveSync(string[] names, DnsRecordType type, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false) {
-            return Resolve(names, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords).RunSync();
+        public DnsResponse[] ResolveSync(string[] names, DnsRecordType type, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false) {
+            return Resolve(names, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt).RunSync();
         }
 
         /// <summary>
@@ -618,9 +619,10 @@ namespace DnsClientX {
             int maxRetries = 3,
             int retryDelayMs = 200,
             bool typedRecords = false,
+            bool typedTxtAsTxt = false,
             CancellationToken cancellationToken = default) {
             string[] names = ExpandPattern(pattern).ToArray();
-            return await Resolve(names, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, cancellationToken).ConfigureAwait(false);
+            return await Resolve(names, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt, cancellationToken).ConfigureAwait(false);
         }
 
         public static IEnumerable<string> ExpandPattern(string pattern) {

--- a/DnsClientX/DnsClientX.ResolveFirst.cs
+++ b/DnsClientX/DnsClientX.ResolveFirst.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the first DNS answer of the provided type, or null if no such answer exists.</returns>
-        public async Task<DnsAnswer?> ResolveFirst(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
+        public async Task<DnsAnswer?> ResolveFirst(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
             DnsResponse res = await Resolve(
                 name,
                 type,
@@ -35,6 +35,7 @@ namespace DnsClientX {
                 validateDnsSec,
                 returnAllTypes: false,
                 typedRecords: typedRecords,
+                typedTxtAsTxt: typedTxtAsTxt,
                 retryOnTransient: retryOnTransient,
                 maxRetries: maxRetries,
                 retryDelayMs: retryDelayMs,
@@ -55,8 +56,8 @@ namespace DnsClientX {
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The first DNS answer of the provided type, or null if no such answer exists.</returns>
-        public DnsAnswer? ResolveFirstSync(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
-            return ResolveFirst(name, type, requestDnsSec, validateDnsSec, typedRecords, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
+        public DnsAnswer? ResolveFirstSync(string name, DnsRecordType type = DnsRecordType.A, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 100, CancellationToken cancellationToken = default) {
+            return ResolveFirst(name, type, requestDnsSec, validateDnsSec, typedRecords, typedTxtAsTxt, retryOnTransient, maxRetries, retryDelayMs, cancellationToken).RunSync();
         }
     }
 }

--- a/DnsClientX/DnsRecords/DkimRecord.cs
+++ b/DnsClientX/DnsRecords/DkimRecord.cs
@@ -1,0 +1,35 @@
+namespace DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Represents a parsed DKIM TXT record.
+/// </summary>
+public sealed class DkimRecord {
+    /// <summary>Gets the record tags.</summary>
+    public IReadOnlyDictionary<string, string> Tags { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="DkimRecord"/> class.</summary>
+    /// <param name="tags">Tags parsed from the record.</param>
+    public DkimRecord(IReadOnlyDictionary<string, string> tags) => Tags = tags;
+
+    /// <summary>Attempts to parse a DKIM record.</summary>
+    /// <param name="record">Raw TXT record.</param>
+    /// <param name="result">Parsed record.</param>
+    /// <returns><c>true</c> if parsing succeeded.</returns>
+    public static bool TryParse(string record, out DkimRecord? result) {
+        result = null;
+        if (string.IsNullOrWhiteSpace(record) || !record.StartsWith("v=DKIM1", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        var tags = record.Split(';')
+            .Select(t => t.Trim())
+            .Where(t => t.Length > 0)
+            .Select(t => t.Split('=', 2))
+            .Where(parts => parts.Length >= 1)
+            .ToDictionary(parts => parts[0], parts => parts.Length > 1 ? parts[1] : string.Empty, StringComparer.OrdinalIgnoreCase);
+        result = new DkimRecord(tags);
+        return true;
+    }
+}

--- a/DnsClientX/DnsRecords/DmarcRecord.cs
+++ b/DnsClientX/DnsRecords/DmarcRecord.cs
@@ -1,0 +1,35 @@
+namespace DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Represents a parsed DMARC TXT record.
+/// </summary>
+public sealed class DmarcRecord {
+    /// <summary>Gets the record tags.</summary>
+    public IReadOnlyDictionary<string, string> Tags { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="DmarcRecord"/> class.</summary>
+    /// <param name="tags">Tags parsed from the record.</param>
+    public DmarcRecord(IReadOnlyDictionary<string, string> tags) => Tags = tags;
+
+    /// <summary>Attempts to parse a DMARC record.</summary>
+    /// <param name="record">Raw TXT record.</param>
+    /// <param name="result">Parsed record.</param>
+    /// <returns><c>true</c> if parsing succeeded.</returns>
+    public static bool TryParse(string record, out DmarcRecord? result) {
+        result = null;
+        if (string.IsNullOrWhiteSpace(record) || !record.StartsWith("v=DMARC1", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        var tags = record.Split(';')
+            .Select(t => t.Trim())
+            .Where(t => t.Length > 0)
+            .Select(t => t.Split('=', 2))
+            .Where(parts => parts.Length >= 1)
+            .ToDictionary(parts => parts[0], parts => parts.Length > 1 ? parts[1] : string.Empty, StringComparer.OrdinalIgnoreCase);
+        result = new DmarcRecord(tags);
+        return true;
+    }
+}

--- a/DnsClientX/DnsRecords/KeyValueTxtRecord.cs
+++ b/DnsClientX/DnsRecords/KeyValueTxtRecord.cs
@@ -1,0 +1,41 @@
+namespace DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Represents a TXT record containing key/value tags.
+/// </summary>
+public sealed class KeyValueTxtRecord {
+    /// <summary>Gets the record tags.</summary>
+    public IReadOnlyDictionary<string, string> Tags { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="KeyValueTxtRecord"/> class.</summary>
+    /// <param name="tags">Tags parsed from the record.</param>
+    public KeyValueTxtRecord(IReadOnlyDictionary<string, string> tags) => Tags = tags;
+
+    /// <summary>Attempts to parse a key/value TXT record.</summary>
+    /// <param name="record">Raw TXT record.</param>
+    /// <param name="result">Parsed record.</param>
+    /// <returns><c>true</c> if parsing succeeded.</returns>
+    public static bool TryParse(string record, out KeyValueTxtRecord? result) {
+        result = null;
+        if (string.IsNullOrWhiteSpace(record)) {
+            return false;
+        }
+        var parts = record.Split(new[] { ';', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var part in parts) {
+            var kv = part.Split('=', 2);
+            if (kv.Length != 2) {
+                return false;
+            }
+            tags[kv[0]] = kv[1];
+        }
+        if (tags.Count == 0) {
+            return false;
+        }
+        result = new KeyValueTxtRecord(tags);
+        return true;
+    }
+}

--- a/DnsClientX/DnsRecords/SpfRecord.cs
+++ b/DnsClientX/DnsRecords/SpfRecord.cs
@@ -1,0 +1,29 @@
+namespace DnsClientX;
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents a parsed SPF TXT record.
+/// </summary>
+public sealed class SpfRecord {
+    /// <summary>Gets the SPF mechanisms.</summary>
+    public IReadOnlyList<string> Mechanisms { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="SpfRecord"/> class.</summary>
+    /// <param name="mechanisms">Mechanisms parsed from the record.</param>
+    public SpfRecord(IReadOnlyList<string> mechanisms) => Mechanisms = mechanisms;
+
+    /// <summary>Attempts to parse an SPF record.</summary>
+    /// <param name="record">Raw TXT record.</param>
+    /// <param name="result">Parsed record.</param>
+    /// <returns><c>true</c> if parsing succeeded.</returns>
+    public static bool TryParse(string record, out SpfRecord? result) {
+        result = null;
+        if (string.IsNullOrWhiteSpace(record) || !record.StartsWith("v=spf1", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        var mechanisms = record.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        result = new SpfRecord(mechanisms);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `KeyValueTxtRecord` for generic TXT parsing
- extend `DnsRecordFactory.Create` with `typedTxtAsTxt` toggle
- support the toggle across resolve/query helpers and PowerShell cmdlet
- add tests for new record and option
- provide example of disabling typed TXT parsing

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: network unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68760a4d72e0832ea8d116a2731d5104