### PR TITLE
Fix delegate nullability warnings

### DIFF
--- a/DnsClientX.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/DnsClientX.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -64,20 +64,20 @@ public class InternalLoggerPowerShell {
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private void Logger_OnVerboseMessage(object sender, LogEventArgs e) {
+    private void Logger_OnVerboseMessage(object? sender, LogEventArgs e) {
         if (e.Args != null && e.Args.Length > 0) {
             WriteVerbose(e.Message, e.Args);
         } else {
             WriteVerbose(e.Message);
         }
     }
-    private void Logger_OnDebugMessage(object sender, LogEventArgs e) {
+    private void Logger_OnDebugMessage(object? sender, LogEventArgs e) {
         WriteDebug(e.Message);
     }
-    private void Logger_OnWarningMessage(object sender, LogEventArgs e) {
+    private void Logger_OnWarningMessage(object? sender, LogEventArgs e) {
         WriteWarning(e.Message);
     }
-    private void Logger_OnErrorMessage(object sender, LogEventArgs e) {
+    private void Logger_OnErrorMessage(object? sender, LogEventArgs e) {
         ErrorRecord errorRecord = new ErrorRecord(new Exception(e.Message), "1", ErrorCategory.NotSpecified, null);
         WriteError(errorRecord);
     }
@@ -89,7 +89,7 @@ public class InternalLoggerPowerShell {
     private int GetNextActivityId() {
         return ++_activityIdCounter;
     }
-    private void Logger_OnProgressMessage(object sender, LogEventArgs e) {
+    private void Logger_OnProgressMessage(object? sender, LogEventArgs e) {
         if (_isCurrentActivityCompleted) {
             _currentActivityId = GetNextActivityId();
             _isCurrentActivityCompleted = false;
@@ -111,7 +111,7 @@ public class InternalLoggerPowerShell {
         }
         WriteProgress(progressRecord);
     }
-    private void Logger_OnInformationMessage(object sender, LogEventArgs e) {
+    private void Logger_OnInformationMessage(object? sender, LogEventArgs e) {
         WriteInformation(e.Message);
     }
 

--- a/DnsClientX.PowerShell/OnImportAndRemove.cs
+++ b/DnsClientX.PowerShell/OnImportAndRemove.cs
@@ -29,7 +29,7 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
     /// <param name="sender"></param>
     /// <param name="args"></param>
     /// <returns></returns>
-    private static Assembly? MyResolveEventHandler(object sender, ResolveEventArgs args) {
+    private static Assembly? MyResolveEventHandler(object? sender, ResolveEventArgs args) {
         var libDirectory = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location);
         var directoriesToSearch = new List<string> { libDirectory };
 


### PR DESCRIPTION
## Summary
- fix delegate parameter types to match nullable event signatures

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.CreateException)*

------
https://chatgpt.com/codex/tasks/task_e_6878c6c7bf24832eb41117087af7c4e6