### PR TITLE
Fix xml comment placement

### DIFF
--- a/DnsClientX.Tests/CompareProvidersResolve.cs
+++ b/DnsClientX.Tests/CompareProvidersResolve.cs
@@ -6,8 +6,14 @@ namespace DnsClientX.Tests {
     /// </summary>
     public class CompareProvidersResolve(ITestOutputHelper output) {
         /// <summary>
-        /// Compares DNS answers returned by various providers.
+        /// Performs a comparison of DNS responses across multiple providers.
         /// </summary>
+        /// <summary>
+        /// Legacy comparison method checking records across providers without additional diagnostics.
+        /// </summary>
+        /// <param name="name">Domain name to resolve.</param>
+        /// <param name="resourceRecordType">Record type.</param>
+        /// <param name="excludedEndpoints">Providers to skip.</param>
         [Theory(Skip = "External dependency - unreliable for automated testing")]
         //[MemberData(nameof(TestData))]
         [InlineData("evotec.pl", DnsRecordType.A, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
@@ -39,9 +45,6 @@ namespace DnsClientX.Tests {
         [InlineData("google.com", DnsRecordType.MX, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("108.138.7.68", DnsRecordType.PTR, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("sip2sip.info", DnsRecordType.NAPTR, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
-        /// <summary>
-        /// Performs a comparison of DNS responses across multiple providers.
-        /// </summary>
         public async Task CompareRecordsImproved(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -169,6 +172,12 @@ namespace DnsClientX.Tests {
             };
             return (failureResponse, "Max retries exceeded");
         }
+        /// <summary>
+        /// Legacy comparison method checking records across providers without additional diagnostics.
+        /// </summary>
+        /// <param name="name">Domain name to resolve.</param>
+        /// <param name="resourceRecordType">Record type.</param>
+        /// <param name="excludedEndpoints">Providers to skip.</param>
 
         [Theory(Skip = "External dependency - unreliable for automated testing")]
         //[MemberData(nameof(TestData))]
@@ -199,12 +208,6 @@ namespace DnsClientX.Tests {
         [InlineData("1.1.1.1", DnsRecordType.PTR)]
         [InlineData("108.138.7.68", DnsRecordType.PTR)]
         [InlineData("sip2sip.info", DnsRecordType.NAPTR)]
-        /// <summary>
-        /// Legacy comparison method checking records across providers without additional diagnostics.
-        /// </summary>
-        /// <param name="name">Domain name to resolve.</param>
-        /// <param name="resourceRecordType">Record type.</param>
-        /// <param name="excludedEndpoints">Providers to skip.</param>
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -35,9 +35,6 @@ namespace DnsClientX.Tests {
         [InlineData("microsoft.com", DnsRecordType.NS, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("google.com", DnsRecordType.MX, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
         [InlineData("_25._tcp.mail.ietf.org", DnsRecordType.TLSA, new[] { DnsEndpoint.Google, DnsEndpoint.OpenDNS, DnsEndpoint.OpenDNSFamily })]
-        /// <summary>
-        /// Compares results returned from multiple providers using <see cref="ClientX.ResolveAll"/>.
-        /// </summary>
         public async Task CompareRecordsImproved(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -153,6 +150,12 @@ namespace DnsClientX.Tests {
             return (Array.Empty<DnsAnswer>(), "Max retries exceeded", DnsResponseCode.ServerFailure);
         }
 
+        /// <summary>
+        /// Validates that providers return consistent results for the specified record type.
+        /// </summary>
+        /// <param name="name">Domain name to resolve.</param>
+        /// <param name="resourceRecordType">Record type.</param>
+        /// <param name="excludedEndpoints">Optional providers to skip.</param>
         [Theory(Skip = "External dependency - unreliable for automated testing")]
         [InlineData("evotec.pl", DnsRecordType.A)]
         [InlineData("evotec.pl", DnsRecordType.SOA)]
@@ -182,9 +185,6 @@ namespace DnsClientX.Tests {
 
         [InlineData("google.com", DnsRecordType.MX)]
         [InlineData("_25._tcp.mail.ietf.org", DnsRecordType.TLSA)]
-        /// <summary>
-        /// Validates that providers return consistent results for the specified record type.
-        /// </summary>
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -219,7 +219,7 @@ namespace DnsClientX.Tests {
                     Assert.True(Enumerable.SequenceEqual<char>(sortedAAnswers[i].Data, sortedAAnswersCompared[i].Data), $"Provider {endpointCompare}. Records not matching content for " + sortedAAnswers[i].Data);
                     Assert.True((bool)(sortedAAnswers[i].DataStrings.Length == sortedAAnswersCompared[i].DataStrings.Length), $"Provider {endpointCompare}. Records not matching length for " + sortedAAnswers[i].DataStrings + " length expected: " + sortedAAnswers[i].DataStrings.Length + " length provided: " + sortedAAnswersCompared[i].DataStrings.Length);
                 }
-            }
+        }
         }
 
         [Theory(Skip = "External dependency - unreliable for automated testing")]
@@ -234,9 +234,6 @@ namespace DnsClientX.Tests {
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.CloudflareWireFormat)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNS)]
         [InlineData("github.com", DnsRecordType.TXT, DnsEndpoint.Cloudflare, DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Compares multiline text records returned by different providers.
-        /// </summary>
         public async Task CompareRecordTextMultiline(string name, DnsRecordType resourceRecordType, DnsEndpoint primaryEndpoint, DnsEndpoint endpointCompare) {
             using var Client = new ClientX(primaryEndpoint);
             DnsAnswer[] aAnswersPrimary = await Client.ResolveAll(name, resourceRecordType);

--- a/DnsClientX.Tests/CompareProvidersResolveFilter.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveFilter.cs
@@ -148,14 +148,14 @@ namespace DnsClientX.Tests {
             return (failureResponse, "Max retries exceeded");
         }
 
+        /// <summary>
+        /// Compares provider answers after filtering responses for a specific pattern.
+        /// </summary>
         [Theory(Skip = "External dependency - unreliable for automated testing")]
         [InlineData("evotec.pl", DnsRecordType.TXT)]
         [InlineData("microsoft.com", DnsRecordType.TXT)]
         [InlineData("disneyplus.com", DnsRecordType.TXT)]
         [InlineData("github.com", DnsRecordType.TXT)]
-        /// <summary>
-        /// Compares provider answers after filtering responses for a specific pattern.
-        /// </summary>
         public async Task CompareRecords(string name, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             output.WriteLine($"Testing record: {name}, type: {resourceRecordType}");
 
@@ -250,11 +250,11 @@ namespace DnsClientX.Tests {
             }
         }
 
-        [Theory(Skip = "External dependency - unreliable for automated testing")]
-        [InlineData(new[] { "evotec.pl", "microsoft.com", "disneyplus.com" }, DnsRecordType.TXT)]
         /// <summary>
         /// Executes filtered resolve tests for multiple domains simultaneously.
         /// </summary>
+        [Theory(Skip = "External dependency - unreliable for automated testing")]
+        [InlineData(new[] { "evotec.pl", "microsoft.com", "disneyplus.com" }, DnsRecordType.TXT)]
         public async Task CompareRecordsMulti(string[] names, DnsRecordType resourceRecordType, DnsEndpoint[]? excludedEndpoints = null) {
             string filter = "v=spf1";
             var primaryEndpoint = DnsEndpoint.Cloudflare;


### PR DESCRIPTION
## Summary
- move misplaced XML comments above attribute lists

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: 141 failed, 446 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6878be2fe724832e882864545808ac14