### PR TITLE
Fix thread safety in SystemInformation cache refresh

### DIFF
--- a/DnsClientX.Tests/GetDnsFromActiveNetworkCardConcurrencyTests.cs
+++ b/DnsClientX.Tests/GetDnsFromActiveNetworkCardConcurrencyTests.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class GetDnsFromActiveNetworkCardConcurrencyTests {
+        [Fact]
+        public async Task RefreshConcurrentCalls_ShouldReturnConsistentResults() {
+            var expected = new List<string> { "1.1.1.1", "8.8.8.8" };
+            SystemInformation.SetDnsServerProvider(() => new List<string>(expected));
+            try {
+                var tasks = Enumerable.Range(0, 20)
+                    .Select(_ => Task.Run(() => SystemInformation.GetDnsFromActiveNetworkCard(refresh: true)));
+                var results = await Task.WhenAll(tasks);
+
+                foreach (var result in results) {
+                    Assert.Equal(expected, result);
+                }
+            } finally {
+                SystemInformation.SetDnsServerProvider(null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add locking around cached DNS refresh logic
- test concurrent cache refresh

## Testing
- `dotnet build --no-restore`
- `dotnet test --verbosity normal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68780773296c832e885dd01ac103a214