### PR TITLE
Fix Do not use warnings

### DIFF
--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -107,7 +107,7 @@ namespace DnsClientX.Tests {
 
             if (failureRate > 0.2) { // More than 20% of providers failing
                 var allIssues = failedProviders.Concat(inconsistentProviders);
-                Assert.True(false, $"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
+                Assert.Fail($"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
             } else if (problematicProviders > 0) {
                 output.WriteLine($"✅ Acceptable failure rate: {problematicProviders}/{totalProviders} providers ({failureRate:P0}) have issues - likely transient");
             }

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -101,7 +101,7 @@ namespace DnsClientX.Tests {
 
             if (failureRate > 0.2) { // More than 20% of providers failing
                 var allIssues = failedProviders.Concat(inconsistentProviders);
-                Assert.True(false, $"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
+                Assert.Fail($"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
             } else if (problematicProviders > 0) {
                 output.WriteLine($"✅ Acceptable failure rate: {problematicProviders}/{totalProviders} providers ({failureRate:P0}) have issues - likely transient");
             }

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -85,7 +85,7 @@ namespace DnsClientX.Tests {
 
             if (failureRate > 0.2) { // More than 20% of providers failing
                 var allIssues = failedProviders.Concat(inconsistentProviders);
-                Assert.True(false, $"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
+                Assert.Fail($"Too many providers ({problematicProviders}/{totalProviders}, {failureRate:P0}) have issues: {string.Join(", ", allIssues)}");
             } else if (problematicProviders > 0) {
                 output.WriteLine($"✅ Acceptable failure rate: {problematicProviders}/{totalProviders} providers ({failureRate:P0}) have issues - likely transient");
             }

--- a/DnsClientX.Tests/Quad9ReliabilityFix.cs
+++ b/DnsClientX.Tests/Quad9ReliabilityFix.cs
@@ -87,7 +87,7 @@ namespace DnsClientX.Tests {
 
                 } catch (Exception ex) {
                     output.WriteLine($"{provider}: ❌ Exception - {ex.GetType().Name}: {ex.Message}");
-                    Assert.True(false, $"{provider} threw exception: {ex.Message}");
+                    Assert.Fail($"{provider} threw exception: {ex.Message}");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- update tests to replace `Assert.True(false)` with `Assert.Fail`

## Testing
- `dotnet build DnsClientX.sln --no-incremental`

------
https://chatgpt.com/codex/tasks/task_e_6878ad328520832e83e730234ad0318b