### PR TITLE
Fix xUnit null parameter warning

### DIFF
--- a/DnsClientX.Tests/ConfigurationTests.cs
+++ b/DnsClientX.Tests/ConfigurationTests.cs
@@ -23,7 +23,7 @@ namespace DnsClientX.Tests {
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]
-        public void Constructor_ShouldThrowOnNullOrWhitespaceHostname(string hostname) {
+        public void Constructor_ShouldThrowOnNullOrWhitespaceHostname(string? hostname) {
             Assert.Throws<ArgumentException>(() => new Configuration(hostname!, DnsRequestFormat.DnsOverHttpsJSON));
         }
 


### PR DESCRIPTION
## Summary
- mark hostname argument as nullable in configuration tests

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: `Failed:   141, Passed:   446, Skipped:    18`)*

------
https://chatgpt.com/codex/tasks/task_e_6878bece30e0832eb6bf3156761f4cd1