### PR TITLE
Enable DNS server injection for testing

### DIFF
--- a/DnsClientX.Tests/ClientXBuilderTests.cs
+++ b/DnsClientX.Tests/ClientXBuilderTests.cs
@@ -75,13 +75,11 @@ namespace DnsClientX.Tests {
         /// </summary>
         [Fact]
         public void BuildShouldThrowOnInvalidHostname() {
-            var field = typeof(SystemInformation).GetField("cachedDnsServers", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var original = (Lazy<List<string>>)field.GetValue(null)!;
+            SystemInformation.SetDnsServerProvider(() => new List<string> { "inv@lid_host" });
             try {
-                field.SetValue(null, new Lazy<List<string>>(() => new List<string> { "inv@lid_host" }, System.Threading.LazyThreadSafetyMode.ExecutionAndPublication));
                 Assert.Throws<ArgumentException>(() => new ClientXBuilder().WithEndpoint(DnsEndpoint.System).Build());
             } finally {
-                field.SetValue(null, original);
+                SystemInformation.SetDnsServerProvider(null);
             }
         }
 


### PR DESCRIPTION
## Summary
- support injecting DNS server list into `SystemInformation`
- use injection hook in `CliDnssecFlagTests` and `ClientXBuilderTests`
- remove test collection from `CliDnssecFlagTests`

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6878019d4ae0832e9af5977f4c0b7890