### PR TITLE
Fix CS0419 ambiguous cref warnings

### DIFF
--- a/DnsClientX.Examples/DemoResolveAsyncEnumerable.cs
+++ b/DnsClientX.Examples/DemoResolveAsyncEnumerable.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace DnsClientX.Examples {
     /// <summary>
-    /// Demonstrates resolving DNS queries concurrently using <see cref="ClientX.ResolveAsyncEnumerable"/>.
+    /// Demonstrates resolving DNS queries concurrently using <see cref="ClientX.ResolveAsyncEnumerable(string[], DnsRecordType[], bool, bool, bool, bool, int, int, System.Threading.CancellationToken)"/>.
     /// </summary>
     internal class DemoResolveAsyncEnumerable {
         /// <summary>Runs the demo.</summary>

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Compares provider results when using <see cref="ClientX.ResolveFilter"/>.
+    /// Compares provider results when using <see cref="ClientX.ResolveFilter(string, DnsRecordType, string, bool, bool, bool, int, int, System.Threading.CancellationToken)"/>.
     /// </summary>
     public class CompareProvidersResolveFilter(ITestOutputHelper output) {
         /// <summary>

--- a/DnsClientX.Tests/DisposeTests.cs
+++ b/DnsClientX.Tests/DisposeTests.cs
@@ -39,7 +39,7 @@ namespace DnsClientX.Tests {
 #endif
 
         /// <summary>
-        /// Ensures that calling <see cref="ClientX.Dispose"/> does not dispose the underlying <see cref="HttpClient"/> twice.
+        /// Ensures that calling <see cref="ClientX.Dispose()"/> does not dispose the underlying <see cref="HttpClient"/> twice.
         /// </summary>
         [Fact]
         public void Client_Dispose_ShouldNotDisposeHttpClientTwice() {
@@ -104,7 +104,7 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// Checks that <see cref="ClientX.DisposeAsync"/> does not dispose the HTTP handler more than once.
+        /// Checks that <see cref="ClientX.DisposeAsync()"/> does not dispose the HTTP handler more than once.
         /// </summary>
         [Fact]
         public async Task Client_DisposeAsync_ShouldNotDisposeHandlerTwice() {
@@ -126,7 +126,7 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// Ensures that concurrent calls to <see cref="ClientX.Dispose"/> only dispose once.
+        /// Ensures that concurrent calls to <see cref="ClientX.Dispose()"/> only dispose once.
         /// </summary>
         [Fact]
         public async Task Client_Dispose_CalledConcurrently_ShouldOnlyDisposeOnce() {
@@ -150,7 +150,7 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// Ensures concurrent invocations of <see cref="ClientX.DisposeAsync"/> only dispose once.
+        /// Ensures concurrent invocations of <see cref="ClientX.DisposeAsync()"/> only dispose once.
         /// </summary>
         [Fact]
         public async Task Client_DisposeAsync_CalledConcurrently_ShouldOnlyDisposeOnce() {
@@ -174,7 +174,7 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// Validates that the disposal counter is incremented when <see cref="ClientX.DisposeAsync"/> is called.
+        /// Validates that the disposal counter is incremented when <see cref="ClientX.DisposeAsync()"/> is called.
         /// </summary>
         [Fact]
         public async Task Client_DisposeAsync_ShouldIncrementDisposalCount() {


### PR DESCRIPTION
## Summary
- disambiguate XML documentation `cref` attributes that triggered CS0419 warnings

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: DnsClientX.Tests.dll)*

------
https://chatgpt.com/codex/tasks/task_e_6878bf166c10832ea07fc63c7699c25f