### PR TITLE
Fix CA1416 warnings for QUIC

### DIFF
--- a/DnsClientX.Tests/DnsWireResolveQuicTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveQuicTests.cs
@@ -6,12 +6,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Quic;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using Xunit;
 
 namespace DnsClientX.Tests {
     /// <summary>
     /// Tests for the QUIC DNS wire resolver.
     /// </summary>
+    [SupportedOSPlatform("windows")]
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macos")]
     public class DnsWireResolveQuicTests {
         /// <summary>
         /// Ensures server failure is returned when the host has no addresses.


### PR DESCRIPTION
## Summary
- ensure QUIC tests and helper are marked as platform specific
- guard QUIC usage with runtime OS checks

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: socket connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878beb43e88832ea1afea68bf831a2b