### PR TITLE
Fix culture invariant filtering

### DIFF
--- a/DnsClientX.Tests/FilterAnswersAccentCultureTests.cs
+++ b/DnsClientX.Tests/FilterAnswersAccentCultureTests.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class FilterAnswersAccentCultureTests {
+        private static DnsAnswer CreateTxt(string data) => new() { Name = "example.com", Type = DnsRecordType.TXT, TTL = 300, DataRaw = data };
+        private static DnsAnswer CreateCname(string data) => new() { Name = "example.com", Type = DnsRecordType.CNAME, TTL = 300, DataRaw = data };
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("tr-TR")]
+        public void FilterAnswers_Txt_Accents_AcrossCultures(string culture) {
+            var client = new ClientX();
+            MethodInfo method = typeof(ClientX).GetMethod("FilterAnswers", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] { CreateTxt("CAF\u00C9\nOTHER") };
+
+            var original = Thread.CurrentThread.CurrentCulture;
+            try {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+                var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, "café", DnsRecordType.TXT })!;
+                Assert.Single(result);
+                Assert.Equal("CAF\u00C9", result[0].Data);
+            } finally {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("tr-TR")]
+        public void FilterAnswers_NonTxt_Accents_AcrossCultures(string culture) {
+            var client = new ClientX();
+            MethodInfo method = typeof(ClientX).GetMethod("FilterAnswers", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var answers = new[] { CreateCname("r\u00E9sum\u00E9.example.com") };
+
+            var original = Thread.CurrentThread.CurrentCulture;
+            try {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+                var result = (DnsAnswer[])method.Invoke(client, new object[] { answers, "R\u00C9SUM\u00C9", DnsRecordType.CNAME })!;
+                Assert.Single(result);
+                Assert.Equal("r\u00E9sum\u00E9.example.com", result[0].Data);
+            } finally {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+    }
+}

--- a/DnsClientX/DnsClientX.ResolveFilter.cs
+++ b/DnsClientX/DnsClientX.ResolveFilter.cs
@@ -144,7 +144,8 @@ namespace DnsClientX {
                 if (type == DnsRecordType.TXT && answer.Type == DnsRecordType.TXT) {
                     // For TXT records, check if any line contains the filter
                     var lines = answer.Data.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
-                    var matchingLines = lines.Where(line => line.ToLower().Contains(filter.ToLower())).ToArray();
+                    var matchingLines = lines.Where(line =>
+                        line.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToArray();
 
                     if (matchingLines.Length > 0) {
                         // Create a new answer with only the matching lines
@@ -160,7 +161,7 @@ namespace DnsClientX {
                     }
                 } else {
                     // For non-TXT records, use the original logic
-                    if (answer.Data.ToLower().Contains(filter.ToLower())) {
+                    if (answer.Data.Contains(filter, StringComparison.OrdinalIgnoreCase)) {
                         filteredAnswers.Add(answer);
                     }
                 }
@@ -231,12 +232,13 @@ namespace DnsClientX {
 
                 if (type == DnsRecordType.TXT && answer.Type == DnsRecordType.TXT) {
                     var lines = answer.Data.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
-                    var matchingLines = lines.Where(line => line.ToLower().Contains(filter.ToLower())).ToArray();
+                    var matchingLines = lines.Where(line =>
+                        line.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToArray();
                     if (matchingLines.Length > 0) {
                         return true;
                     }
                 } else {
-                    if (answer.Data.ToLower().Contains(filter.ToLower())) {
+                    if (answer.Data.Contains(filter, StringComparison.OrdinalIgnoreCase)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
## Summary
- fix filtering logic with `StringComparison.OrdinalIgnoreCase`
- add tests for accented characters across cultures

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~FilterAnswersAccentCultureTests`

------
https://chatgpt.com/codex/tasks/task_e_6876a04fa6ec832eb9bf54c591e1b294