### PR TITLE
Add XML docs for tests and cmdlet

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -99,6 +99,11 @@ namespace DnsClientX.PowerShell {
         [Parameter(Mandatory = false, ParameterSetName = "PatternServerName")]
         public SwitchParameter TypedRecords;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether TXT records should be
+        /// returned as raw text records even when <see cref="TypedRecords"/> is
+        /// specified.
+        /// </summary>
         [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]

--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -37,11 +37,11 @@ namespace DnsClientX.Tests {
         [InlineData("microsoft.com", DnsRecordType.NS, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
 
         [InlineData("google.com", DnsRecordType.MX, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
+        [InlineData("108.138.7.68", DnsRecordType.PTR, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
+        [InlineData("sip2sip.info", DnsRecordType.NAPTR, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         /// <summary>
         /// Performs a comparison of DNS responses across multiple providers.
         /// </summary>
-        [InlineData("108.138.7.68", DnsRecordType.PTR, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
-        [InlineData("sip2sip.info", DnsRecordType.NAPTR, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         public async Task CompareRecordsImproved(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -191,12 +191,6 @@ namespace DnsClientX.Tests {
         // lets try different sites
         [InlineData("reddit.com", DnsRecordType.A)]
         [InlineData("reddit.com", DnsRecordType.CAA)]
-        /// <summary>
-        /// Legacy comparison method checking records across providers without additional diagnostics.
-        /// </summary>
-        /// <param name="name">Domain name to resolve.</param>
-        /// <param name="resourceRecordType">Record type.</param>
-        /// <param name="excludedEndpoints">Providers to skip.</param>
         [InlineData("reddit.com", DnsRecordType.SOA)]
         // github.com has a lot of TXT records, including multiline, however google dns doesn't do multiline TXT records and delivers them as one line
         [InlineData("microsoft.com", DnsRecordType.MX)]
@@ -206,8 +200,11 @@ namespace DnsClientX.Tests {
         [InlineData("108.138.7.68", DnsRecordType.PTR)]
         [InlineData("sip2sip.info", DnsRecordType.NAPTR)]
         /// <summary>
-        /// Legacy implementation used to compare responses between providers.
+        /// Legacy comparison method checking records across providers without additional diagnostics.
         /// </summary>
+        /// <param name="name">Domain name to resolve.</param>
+        /// <param name="resourceRecordType">Record type.</param>
+        /// <param name="excludedEndpoints">Providers to skip.</param>
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -31,13 +31,13 @@ namespace DnsClientX.Tests {
         [InlineData("reddit.com", DnsRecordType.CAA, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("reddit.com", DnsRecordType.SOA, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("github.com", DnsRecordType.TXT, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
-        /// <summary>
-        /// Compares results returned from multiple providers using <see cref="ClientX.ResolveAll"/>.
-        /// </summary>
         [InlineData("microsoft.com", DnsRecordType.MX, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("microsoft.com", DnsRecordType.NS, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("google.com", DnsRecordType.MX, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("_25._tcp.mail.ietf.org", DnsRecordType.TLSA, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
+        /// <summary>
+        /// Compares results returned from multiple providers using <see cref="ClientX.ResolveAll"/>.
+        /// </summary>
         public async Task CompareRecordsImproved(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 

--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -37,10 +37,10 @@ namespace DnsClientX.Tests {
         }
 #endif
 
-        [Fact]
         /// <summary>
         /// Ensures that calling <see cref="ClientX.Dispose"/> does not dispose the underlying <see cref="HttpClient"/> twice.
         /// </summary>
+        [Fact]
         public void Client_Dispose_ShouldNotDisposeHttpClientTwice() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.com") };
@@ -60,10 +60,10 @@ namespace DnsClientX.Tests {
             Assert.Equal(1, handler.DisposeCount);
         }
 
-        [Fact]
         /// <summary>
         /// Verifies that disposing <see cref="ClientX"/> does not dispose the HTTP handler multiple times.
         /// </summary>
+        [Fact]
         public void Client_Dispose_ShouldNotDisposeHandlerTwice() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -82,10 +82,10 @@ namespace DnsClientX.Tests {
             Assert.Equal(1, handler.DisposeCount);
         }
 
-        [Fact]
         /// <summary>
         /// Ensures the asynchronous dispose method does not dispose the <see cref="HttpClient"/> twice.
         /// </summary>
+        [Fact]
         public async Task Client_DisposeAsync_ShouldNotDisposeHttpClientTwice() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -102,10 +102,10 @@ namespace DnsClientX.Tests {
             Assert.Equal(1, handler.DisposeCount);
         }
 
-        [Fact]
         /// <summary>
         /// Checks that <see cref="ClientX.DisposeAsync"/> does not dispose the HTTP handler more than once.
         /// </summary>
+        [Fact]
         public async Task Client_DisposeAsync_ShouldNotDisposeHandlerTwice() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -124,10 +124,10 @@ namespace DnsClientX.Tests {
             Assert.Equal(1, handler.DisposeCount);
         }
 
-        [Fact]
         /// <summary>
         /// Ensures that concurrent calls to <see cref="ClientX.Dispose"/> only dispose once.
         /// </summary>
+        [Fact]
         public async Task Client_Dispose_CalledConcurrently_ShouldOnlyDisposeOnce() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -148,10 +148,10 @@ namespace DnsClientX.Tests {
             Assert.Equal(1, handler.DisposeCount);
         }
 
-        [Fact]
         /// <summary>
         /// Ensures concurrent invocations of <see cref="ClientX.DisposeAsync"/> only dispose once.
         /// </summary>
+        [Fact]
         public async Task Client_DisposeAsync_CalledConcurrently_ShouldOnlyDisposeOnce() {
             var handler = new TrackingHandler();
             var customClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
@@ -172,10 +172,10 @@ namespace DnsClientX.Tests {
             Assert.Equal(1, handler.DisposeCount);
         }
 
-        [Fact]
         /// <summary>
         /// Validates that the disposal counter is incremented when <see cref="ClientX.DisposeAsync"/> is called.
         /// </summary>
+        [Fact]
         public async Task Client_DisposeAsync_ShouldIncrementDisposalCount() {
             ClientX.DisposalCount = 0;
             await using var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
@@ -186,10 +186,10 @@ namespace DnsClientX.Tests {
         }
 
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-        [Fact]
         /// <summary>
         /// Tests that asynchronous disposal prefers calling <see cref="IAsyncDisposable.DisposeAsync"/> on the handler when available.
         /// </summary>
+        [Fact]
         public async Task Client_DisposeAsync_ShouldPreferAsyncHandlerDisposal() {
             var handler = new TrackingAsyncHandler();
             var customClient = new HttpClient(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.com") };
@@ -210,10 +210,10 @@ namespace DnsClientX.Tests {
         }
 #endif
 
-        [Fact]
         /// <summary>
         /// Ensures the list tracking disposed clients is cleared upon disposal.
         /// </summary>
+        [Fact]
         public void Client_Dispose_ShouldClearDisposedClientsList() {
             var clientX = new ClientX("example.com", DnsRequestFormat.DnsOverHttps);
 

--- a/DnsClientX.Tests/DnsAnswerMinimalTests.cs
+++ b/DnsClientX.Tests/DnsAnswerMinimalTests.cs
@@ -5,10 +5,10 @@ namespace DnsClientX.Tests {
     /// Tests for the lightweight <see cref="DnsAnswerMinimal"/> structure.
     /// </summary>
     public class DnsAnswerMinimalTests {
-        [Fact]
         /// <summary>
         /// Verifies that explicit conversion from <see cref="DnsAnswer"/> copies all fields.
         /// </summary>
+        [Fact]
         public void ExplicitConversionCopiesFields() {
             var answer = new DnsAnswer {
                 Name = "example.com",
@@ -25,10 +25,10 @@ namespace DnsClientX.Tests {
             Assert.Equal("1.1.1.1", minimal.Data);
         }
 
-        [Fact]
         /// <summary>
         /// Checks that converting an array of <see cref="DnsAnswer"/> objects to <see cref="DnsAnswerMinimal"/> produces matching elements.
         /// </summary>
+        [Fact]
         public void ConvertFromDnsAnswerArrayConvertsAll() {
             var answers = new[] {
                 new DnsAnswer { Name = "a.com", Type = DnsRecordType.A, TTL = 60, DataRaw = "1.1.1.1" },

--- a/DnsClientX.Tests/DnsClientExceptionTests.cs
+++ b/DnsClientX.Tests/DnsClientExceptionTests.cs
@@ -1,7 +1,13 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for the <see cref="DnsClientException"/> type.
+    /// </summary>
     public class DnsClientExceptionTests {
+        /// <summary>
+        /// Ensures the exception message includes details about the endpoint.
+        /// </summary>
         [Fact]
         public void MessageIncludesEndpointDetails() {
             var response = new DnsResponse {
@@ -24,6 +30,9 @@ namespace DnsClientX.Tests {
             Assert.Contains(nameof(DnsRequestFormat.DnsOverHttps), ex.Message);
         }
 
+        /// <summary>
+        /// Ensures the message remains unchanged when no endpoint details are provided.
+        /// </summary>
         [Fact]
         public void MessageWithoutEndpointDetailsUnchanged() {
             var response = new DnsResponse { Status = DnsResponseCode.ServerFailure };

--- a/DnsClientX.Tests/DnsEndpointDescriptionTests.cs
+++ b/DnsClientX.Tests/DnsEndpointDescriptionTests.cs
@@ -3,7 +3,13 @@ using Xunit;
 using DnsClientX;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for extension methods on <see cref="DnsEndpoint"/>.
+    /// </summary>
     public class DnsEndpointDescriptionTests {
+        /// <summary>
+        /// Ensures each endpoint has a non-empty description.
+        /// </summary>
         [Fact]
         public void AllEndpointsHaveDescriptions() {
             foreach (DnsEndpoint ep in Enum.GetValues(typeof(DnsEndpoint))) {

--- a/DnsClientX.Tests/DnsEndpointExtensionsTests.cs
+++ b/DnsClientX.Tests/DnsEndpointExtensionsTests.cs
@@ -3,7 +3,13 @@ using System.Linq;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for <see cref="DnsEndpointExtensions"/> helper methods.
+    /// </summary>
     public class DnsEndpointExtensionsTests {
+        /// <summary>
+        /// Verifies that all endpoints have descriptions.
+        /// </summary>
         [Fact]
         public void GetAllWithDescriptions_ReturnsAllEndpoints() {
             var all = DnsEndpointExtensions.GetAllWithDescriptions().ToList();

--- a/DnsClientX.Tests/DnsJsonDeserializeTests.cs
+++ b/DnsClientX.Tests/DnsJsonDeserializeTests.cs
@@ -6,7 +6,13 @@ using Xunit;
 using DnsClientX;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for JSON deserialization helper methods.
+    /// </summary>
     public class DnsJsonDeserializeTests {
+        /// <summary>
+        /// Ensures an exception is thrown when the HTTP response has no content.
+        /// </summary>
         [Fact]
         public async Task Deserialize_ContentLengthZero_ThrowsException() {
             using var response = new HttpResponseMessage(HttpStatusCode.OK) {

--- a/DnsClientX.Tests/DnsJsonSerializationTests.cs
+++ b/DnsClientX.Tests/DnsJsonSerializationTests.cs
@@ -2,7 +2,13 @@ using DnsClientX;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for JSON serialization utilities.
+    /// </summary>
     public class DnsJsonSerializationTests {
+        /// <summary>
+        /// Verifies that serialized property names use camelCase.
+        /// </summary>
         [Fact]
         public void Serialize_UsesCamelCasePropertyNames() {
             var minimal = new DnsAnswerMinimal {

--- a/DnsClientX.Tests/DnsJsonUpdateTests.cs
+++ b/DnsClientX.Tests/DnsJsonUpdateTests.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for DNS record updates via JSON API.
+    /// </summary>
     public class DnsJsonUpdateTests {
         private class JsonUpdateHandler : HttpMessageHandler {
             public HttpRequestMessage? Request { get; private set; }
@@ -26,6 +29,9 @@ namespace DnsClientX.Tests {
             clientField.SetValue(client, httpClient);
         }
 
+        /// <summary>
+        /// Verifies that an update request is posted using JSON.
+        /// </summary>
         [Fact]
         public async Task UpdateRecordJsonPost_Add() {
             var handler = new JsonUpdateHandler();
@@ -40,6 +46,9 @@ namespace DnsClientX.Tests {
             Assert.Equal(DnsResponseCode.NoError, response.Status);
         }
 
+        /// <summary>
+        /// Verifies that deleting a record uses a JSON POST request.
+        /// </summary>
         [Fact]
         public async Task DeleteRecordJsonPost_Delete() {
             var handler = new JsonUpdateHandler();

--- a/DnsClientX.Tests/DnsKeyAlgorithmExtensionsTests.cs
+++ b/DnsClientX.Tests/DnsKeyAlgorithmExtensionsTests.cs
@@ -6,12 +6,18 @@ namespace DnsClientX.Tests {
     /// Tests for <see cref="DnsKeyAlgorithmExtensions"/> utilities.
     /// </summary>
     public class DnsKeyAlgorithmExtensionsTests {
+        /// <summary>
+        /// Ensures known algorithm values are correctly parsed.
+        /// </summary>
         [Fact]
         public void FromValue_ReturnsEnum() {
             var result = DnsKeyAlgorithmExtensions.FromValue(8);
             Assert.Equal(DnsKeyAlgorithm.RSASHA256, result);
         }
 
+        /// <summary>
+        /// Ensures invalid values throw an exception.
+        /// </summary>
         [Fact]
         public void FromValue_Invalid_Throws() {
             Assert.Throws<ArgumentException>(() => DnsKeyAlgorithmExtensions.FromValue(999));

--- a/DnsClientX.Tests/DnsMessageOptionsTests.cs
+++ b/DnsClientX.Tests/DnsMessageOptionsTests.cs
@@ -1,6 +1,9 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for <see cref="DnsMessageOptions"/> serialization.
+    /// </summary>
     public class DnsMessageOptionsTests {
         private static void AssertEcsOption(byte[] query, string name) {
             int offset = 12;
@@ -14,6 +17,9 @@ namespace DnsClientX.Tests {
             Assert.Equal((ushort)DnsRecordType.OPT, type);
         }
 
+        /// <summary>
+        /// Ensures EDNS client subnet options are included in wire format serialization.
+        /// </summary>
         [Fact]
         public void SerializeDnsWireFormat_ShouldIncludeEcsOption_WhenUsingOptionsStruct() {
             var opts = new DnsMessageOptions(EnableEdns: true, Subnet: new EdnsClientSubnetOption("192.0.2.1/24"));

--- a/DnsClientX.Tests/DnsMessageSigningTests.cs
+++ b/DnsClientX.Tests/DnsMessageSigningTests.cs
@@ -2,9 +2,15 @@ using System.Security.Cryptography;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for DNS message signing utilities.
+    /// </summary>
     public class DnsMessageSigningTests {
         private const string RsaXml = "<RSAKeyValue><Modulus>53YFIke7QJ+BflZmkvTPuUtScT97JPn4N0Lvek6ukY3IOPYkOndVFXLvJSUYcI6b0RvLjaIx1wcGPcJW7+V0nUCiqnxi85roJp1NVyIPMWs/JIS5WYcv9bPbqBsAJuxGMM2m49CjlDqVlggw49Rh431e2sDeZ729AqOOlm6qV4k=</Modulus><Exponent>AQAB</Exponent><P>/DCmdjyqUn8axK4tQqzq60McH/UoDTa+1LCxfmn9aewPIkMhRidQaxwp0MdadvTDkEbKX6J9ucwO/PIHtSp4nQ==</P><Q>6vUzLeLIuypxL+vIKZr+je+7tbFlDyGFEko24F18zE1RE8kxOQ4k9BdstQchm3O/edknXEuAyvL3+kSeUf+Y3Q==</Q><DP>Ra83wAIhWixO/DvYu8zGGP3xPo9iYsxWzLSKRxEIegVFZUVBY34nhYFBuLPtNmOJyksVTnm63eUZ2yERqiizLQ==</DP><DQ>C4ecy1OlpgmfJErdt6zzcOOiwnfCDcwHS654ounzhdMFd4MX90TKa2/61adT7tzvOHt/gvfxigQCRzW2zy9LwQ==</DQ><InverseQ>rFiNryKWal8UiXOsuW46IgUGOHQGZ9IoRof5jvk428nGfrYBdKfVS5l1hU5i3Y8FTsC4NyRo3njx806i+0ZZiw==</InverseQ><D>VDqdiakC2nRxIjF86FOQWASx/qY0QPN6QVnpXd/OJQesahYgfuo4GzMVFbZXG3a5+zGbNHJmorJashTLoEcm1PWOt01L2zcLJiroBFGrMGJD2ZAITj0/OuOskfmDwk4Jgcr5o5I3eaEqG1ouR0XOYyvtI8z5U8E6o+BGrCRuCJE=</D></RSAKeyValue>";
 
+        /// <summary>
+        /// Ensures signatures are included when messages are serialized.
+        /// </summary>
         [Fact]
         public void SerializeDnsWireFormat_ShouldIncludeSignature() {
             using RSA rsa = RSA.Create();

--- a/DnsClientX.Tests/DnsQueryableTests.cs
+++ b/DnsClientX.Tests/DnsQueryableTests.cs
@@ -4,7 +4,13 @@ using DnsClientX.Linq;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for LINQ-based DNS querying APIs.
+    /// </summary>
     public class DnsQueryableTests {
+        /// <summary>
+        /// Demonstrates filtering query results via LINQ.
+        /// </summary>
         [Fact(Skip = "External dependency - network unreachable in CI")]
         public async Task ShouldFilterResults() {
             using var client = new ClientX(DnsEndpoint.Cloudflare);

--- a/DnsClientX.Tests/DnsQuestionTests.cs
+++ b/DnsClientX.Tests/DnsQuestionTests.cs
@@ -1,7 +1,13 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for the <see cref="DnsQuestion"/> model.
+    /// </summary>
     public class DnsQuestionTests {
+        /// <summary>
+        /// Setting a trailing dot strips it from the stored name but preserves the original value.
+        /// </summary>
         [Fact]
         public void SettingNameStripsTrailingDotButKeepsOriginal() {
             var q = new DnsQuestion { Name = "example.com." };
@@ -9,6 +15,9 @@ namespace DnsClientX.Tests {
             Assert.Equal("example.com.", q.OriginalName);
         }
 
+        /// <summary>
+        /// Names without a trailing dot should remain unchanged.
+        /// </summary>
         [Fact]
         public void SettingNameWithoutDotUnchanged() {
             var q = new DnsQuestion { Name = "example.com" };

--- a/DnsClientX.Tests/DnsRecordTypeSerializationTests.cs
+++ b/DnsClientX.Tests/DnsRecordTypeSerializationTests.cs
@@ -2,7 +2,13 @@ using System.Text.Json;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests JSON serialization behavior for <see cref="DnsRecordType"/> values.
+    /// </summary>
     public class DnsRecordTypeSerializationTests {
+        /// <summary>
+        /// Ensures values round-trip through serialization.
+        /// </summary>
         [Theory]
         [InlineData(DnsRecordType.SVCB, 64)]
         [InlineData(DnsRecordType.HTTPS, 65)]
@@ -21,6 +27,9 @@ namespace DnsClientX.Tests {
             Assert.Equal(type, deserialized.Type);
         }
 
+        /// <summary>
+        /// Verifies that converting data leaves raw values intact for SVCB/HTTPS.
+        /// </summary>
         [Theory]
         [InlineData(DnsRecordType.SVCB)]
         [InlineData(DnsRecordType.HTTPS)]

--- a/DnsClientX.Tests/DnsResponseCacheTests.cs
+++ b/DnsClientX.Tests/DnsResponseCacheTests.cs
@@ -8,7 +8,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for the <see cref="DnsResponseCache"/> class.
+    /// </summary>
     public class DnsResponseCacheTests {
+        /// <summary>
+        /// Ensures cache items can be stored and retrieved.
+        /// </summary>
         [Fact]
         public void ShouldStoreAndRetrieve() {
             var cache = new DnsResponseCache();
@@ -18,6 +24,9 @@ namespace DnsClientX.Tests {
             Assert.Same(response, cached);
         }
 
+        /// <summary>
+        /// Items should be removed once their TTL expires.
+        /// </summary>
         [Fact]
         public void ShouldEvictAfterExpiration() {
             var cache = new DnsResponseCache();
@@ -27,6 +36,9 @@ namespace DnsClientX.Tests {
             Assert.False(cache.TryGet("a", out _));
         }
 
+        /// <summary>
+        /// Calling <see cref="DnsResponseCache.Cleanup"/> should remove expired entries.
+        /// </summary>
         [Fact]
         public void ShouldCleanupExpiredEntries() {
             var cache = new DnsResponseCache();
@@ -39,6 +51,9 @@ namespace DnsClientX.Tests {
             Assert.False(cache.TryGet("b", out _));
         }
 
+        /// <summary>
+        /// Verifies that constructing <see cref="ClientX"/> with caching enabled sets the property.
+        /// </summary>
         [Fact]
         public void ClientConstructorEnablesCache() {
             using var client = new ClientX(enableCache: true);

--- a/DnsClientX.Tests/DnsResponseRetryCountTests.cs
+++ b/DnsClientX.Tests/DnsResponseRetryCountTests.cs
@@ -5,7 +5,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests that the <see cref="DnsResponse.RetryCount"/> property is set correctly.
+    /// </summary>
     public class DnsResponseRetryCountTests {
+        /// <summary>
+        /// Ensures the retry counter reflects the number of attempts.
+        /// </summary>
         [Fact]
         public async Task RetryCountIsSetOnSuccess() {
             int call = 0;

--- a/DnsClientX.Tests/DnsResponseTests.cs
+++ b/DnsClientX.Tests/DnsResponseTests.cs
@@ -3,7 +3,13 @@ using System.Text.Json;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for the <see cref="DnsResponse"/> type.
+    /// </summary>
     public class DnsResponseTests {
+        /// <summary>
+        /// Validates that server details are copied to the response.
+        /// </summary>
         [Fact]
         public void AddServerDetailsPopulatesFields() {
             var response = new DnsResponse {
@@ -23,6 +29,9 @@ namespace DnsClientX.Tests {
             Assert.Equal(config.Port, response.AnswersMinimal[0].Port);
         }
 
+        /// <summary>
+        /// BaseUri should remain null for UDP responses.
+        /// </summary>
         [Fact]
         public void AddServerDetailsLeavesBaseUriNullForUdp() {
             var response = new DnsResponse {
@@ -39,6 +48,9 @@ namespace DnsClientX.Tests {
             Assert.Equal(config.Hostname, response.ServerAddress);
         }
 
+        /// <summary>
+        /// BaseUri should remain null for TCP responses.
+        /// </summary>
         [Fact]
         public void AddServerDetailsLeavesBaseUriNullForTcp() {
             var response = new DnsResponse {
@@ -55,6 +67,9 @@ namespace DnsClientX.Tests {
             Assert.Equal(config.Hostname, response.ServerAddress);
         }
 
+        /// <summary>
+        /// Converter should transform arrays of comment strings.
+        /// </summary>
         [Fact]
         public void CommentConverterReadsArray() {
             var json = "[\"a\",\"b\"]";
@@ -64,6 +79,9 @@ namespace DnsClientX.Tests {
             Assert.Equal("a; b", result);
         }
 
+        /// <summary>
+        /// Extended error information should be accessible via helper property.
+        /// </summary>
         [Fact]
         public void ExtendedDnsErrorInfoReflectsErrors() {
             var response = new DnsResponse {
@@ -80,6 +98,9 @@ namespace DnsClientX.Tests {
             Assert.Equal("two", response.ExtendedDnsErrorInfo[1].Text);
         }
 
+        /// <summary>
+        /// When no answers are present, <see cref="DnsResponse.AnswersMinimal"/> should be empty.
+        /// </summary>
         [Fact]
         public void AnswersMinimalReturnsEmptyWhenAnswersNull() {
             var response = new DnsResponse();


### PR DESCRIPTION
## Summary
- document CmdletResolveDnsQuery property
- add XML summaries for numerous test classes and methods
- fix invalid XML doc placements

## Testing
- `dotnet build DnsClientX.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878b4fe3a5c832ea1b4f956c4bf35d4