### PR TITLE
Fix nullable warnings

### DIFF
--- a/DnsClientX.Tests/DnsResponseRetryCountTests.cs
+++ b/DnsClientX.Tests/DnsResponseRetryCountTests.cs
@@ -27,7 +27,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<DnsResponse> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(DnsResponse));
-                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 3, 1, null, false, CancellationToken.None })!;
+                return (Task<DnsResponse>)generic.Invoke(null, new object?[] { action, 3, 1, null, false, CancellationToken.None })!;
             }
 
             DnsResponse res = await Invoke();

--- a/DnsClientX.Tests/ParseBindFileTests.cs
+++ b/DnsClientX.Tests/ParseBindFileTests.cs
@@ -13,7 +13,7 @@ namespace DnsClientX.Tests {
         public void MissingFile_ReturnsEmptyList() {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object?[] { tempPath, null })!;
             Assert.Empty(result);
         }
 
@@ -22,7 +22,7 @@ namespace DnsClientX.Tests {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
             File.WriteAllText(tempPath, "$TTL 3600\n@ IN SOA ns.example.com. admin.example.com. 2024010101 7200 3600 1209600 3600\n@ IN NS ns.example.com.\nwww 600 IN A 203.0.113.10\nmail IN MX 10 mail.example.com.\n");
             MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object?[] { tempPath, null })!;
             File.Delete(tempPath);
             Assert.Equal(4, result.Count);
             Assert.Equal(DnsRecordType.SOA, result[0].Type);
@@ -36,7 +36,7 @@ namespace DnsClientX.Tests {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
             File.WriteAllText(tempPath, "www -60 IN A 203.0.113.10\n");
             MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object?[] { tempPath, null })!;
             File.Delete(tempPath);
             Assert.Empty(result);
         }
@@ -46,7 +46,7 @@ namespace DnsClientX.Tests {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
             File.WriteAllText(tempPath, "test IN TXT \"text;not comment\"\n");
             MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object?[] { tempPath, null })!;
             File.Delete(tempPath);
             Assert.Single(result);
             Assert.Equal("text;not comment", result[0].DataRaw);

--- a/DnsClientX.Tests/ParseResolvConfTests.cs
+++ b/DnsClientX.Tests/ParseResolvConfTests.cs
@@ -9,7 +9,7 @@ namespace DnsClientX.Tests {
         public void MissingFile_ReturnsEmptyList() {
             string tempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
             MethodInfo method = typeof(SystemInformation).GetMethod("ParseResolvConf", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<string>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<string>)method.Invoke(null, new object?[] { tempPath, null })!;
             Assert.Empty(result);
         }
     }

--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -18,7 +18,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1, null, false, CancellationToken.None })!;
+                return (Task<int>)generic.Invoke(null, new object?[] { action, 3, 1, null, false, CancellationToken.None })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -47,7 +47,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, beforeRetry, false, CancellationToken.None })!;
+                return (Task<int>)generic.Invoke(null, new object?[] { action, 3, 50, beforeRetry, false, CancellationToken.None })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -84,7 +84,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, beforeRetry, false, CancellationToken.None })!;
+                return (Task<int>)generic.Invoke(null, new object?[] { action, 3, 50, beforeRetry, false, CancellationToken.None })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -115,7 +115,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<DnsResponse> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(DnsResponse));
-                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, null, false, CancellationToken.None })!;
+                return (Task<DnsResponse>)generic.Invoke(null, new object?[] { action, 2, 1, null, false, CancellationToken.None })!;
             }
 
             var ex = await Assert.ThrowsAsync<DnsClientException>(Invoke);
@@ -135,7 +135,7 @@ namespace DnsClientX.Tests {
             var generic = method.MakeGenericMethod(typeof(int));
             using var cts = new CancellationTokenSource();
 
-            Task<int> task = (Task<int>)generic.Invoke(null, new object[] { action, 3, 5000, null, false, cts.Token })!;
+            Task<int> task = (Task<int>)generic.Invoke(null, new object?[] { action, 3, 5000, null, false, cts.Token })!;
             cts.CancelAfter(200);
 
             await Assert.ThrowsAsync<TaskCanceledException>(() => task);

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
 
         private readonly List<string> hostnames = new();
         private readonly Dictionary<string, DateTime> unavailable = new();
-        private string baseUriFormat;
+        private string? baseUriFormat;
         private int hostnameIndex;
 
         /// <summary>

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -19,7 +19,7 @@ namespace DnsClientX {
         /// <summary>
         /// The client
         /// </summary>
-        private HttpClient Client;
+        private HttpClient? Client;
 
         /// <summary>
         /// Gets the endpoint configuration.
@@ -60,7 +60,7 @@ namespace DnsClientX {
         /// <summary>
         /// The handler
         /// </summary>
-        private HttpClientHandler handler;
+        private HttpClientHandler? handler;
         private bool _handlerOwnedByClient;
 
         /// <summary>

--- a/DnsClientX/DnsResponseCache.cs
+++ b/DnsClientX/DnsResponseCache.cs
@@ -52,7 +52,7 @@ namespace DnsClientX {
         /// <param name="key">Cache key.</param>
         /// <param name="response">Retrieved response if found and not expired.</param>
         /// <returns><c>true</c> if a valid entry was found; otherwise <c>false</c>.</returns>
-        public bool TryGet(string key, out DnsResponse response) {
+        public bool TryGet(string key, out DnsResponse? response) {
             if (_cache.TryGetValue(key, out var entry)) {
                 if (DateTimeOffset.UtcNow < entry.Expiration) {
                     response = entry.Response;

--- a/DnsClientX/ProtocolDnsWire/DnsWire.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWire.cs
@@ -29,7 +29,7 @@ namespace DnsClientX {
         /// Not enough data in the stream to read the additional.
         /// or
         /// </exception>
-        internal static async Task<DnsResponse> DeserializeDnsWireFormat(this HttpResponseMessage res, bool debug = false, byte[] bytes = null) {
+        internal static async Task<DnsResponse> DeserializeDnsWireFormat(this HttpResponseMessage? res, bool debug = false, byte[]? bytes = null) {
             if (res == null && bytes == null) throw new ArgumentNullException(nameof(res));
             try {
                 byte[] dnsWireFormatBytes;


### PR DESCRIPTION
## Summary
- mark some parameters and fields as nullable to avoid warnings
- relax cache TryGet signature to allow null
- tweak reflection tests to use nullable object arrays

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: DnsClientX.Tests, 141 failed, 446 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6878bf33b918832ea2c35748ed64bbec