### PR TITLE
Fix CS8600 warnings

### DIFF
--- a/DnsClientX.Tests/DeduplicateDnsServersTests.cs
+++ b/DnsClientX.Tests/DeduplicateDnsServersTests.cs
@@ -15,7 +15,7 @@ namespace DnsClientX.Tests {
         public void DuplicateDnsServers_AreRemoved() {
             MethodInfo method = typeof(SystemInformation).GetMethod("DeduplicateDnsServers", BindingFlags.NonPublic | BindingFlags.Static)!;
             var input = new List<string> { "1.1.1.1", "1.1.1.1", "[2001:db8::1]", "[2001:db8::1]" };
-            var result = (List<string>)method.Invoke(null, new object[] { input })!;
+            var result = (List<string>)method.Invoke(null, new object?[] { input })!;
             Assert.Equal(new[] { "1.1.1.1", "[2001:db8::1]" }, result);
         }
 
@@ -26,7 +26,7 @@ namespace DnsClientX.Tests {
         public void DuplicateDnsServers_OrderIsPreserved() {
             MethodInfo method = typeof(SystemInformation).GetMethod("DeduplicateDnsServers", BindingFlags.NonPublic | BindingFlags.Static)!;
             var input = new List<string> { "2.2.2.2", "1.1.1.1", "2.2.2.2", "[2001:db8::1]", "1.1.1.1" };
-            var result = (List<string>)method.Invoke(null, new object[] { input })!;
+            var result = (List<string>)method.Invoke(null, new object?[] { input })!;
             Assert.Equal(new[] { "2.2.2.2", "1.1.1.1", "[2001:db8::1]" }, result);
         }
 

--- a/DnsClientX.Tests/DnsResponseRetryCountTests.cs
+++ b/DnsClientX.Tests/DnsResponseRetryCountTests.cs
@@ -27,7 +27,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<DnsResponse> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(DnsResponse));
-                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 3, 1, null, false, CancellationToken.None })!;
+                return (Task<DnsResponse>)generic.Invoke(null, new object?[] { action, 3, 1, null, false, CancellationToken.None })!;
             }
 
             DnsResponse res = await Invoke();

