### PR TITLE
Fix non-nullable initialization warnings

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -26,14 +26,14 @@ namespace DnsClientX.PowerShell {
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "DnsProvider")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
-        public string[] Name;
+        public string[] Name { get; set; } = Array.Empty<string>();
 
         /// <summary>
         /// <para type="description">Pattern to expand into multiple DNS queries.</para>
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "PatternDnsProvider")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "PatternServerName")]
-        public string Pattern;
+        public string? Pattern { get; set; }
         /// <summary>
         /// <para type="description">The type of the record to query for. If not specified, A record is queried.</para>
         /// </summary>
@@ -153,7 +153,7 @@ namespace DnsClientX.PowerShell {
         [Parameter(Mandatory = false, ParameterSetName = "PatternServerName")]
         public SwitchParameter ValidateDnsSec;
 
-        private InternalLogger _logger;
+        private InternalLogger? _logger;
 
         private static readonly MethodInfo _isTransientResponse = typeof(ClientX).GetMethod("IsTransientResponse", BindingFlags.NonPublic | BindingFlags.Static)!;
         private static readonly MethodInfo _isTransientException = typeof(ClientX).GetMethod("IsTransient", BindingFlags.NonPublic | BindingFlags.Static)!;

--- a/DnsClientX.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/DnsClientX.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -7,13 +7,13 @@ namespace DnsClientX.PowerShell;
 /// This class allow connecting to the InternalLogger class of ADPlayground and act on events from it in different streams
 /// </summary>
 public class InternalLoggerPowerShell {
-    private readonly InternalLogger _logger;
-    private readonly Action<string> _writeVerboseAction;
-    private readonly Action<string> _writeDebugAction;
-    private readonly Action<InformationRecord> _writeInformationAction;
-    private readonly Action<string> _writeWarningAction;
-    private readonly Action<ErrorRecord> _writeErrorAction;
-    private readonly Action<ProgressRecord> _writeProgressAction;
+    private readonly InternalLogger? _logger;
+    private readonly Action<string>? _writeVerboseAction;
+    private readonly Action<string>? _writeDebugAction;
+    private readonly Action<InformationRecord>? _writeInformationAction;
+    private readonly Action<string>? _writeWarningAction;
+    private readonly Action<ErrorRecord>? _writeErrorAction;
+    private readonly Action<ProgressRecord>? _writeProgressAction;
 
     /// <summary>
     /// Initialize the InternalLoggerPowerShell class

--- a/DnsClientX/Definitions/DnsResponse.cs
+++ b/DnsClientX/Definitions/DnsResponse.cs
@@ -63,13 +63,13 @@ namespace DnsClientX {
         /// this property will be <c>null</c>.
         /// </summary>
         [JsonPropertyName("Question")]
-        public DnsQuestion[] Questions { get; set; }
+        public DnsQuestion[] Questions { get; set; } = Array.Empty<DnsQuestion>();
 
         /// <summary>
         /// The answers provided by the DNS server.
         /// </summary>
         [JsonPropertyName("Answer")]
-        public DnsAnswer[] Answers { get; set; }
+        public DnsAnswer[] Answers { get; set; } = Array.Empty<DnsAnswer>();
 
         /// <summary>
         /// When typed parsing is enabled, contains typed representations of <see cref="Answers"/>.
@@ -81,7 +81,7 @@ namespace DnsClientX {
         /// Gets the answers in their minimal form.
         /// </summary>
         [JsonIgnore]
-        private DnsAnswerMinimal[] _answersMinimal;
+        private DnsAnswerMinimal[] _answersMinimal = Array.Empty<DnsAnswerMinimal>();
 
         /// <summary>
         /// Address of the DNS server that returned this response.
@@ -103,32 +103,32 @@ namespace DnsClientX {
         /// The authority records provided by the DNS server.
         /// </summary>
         [JsonPropertyName("Authority")]
-        public DnsAnswer[] Authorities { get; set; }
+        public DnsAnswer[] Authorities { get; set; } = Array.Empty<DnsAnswer>();
 
         /// <summary>
         /// Any additional records provided by the DNS server.
         /// </summary>
         [JsonPropertyName("Additional")]
-        public DnsAnswer[] Additional { get; set; }
+        public DnsAnswer[] Additional { get; set; } = Array.Empty<DnsAnswer>();
 
         /// <summary>
         /// An error message, if there was an issue with the DNS query. This is typically included when the HTTP status code is 400 (Bad Request).
         /// </summary>
         [JsonPropertyName("error")]
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
 
         /// <summary>
         /// An extended DNS error code message. For more information, see the <a href="https://developers.cloudflare.com/1.1.1.1/infrastructure/extended-dns-error-codes/">Cloudflare documentation</a>.
         /// </summary>
         [JsonPropertyName("Comment")]
         [JsonConverter(typeof(CommentConverter))]
-        public string Comments { get; set; }
+        public string Comments { get; set; } = string.Empty;
 
         /// <summary>
         /// Extended DNS error information provided by the DNS server.
         /// </summary>
         [JsonPropertyName("extended_dns_errors")]
-        public ExtendedDnsError[] ExtendedDnsErrors { get; set; }
+        public ExtendedDnsError[] ExtendedDnsErrors { get; set; } = Array.Empty<ExtendedDnsError>();
 
         [JsonIgnore]
         private ExtendedDnsErrorInfo[]? _extendedDnsErrorInfo;
@@ -149,7 +149,7 @@ namespace DnsClientX {
         /// The client subnet information that the DNS server used to generate the response.
         /// </summary>
         [JsonPropertyName("edns_client_subnet")]
-        public string EdnsClientSubnet { get; set; }
+        public string EdnsClientSubnet { get; set; } = string.Empty;
 
         /// <summary>
         /// Adds the server details to the DNS questions for output purposes.

--- a/DnsClientX/Exception.cs
+++ b/DnsClientX/Exception.cs
@@ -12,7 +12,7 @@ namespace DnsClientX {
         /// <summary>
         /// Gets or sets the DNS response that caused this exception.
         /// </summary>
-        public DnsResponse Response { get; set; }
+        public DnsResponse? Response { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DnsClientException"/> class with a specified error message.

--- a/DnsClientX/Logging/InternalLogger.cs
+++ b/DnsClientX/Logging/InternalLogger.cs
@@ -14,32 +14,32 @@ public class InternalLogger {
     /// <summary>
     /// Occurs when a verbose message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnVerboseMessage;
+    public event EventHandler<LogEventArgs>? OnVerboseMessage;
 
     /// <summary>
     /// Occurs when a warning message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnWarningMessage;
+    public event EventHandler<LogEventArgs>? OnWarningMessage;
 
     /// <summary>
     /// Occurs when an error message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnErrorMessage;
+    public event EventHandler<LogEventArgs>? OnErrorMessage;
 
     /// <summary>
     /// Occurs when a debug message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnDebugMessage;
+    public event EventHandler<LogEventArgs>? OnDebugMessage;
 
     /// <summary>
     /// Occurs when a progress message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnProgressMessage;
+    public event EventHandler<LogEventArgs>? OnProgressMessage;
 
     /// <summary>
     /// Occurs when an information message is logged.
     /// </summary>
-    public event EventHandler<LogEventArgs> OnInformationMessage;
+    public event EventHandler<LogEventArgs>? OnInformationMessage;
 
     /// <summary>
     /// Gets or sets a value indicating whether verbose messages should be logged.
@@ -235,22 +235,22 @@ public class LogEventArgs : EventArgs {
     /// <summary>
     /// Progress current operation
     /// </summary>
-    public string ProgressCurrentOperation { get; set; }
+    public string ProgressCurrentOperation { get; set; } = string.Empty;
 
     /// <summary>
     /// Progress activity
     /// </summary>
-    public string ProgressActivity { get; set; }
+    public string ProgressActivity { get; set; } = string.Empty;
 
     /// <summary>
     /// Message to be written including arguments substitution
     /// </summary>
-    public string FullMessage { get; set; }
+    public string FullMessage { get; set; } = string.Empty;
 
     /// <summary>
     /// Message to be written
     /// </summary>
-    public string Message { get; set; }
+    public string Message { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the arguments.
@@ -258,7 +258,7 @@ public class LogEventArgs : EventArgs {
     /// <value>
     /// The arguments.
     /// </value>
-    public object[] Args { get; set; }
+    public object[] Args { get; set; } = Array.Empty<object>();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LogEventArgs"/> class.


### PR DESCRIPTION
## Summary
- initialize collections and strings in `DnsResponse`
- allow `DnsClientException.Response` to be nullable
- mark logging events as nullable and default message strings
- adjust PowerShell logger and cmdlet fields to allow nulls

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6878c6aace90832ebab3c822eba0ec0b