### PR TITLE
Add TTL argument validation

### DIFF
--- a/DnsClientX.Examples/DemoDnsUpdate.cs
+++ b/DnsClientX.Examples/DemoDnsUpdate.cs
@@ -14,6 +14,14 @@ namespace DnsClientX.Examples {
         }
 
         /// <summary>
+        /// Demonstrates adding a record to a zone with a custom TTL.
+        /// </summary>
+        public static async Task ExampleAddWithTtl() {
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP);
+            await client.UpdateRecordAsync("example.com", "www.example.com", DnsRecordType.A, "1.2.3.4", 600);
+        }
+
+        /// <summary>
         /// Demonstrates deleting a record from a zone.
         /// </summary>
         public static async Task ExampleDelete() {

--- a/DnsClientX.Tests/DnsUpdateTests.cs
+++ b/DnsClientX.Tests/DnsUpdateTests.cs
@@ -96,5 +96,14 @@ namespace DnsClientX.Tests {
             await Assert.ThrowsAsync<DnsClientException>(() => client.UpdateRecordAsync("example.com", "www.example.com", DnsRecordType.A, "1.2.3.4"));
             await server.Task;
         }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public async Task UpdateRecordAsync_InvalidTtl_Throws(int ttl) {
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverTCP);
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                () => client.UpdateRecordAsync("example.com", "www.example.com", DnsRecordType.A, "1.2.3.4", ttl));
+        }
     }
 }

--- a/DnsClientX/DnsClientX.Update.cs
+++ b/DnsClientX/DnsClientX.Update.cs
@@ -24,6 +24,7 @@ namespace DnsClientX {
         public async Task<DnsResponse> UpdateRecordAsync(string zone, string name, DnsRecordType type, string data, int ttl = 300, CancellationToken cancellationToken = default) {
             if (string.IsNullOrEmpty(zone)) throw new ArgumentNullException(nameof(zone));
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
+            if (ttl <= 0) throw new ArgumentOutOfRangeException(nameof(ttl));
             EndpointConfiguration.SelectHostNameStrategy();
             DnsResponse response;
             if (EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsJSONPOST) {


### PR DESCRIPTION
## Summary
- throw `ArgumentOutOfRangeException` when TTL is 0 or less
- add an example showing custom TTL
- test TTL parameter validation in `UpdateRecordAsync`

## Testing
- `dotnet test` *(fails: The tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6876a07424d8832ebc66b78f8fa73a9c