### PR TITLE
Fix malformed XML comment

### DIFF
--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -199,7 +199,6 @@ namespace DnsClientX.Tests {
         /// <param name="excludedEndpoints">Providers to skip.</param>
         [InlineData("reddit.com", DnsRecordType.SOA)]
         // github.com has a lot of TXT records, including multiline, however google dns doesn't do multiline TXT records and delivers them as one line
-        /// <summary>
         [InlineData("microsoft.com", DnsRecordType.MX)]
 
         [InlineData("google.com", DnsRecordType.MX)]


### PR DESCRIPTION
## Summary
- fix stray `<summary>` tag in `CompareProvidersResolve` test

## Testing
- `dotnet build DnsClientX.sln --no-incremental --nologo -warnaserror` *(fails: CS8605 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6878ad61ade8832e97ca4152594afb51