### PR TITLE
Fix TcpClient disposal logic

### DIFF
--- a/DnsClientX.Tests/TcpDisposeCountTests.cs
+++ b/DnsClientX.Tests/TcpDisposeCountTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class TcpDisposeCountTests {
+        private class CountingTcpClient : TcpClient {
+            private readonly Action _onDispose;
+            public CountingTcpClient(Action onDispose) => _onDispose = onDispose;
+            protected override void Dispose(bool disposing) {
+                base.Dispose(disposing);
+                _onDispose();
+            }
+        }
+
+        private static byte[] CreateDnsHeader() {
+            byte[] bytes = new byte[12];
+            ushort id = 0x1234;
+            bytes[0] = (byte)(id >> 8);
+            bytes[1] = (byte)(id & 0xFF);
+            ushort flags = 0x8180;
+            bytes[2] = (byte)(flags >> 8);
+            bytes[3] = (byte)(flags & 0xFF);
+            return bytes;
+        }
+
+        private static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task RunTcpServerAsync(int port, CancellationToken token) {
+            byte[] response = CreateDnsHeader();
+            TcpListener listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream stream = client.GetStream();
+            byte[] len = new byte[2];
+            await stream.ReadAsync(len, 0, 2, token);
+            if (BitConverter.IsLittleEndian) Array.Reverse(len);
+            int length = BitConverter.ToUInt16(len, 0);
+            byte[] buffer = new byte[length];
+            await stream.ReadAsync(buffer, 0, length, token);
+            byte[] prefix = BitConverter.GetBytes((ushort)response.Length);
+            if (BitConverter.IsLittleEndian) Array.Reverse(prefix);
+            await stream.WriteAsync(prefix, 0, prefix.Length, token);
+            await stream.WriteAsync(response, 0, response.Length, token);
+            listener.Stop();
+        }
+
+        [Fact]
+        public async Task ResolveWireFormatTcp_ShouldDisposeConnection() {
+            int disposed = 0;
+            var prevFactory = DnsWireResolveTcp.TcpClientFactory;
+            try {
+                DnsWireResolveTcp.TcpClientFactory = () => new CountingTcpClient(() => disposed++);
+                int port = GetFreePort();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                var serverTask = RunTcpServerAsync(port, cts.Token);
+
+                var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port };
+                Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
+                MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
+                var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+                await task;
+                await serverTask;
+
+                Assert.Equal(1, disposed);
+            } finally {
+                DnsWireResolveTcp.TcpClientFactory = prevFactory;
+            }
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -7,6 +7,7 @@ using System.Threading;
 
 namespace DnsClientX {
     internal class DnsWireResolveTcp {
+        internal static Func<TcpClient> TcpClientFactory { get; set; } = () => new TcpClient();
         /// <summary>
         /// Sends a DNS query in wire format using DNS over TCP (53) and returns the response.
         /// </summary>
@@ -97,7 +98,7 @@ namespace DnsClientX {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Raw DNS response bytes.</returns>
         private static async Task<byte[]> SendQueryOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
-            var tcpClient = new TcpClient();
+            using var tcpClient = TcpClientFactory();
             NetworkStream? stream = null;
             try {
                 // Connect to the server with timeout
@@ -158,8 +159,6 @@ namespace DnsClientX {
 #else
                 stream?.Dispose();
 #endif
-                tcpClient.Close();
-                tcpClient.Dispose();
             }
         }
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireUpdateTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireUpdateTcp.cs
@@ -10,7 +10,7 @@ namespace DnsClientX {
     /// </summary>
     internal static class DnsWireUpdateTcp {
         private static async Task<byte[]> SendMessageOverTcp(byte[] message, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
-            var tcpClient = new TcpClient();
+            using TcpClient tcpClient = DnsWireResolveTcp.TcpClientFactory();
             NetworkStream? stream = null;
             try {
                 await ConnectAsync(tcpClient, dnsServer, port, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
@@ -32,8 +32,6 @@ namespace DnsClientX {
 #else
                 stream?.Dispose();
 #endif
-                tcpClient.Close();
-                tcpClient.Dispose();
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure TcpClient creation uses a using declaration
- remove explicit disposal statements when using blocks handle cleanup
- expose a factory for TcpClient creation so tests can track disposal
- test connection disposal count

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --filter FullyQualifiedName~TcpDisposeCountTests.ResolveWireFormatTcp_ShouldDisposeConnection`

------
https://chatgpt.com/codex/tasks/task_e_6876a06767d0832e96ff619934303f46