### PR TITLE
Fix port selection for CLI DNSSEC tests

### DIFF
--- a/DnsClientX.Cli/Program.cs
+++ b/DnsClientX.Cli/Program.cs
@@ -109,6 +109,10 @@ namespace DnsClientX.Cli {
 
             try {
                 await using var client = new ClientX(endpoint);
+                string? envPort = Environment.GetEnvironmentVariable("DNSCLIENTX_CLI_PORT");
+                if (int.TryParse(envPort, out int customPort) && customPort > 0) {
+                    client.EndpointConfiguration.Port = customPort;
+                }
                 if (wirePost &&
                     (client.EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttps ||
                      client.EndpointConfiguration.RequestFormat == DnsRequestFormat.DnsOverHttpsPOST ||

--- a/DnsClientX.Tests/TestUtilities.cs
+++ b/DnsClientX.Tests/TestUtilities.cs
@@ -1,0 +1,14 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace DnsClientX.Tests {
+    internal static class TestUtilities {
+        public static int GetFreePort() {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `TestUtilities.GetFreePort()` for tests
- let CLI respect optional `DNSCLIENTX_CLI_PORT` env var
- update `CliDnssecFlagTests` to use a dynamic port

## Testing
- `dotnet test` *(fails: ConnectFailure errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878a01068c4832ebf3fd3115365f810