--- a/DnsClientX.Tests/DnssecChainValidatorTests.cs
+++ b/DnsClientX.Tests/DnssecChainValidatorTests.cs
@@ -171,8 +171,8 @@ namespace DnsClientX.Tests {
         }
 
         private static byte[] BuildPublicKey(RSAParameters p) {
-            byte[] exponent = p.Exponent;
-            byte[] modulus = p.Modulus;
+            byte[] exponent = p.Exponent!;
+            byte[] modulus = p.Modulus!;
             var key = new byte[(exponent.Length > 255 ? 3 : 1) + exponent.Length + modulus.Length];
             int index = 0;
             if (exponent.Length > 255) {

--- a/DnsClientX.Tests/EdnsOptionsTests.cs
+++ b/DnsClientX.Tests/EdnsOptionsTests.cs
@@ -66,7 +66,7 @@ namespace DnsClientX.Tests {
             };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object?[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
             byte[] query = await udpTask;
 
@@ -86,7 +86,7 @@ namespace DnsClientX.Tests {
             };
             Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
             MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
+            var task = (Task<DnsResponse>)method.Invoke(null, new object?[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
             await task;
             await udpTask;
         }

--- a/DnsClientX.Tests/FailoverStrategyTests.cs
+++ b/DnsClientX.Tests/FailoverStrategyTests.cs
@@ -31,7 +31,7 @@ namespace DnsClientX.Tests {
             var advance = (Action)Delegate.CreateDelegate(typeof(Action), config, "AdvanceToNextHostname", false)!;
             var ex = await Assert.ThrowsAsync<DnsClientException>(async () =>
             {
-                await (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, advance, false, CancellationToken.None })!;
+                await (Task<DnsResponse>)generic.Invoke(null, new object?[] { action, 2, 1, advance, false, CancellationToken.None })!;
             });
             Assert.Same(response, ex.Response);
 

--- a/DnsClientX.Tests/ParseBindFileTests.cs
+++ b/DnsClientX.Tests/ParseBindFileTests.cs
@@ -13,7 +13,7 @@ namespace DnsClientX.Tests {
         public void MissingFile_ReturnsEmptyList() {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object?[] { tempPath, null })!;
             Assert.Empty(result);
         }
 
@@ -22,7 +22,7 @@ namespace DnsClientX.Tests {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
             File.WriteAllText(tempPath, "$TTL 3600\n@ IN SOA ns.example.com. admin.example.com. 2024010101 7200 3600 1209600 3600\n@ IN NS ns.example.com.\nwww 600 IN A 203.0.113.10\nmail IN MX 10 mail.example.com.\n");
             MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object?[] { tempPath, null })!;
             File.Delete(tempPath);
             Assert.Equal(4, result.Count);
             Assert.Equal(DnsRecordType.SOA, result[0].Type);
@@ -36,7 +36,7 @@ namespace DnsClientX.Tests {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
             File.WriteAllText(tempPath, "www -60 IN A 203.0.113.10\n");
             MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object?[] { tempPath, null })!;
             File.Delete(tempPath);
             Assert.Empty(result);
         }
@@ -46,7 +46,7 @@ namespace DnsClientX.Tests {
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zone");
             File.WriteAllText(tempPath, "test IN TXT \"text;not comment\"\n");
             MethodInfo method = typeof(BindFileParser).GetMethod("ParseZoneFile", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<DnsAnswer>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<DnsAnswer>)method.Invoke(null, new object?[] { tempPath, null })!;
             File.Delete(tempPath);
             Assert.Single(result);
             Assert.Equal("text;not comment", result[0].DataRaw);

--- a/DnsClientX.Tests/ParseResolvConfTests.cs
+++ b/DnsClientX.Tests/ParseResolvConfTests.cs
@@ -9,7 +9,7 @@ namespace DnsClientX.Tests {
         public void MissingFile_ReturnsEmptyList() {
             string tempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
             MethodInfo method = typeof(SystemInformation).GetMethod("ParseResolvConf", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var result = (List<string>)method.Invoke(null, new object[] { tempPath, null })!;
+            var result = (List<string>)method.Invoke(null, new object?[] { tempPath, null })!;
             Assert.Empty(result);
         }
     }

--- a/DnsClientX.Tests/ResolveSync.cs
+++ b/DnsClientX.Tests/ResolveSync.cs
@@ -24,7 +24,7 @@ namespace DnsClientX.Tests {
             LogDiagnostics($"DNS Servers: {string.Join(", ", SystemInformation.GetDnsFromActiveNetworkCard())}");
 
             DnsResponse response = new DnsResponse();
-            Exception lastException = null;
+            Exception? lastException = null;
 
             for (int attempt = 1; attempt <= maxRetries; attempt++)
             {

--- a/DnsClientX.Tests/RetryAsyncTests.cs
+++ b/DnsClientX.Tests/RetryAsyncTests.cs
@@ -18,7 +18,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 1, null, false, CancellationToken.None })!;
+                return (Task<int>)generic.Invoke(null, new object?[] { action, 3, 1, null, false, CancellationToken.None })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -47,7 +47,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, beforeRetry, false, CancellationToken.None })!;
+                return (Task<int>)generic.Invoke(null, new object?[] { action, 3, 50, beforeRetry, false, CancellationToken.None })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -84,7 +84,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(int));
-                return (Task<int>)generic.Invoke(null, new object[] { action, 3, 50, beforeRetry, false, CancellationToken.None })!;
+                return (Task<int>)generic.Invoke(null, new object?[] { action, 3, 50, beforeRetry, false, CancellationToken.None })!;
             }
 
             await Assert.ThrowsAsync<TimeoutException>(Invoke);
@@ -115,7 +115,7 @@ namespace DnsClientX.Tests {
             MethodInfo method = typeof(ClientX).GetMethod("RetryAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<DnsResponse> Invoke() {
                 var generic = method.MakeGenericMethod(typeof(DnsResponse));
-                return (Task<DnsResponse>)generic.Invoke(null, new object[] { action, 2, 1, null, false, CancellationToken.None })!;
+                return (Task<DnsResponse>)generic.Invoke(null, new object?[] { action, 2, 1, null, false, CancellationToken.None })!;
             }
 
             var ex = await Assert.ThrowsAsync<DnsClientException>(Invoke);
@@ -135,7 +135,7 @@ namespace DnsClientX.Tests {
             var generic = method.MakeGenericMethod(typeof(int));
             using var cts = new CancellationTokenSource();
 
-            Task<int> task = (Task<int>)generic.Invoke(null, new object[] { action, 3, 5000, null, false, cts.Token })!;
+            Task<int> task = (Task<int>)generic.Invoke(null, new object?[] { action, 3, 5000, null, false, cts.Token })!;
             cts.CancelAfter(200);
 
             await Assert.ThrowsAsync<TaskCanceledException>(() => task);

--- a/DnsClientX.Tests/SocketCountTests.cs
+++ b/DnsClientX.Tests/SocketCountTests.cs
@@ -69,7 +69,7 @@ namespace DnsClientX.Tests {
 
             int before = GetTcpConnectionCount(port);
             for (int i = 0; i < iterations; i++) {
-                var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
+                var task = (Task<DnsResponse>)method.Invoke(null, new object?[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
                 await task;
             }
             await serverTask;

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -27,7 +27,7 @@ namespace DnsClientX {
 
         private readonly List<string> hostnames = new();
         private readonly Dictionary<string, DateTime> unavailable = new();
-        private string baseUriFormat;
+        private string? baseUriFormat;
         private int hostnameIndex;
 
         /// <summary>
@@ -339,7 +339,7 @@ namespace DnsClientX {
         public Configuration(DnsEndpoint endpoint, DnsSelectionStrategy selectionStrategy = DnsSelectionStrategy.First) {
             List<string> hostnames;
             SelectionStrategy = selectionStrategy;
-            string baseUriFormat;
+            string? baseUriFormat;
             switch (endpoint) {
                 case DnsEndpoint.System:
                     // Use the system's default DNS resolver

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -254,9 +254,9 @@ namespace DnsClientX {
                 return result;
             }
 
-            Exception lastException = null;
-            DnsClientException lastDnsClientException = null;
-            T lastResult = default(T);
+            Exception? lastException = null;
+            DnsClientException? lastDnsClientException = null;
+            T? lastResult = default;
 
             for (int attempt = 1; attempt <= maxRetries; attempt++) {
                 try {
@@ -327,7 +327,7 @@ namespace DnsClientX {
             {
                 finalResponse.RetryCount = maxRetries - 1;
             }
-            return lastResult;
+            return lastResult!;
         }
 
         /// <summary>

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -19,7 +19,7 @@ namespace DnsClientX {
         /// <summary>
         /// The client
         /// </summary>
-        private HttpClient Client;
+        private HttpClient? Client;
 
         /// <summary>
         /// Gets the endpoint configuration.
@@ -60,7 +60,7 @@ namespace DnsClientX {
         /// <summary>
         /// The handler
         /// </summary>
-        private HttpClientHandler handler;
+        private HttpClientHandler? handler;
         private bool _handlerOwnedByClient;
 
         /// <summary>

--- a/DnsClientX/DnsResponseCache.cs
+++ b/DnsClientX/DnsResponseCache.cs
@@ -60,7 +60,7 @@ namespace DnsClientX {
                 }
                 _cache.TryRemove(key, out _);
             }
-            response = default;
+            response = default!;
             return false;
         }
 

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -80,7 +80,7 @@ namespace DnsClientX {
             // Normalize the DNS server address. If it's not an IP address,
             // resolve it using DNS. IPv6 addresses should be wrapped in
             // brackets when constructing the endpoint string.
-            IPAddress ipAddress;
+            IPAddress? ipAddress;
             if (!IPAddress.TryParse(dnsServer, out ipAddress)) {
                 var hostEntry = HostEntryResolver?.Invoke(dnsServer) ?? Dns.GetHostEntry(dnsServer);
                 if (hostEntry.AddressList.Length == 0) {
@@ -95,13 +95,13 @@ namespace DnsClientX {
                 ipAddress = hostEntry.AddressList[0];
             }
 
-            var ipString = ipAddress.ToString();
+            var ipString = ipAddress!.ToString();
             int zoneIndex = ipString.IndexOf('%');
             if (zoneIndex >= 0) {
                 ipString = ipString[..zoneIndex];
             }
 
-            if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6) {
+            if (ipAddress!.AddressFamily == AddressFamily.InterNetworkV6) {
                 ipString = $"[{ipString}]";
             }
 

--- a/DnsClientX/ProtocolDnsWire/DnsWire.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWire.cs
@@ -29,7 +29,7 @@ namespace DnsClientX {
         /// Not enough data in the stream to read the additional.
         /// or
         /// </exception>
-        internal static async Task<DnsResponse> DeserializeDnsWireFormat(this HttpResponseMessage res, bool debug = false, byte[] bytes = null) {
+        internal static async Task<DnsResponse> DeserializeDnsWireFormat(this HttpResponseMessage? res, bool debug = false, byte[]? bytes = null) {
             if (res == null && bytes == null) throw new ArgumentNullException(nameof(res));
             try {
                 byte[] dnsWireFormatBytes;

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -54,7 +54,7 @@ namespace DnsClientX {
                 Settings.Logger.WriteDebug($"Question class: {BitConverter.ToString(queryBytes, queryBytes.Length - 2, 2)}");
             }
 
-            if (!IPAddress.TryParse(dnsServer, out IPAddress address)) {
+            if (!IPAddress.TryParse(dnsServer, out IPAddress? address)) {
                 DnsResponse invalidAddress = new DnsResponse {
                     Questions = [
                         new DnsQuestion {
@@ -71,11 +71,11 @@ namespace DnsClientX {
                 return invalidAddress;
             }
 
-            Exception lastException = null;
+            Exception? lastException = null;
             for (int attempt = 1; attempt <= Math.Max(1, maxRetries); attempt++) {
                 try {
-                    using var udpClient = new UdpClient(address.AddressFamily);
-                    var responseBuffer = await SendQueryOverUdp(udpClient, queryBytes, address, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
+                    using var udpClient = new UdpClient(address!.AddressFamily);
+                    var responseBuffer = await SendQueryOverUdp(udpClient, queryBytes, address!, port, endpointConfiguration.TimeOut, cancellationToken).ConfigureAwait(false);
 
                     var response = await DnsWire.DeserializeDnsWireFormat(null, debug, responseBuffer).ConfigureAwait(false);
                     if (response.IsTruncated && endpointConfiguration.UseTcpFallback) {

--- a/DnsClientX/Security/DnsSecValidator.cs
+++ b/DnsClientX/Security/DnsSecValidator.cs
@@ -441,7 +441,7 @@ namespace DnsClientX {
                 }
 #if NET5_0_OR_GREATER
                 else if (key.Algorithm == DnsKeyAlgorithm.ECDSAP256SHA256 || key.Algorithm == DnsKeyAlgorithm.ECDSAP384SHA384) {
-                    if (TryGetEcdsa(key.PublicKey, key.Algorithm, out ECDsa? ecdsa)) {
+                    if (TryGetEcdsa(key.PublicKey, key.Algorithm, out ECDsa? ecdsa) && ecdsa != null) {
                         using (ecdsa) {
                             HashAlgorithmName hashAlg = key.Algorithm == DnsKeyAlgorithm.ECDSAP256SHA256 ? HashAlgorithmName.SHA256 : HashAlgorithmName.SHA384;
                             if (ecdsa.VerifyData(data, rrsig.Signature, hashAlg)) {


### PR DESCRIPTION
## Summary
- make DnsWire.DeserializeDnsWireFormat accept nullable parameters
- guard UDP and QUIC code from nullable addresses
- handle nullable fields in ClientX and cache
- tweak retry logic to use nullable locals
- update tests to use nullable object arrays

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6878be87361c832ebf152ace7b8ef6fc