### PR TITLE
Fix AllServers validation

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -196,6 +196,9 @@ namespace DnsClientX.PowerShell {
             if (TimeOut <= 0) {
                 throw new ArgumentOutOfRangeException(nameof(TimeOut), "TimeOut must be greater than zero.");
             }
+            if (AllServers.IsPresent && Server.Count == 0) {
+                throw new InvalidOperationException("AllServers requires at least one server.");
+            }
             var namesToUse = Pattern is null ? Name : ClientX.ExpandPattern(Pattern).ToArray();
             string names = string.Join(", ", namesToUse);
             string types = string.Join(", ", Type);

--- a/Module/Tests/ResolveDns.Tests.ps1
+++ b/Module/Tests/ResolveDns.Tests.ps1
@@ -5,6 +5,10 @@ Describe 'Resolve-Dns cmdlet' {
         { Resolve-Dns -Name 'example.com' -TimeOut 0 -ErrorAction Stop } | Should -Throw -ExceptionType System.ArgumentOutOfRangeException
     }
 
+    It 'Throws when AllServers is used without Server' {
+        { Resolve-Dns -Name 'example.com' -AllServers -ErrorAction Stop } | Should -Throw -ExceptionType System.InvalidOperationException
+    }
+
     It 'Removes duplicate servers before processing' {
         $result = Resolve-Dns -Name 'example.com' -Server @('127.0.0.1','127.0.0.1') -AllServers -FullResponse -TimeOut 10 -ErrorAction SilentlyContinue
         $result.Count | Should -Be 1


### PR DESCRIPTION
## Summary
- throw InvalidOperationException when `AllServers` used without a server
- test error condition in Pester tests

## Testing
- `dotnet test` *(fails: UDP query timed out)*
- `Invoke-Pester -Path Module/Tests -CI`

------
https://chatgpt.com/codex/tasks/task_e_6876a09cee48832e9d4620bab18bf78a