### PR TITLE
Fix FormatterServices warning

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveQuicTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveQuicTests.cs
@@ -5,7 +5,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Quic;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace DnsClientX.Tests {
@@ -83,8 +83,8 @@ namespace DnsClientX.Tests {
                 DnsWireResolveQuic.ConnectionDisposeCount = 0;
                 DnsWireResolveQuic.StreamDisposeCount = 0;
                 DnsWireResolveQuic.HostEntryResolver = _ => new IPHostEntry { AddressList = [IPAddress.Loopback] };
-                DnsWireResolveQuic.QuicConnectionFactory = (_, _) => new ValueTask<QuicConnection>((QuicConnection)FormatterServices.GetUninitializedObject(typeof(QuicConnection)));
-                DnsWireResolveQuic.StreamFactory = (_, _) => new ValueTask<QuicStream>((QuicStream)FormatterServices.GetUninitializedObject(typeof(QuicStream)));
+                DnsWireResolveQuic.QuicConnectionFactory = (_, _) => new ValueTask<QuicConnection>((QuicConnection)RuntimeHelpers.GetUninitializedObject(typeof(QuicConnection)));
+                DnsWireResolveQuic.StreamFactory = (_, _) => new ValueTask<QuicStream>((QuicStream)RuntimeHelpers.GetUninitializedObject(typeof(QuicStream)));
                 DnsWireResolveQuic.ConnectionDisposer = _ => { DnsWireResolveQuic.ConnectionDisposeCount++; return ValueTask.CompletedTask; };
                 DnsWireResolveQuic.StreamDisposer = _ => { DnsWireResolveQuic.StreamDisposeCount++; return ValueTask.CompletedTask; };
 


### PR DESCRIPTION
## Summary
- use `RuntimeHelpers.GetUninitializedObject` in tests instead of obsolete `FormatterServices`

## Testing
- `dotnet test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6878beeb66d0832eb3c4bce74f980e19