### PR TITLE
Fix XML param tag warnings

### DIFF
--- a/DnsClientX/DnsClientX.QueryDns.cs
+++ b/DnsClientX/DnsClientX.QueryDns.cs
@@ -25,6 +25,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -57,6 +61,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -75,6 +83,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -110,6 +122,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -128,6 +144,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -152,6 +172,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -169,6 +193,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -192,6 +220,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, Uri dnsUri, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -210,6 +242,9 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         public static async Task<DnsResponse> QueryDns(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -234,6 +269,9 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         public static DnsResponse QueryDnsSync(string name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -251,6 +289,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -274,6 +316,9 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -297,6 +342,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, string hostName, DnsRequestFormat requestFormat, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -313,6 +362,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static async Task<DnsResponse[]> QueryDns(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -336,6 +389,10 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors</param>
         /// <param name="maxRetries">Maximum number of retries</param>
         /// <param name="retryDelayMs">Retry delay in milliseconds</param>
+        /// <param name="requestDnsSec">Whether to request DNSSEC data.</param>
+        /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns></returns>
         public static DnsResponse[] QueryDnsSync(string[] name, DnsRecordType[] recordType, DnsEndpoint dnsEndpoint = DnsEndpoint.System, int timeOutMilliseconds = Configuration.DefaultTimeout, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool requestDnsSec = false, bool validateDnsSec = false, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -28,6 +28,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the DNS response.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
@@ -453,6 +455,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <returns>The DNS response.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
@@ -471,6 +475,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of DNS responses.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
@@ -503,6 +509,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <returns>An array of DNS responses.</returns>
         /// <exception cref="DnsClientException">Thrown when an invalid RequestFormat is provided.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the provided name is null or empty.</exception>
@@ -521,6 +529,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains an array of DNS responses.</returns>
         public async Task<DnsResponse[]> Resolve(string[] names, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -548,6 +558,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <returns>An array of DNS responses.</returns>
         public DnsResponse[] ResolveSync(string[] names, DnsRecordType[] types, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false) {
             return Resolve(names, types, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt).RunSync();
@@ -564,6 +576,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The array of DNS responses from all queries.</returns>
         public async Task<DnsResponse[]> Resolve(string[] names, DnsRecordType type, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false, CancellationToken cancellationToken = default) {
@@ -589,6 +603,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <returns>An array of DNS responses.</returns>
         public DnsResponse[] ResolveSync(string[] names, DnsRecordType type, bool requestDnsSec = false, bool validateDnsSec = false, bool returnAllTypes = false, bool retryOnTransient = true, int maxRetries = 3, int retryDelayMs = 200, bool typedRecords = false, bool typedTxtAsTxt = false) {
             return Resolve(names, type, requestDnsSec, validateDnsSec, returnAllTypes, retryOnTransient, maxRetries, retryDelayMs, typedRecords, typedTxtAsTxt).RunSync();
@@ -607,6 +623,8 @@ namespace DnsClientX {
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">Maximum number of retries.</param>
         /// <param name="retryDelayMs">Delay between retries in milliseconds.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Array of DNS responses for each expanded query.</returns>
         public async Task<DnsResponse[]> ResolvePattern(

--- a/DnsClientX/DnsClientX.ResolveFirst.cs
+++ b/DnsClientX/DnsClientX.ResolveFirst.cs
@@ -22,6 +22,8 @@ namespace DnsClientX {
         /// <param name="type">The DNS resource type to resolve. By default, this is the <c>A</c> record.</param>
         /// <param name="requestDnsSec">Whether to request DNSSEC data in the response. When requested, it will be accessible under the <see cref="DnsAnswer"/> array.</param>
         /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>
@@ -51,6 +53,8 @@ namespace DnsClientX {
         /// <param name="type">The DNS resource type to resolve. By default, this is the <c>A</c> record.</param>
         /// <param name="requestDnsSec">Whether to request DNSSEC data in the response. When requested, it will be accessible under the <see cref="DnsAnswer"/> array.</param>
         /// <param name="validateDnsSec">Whether to validate DNSSEC data.</param>
+        /// <param name="typedRecords">Return answers as typed records.</param>
+        /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
         /// <param name="retryOnTransient">Whether to retry on transient errors.</param>
         /// <param name="maxRetries">The maximum number of retries.</param>
         /// <param name="retryDelayMs">The delay between retries in milliseconds.</param>

--- a/DnsClientX/DnsClientX.cs
+++ b/DnsClientX/DnsClientX.cs
@@ -144,6 +144,7 @@ namespace DnsClientX {
         /// <param name="enableCache">Enable in-memory caching of responses.</param>
         /// <param name="useTcpFallback">Falls back to TCP when UDP responses are truncated.</param>
         /// <param name="webProxy">Optional HTTP proxy.</param>
+        /// <param name="maxConnectionsPerServer">Maximum number of concurrent connections per server.</param>
         public ClientX(
             DnsEndpoint endpoint = DnsEndpoint.Cloudflare,
             DnsSelectionStrategy dnsSelectionStrategy = DnsSelectionStrategy.First,
@@ -184,6 +185,7 @@ namespace DnsClientX {
         /// <param name="enableCache">Enable in-memory caching of responses.</param>
         /// <param name="useTcpFallback">Falls back to TCP when UDP responses are truncated.</param>
         /// <param name="webProxy">Optional HTTP proxy.</param>
+        /// <param name="maxConnectionsPerServer">Maximum number of concurrent connections per server.</param>
         public ClientX(
             string hostname,
             DnsRequestFormat requestFormat,
@@ -224,6 +226,7 @@ namespace DnsClientX {
         /// <param name="enableCache">Enable in-memory caching of responses.</param>
         /// <param name="useTcpFallback">Falls back to TCP when UDP responses are truncated.</param>
         /// <param name="webProxy">Optional HTTP proxy.</param>
+        /// <param name="maxConnectionsPerServer">Maximum number of concurrent connections per server.</param>
         public ClientX(
             Uri baseUri,
             DnsRequestFormat requestFormat,

--- a/DnsClientX/DnsRecords/DnsRecordFactory.cs
+++ b/DnsClientX/DnsRecords/DnsRecordFactory.cs
@@ -11,6 +11,7 @@ public static class DnsRecordFactory {
     /// Parses an answer into a typed record if the type is known.
     /// </summary>
     /// <param name="answer">Answer to parse.</param>
+    /// <param name="typedTxtAsTxt">Return TXT answers as simple TXT records.</param>
     /// <returns>Typed record instance or <c>null</c> if the type is not supported.</returns>
     public static object? Create(DnsAnswer answer, bool typedTxtAsTxt = false) {
         switch (answer.Type) {

--- a/DnsClientX/ProtocolDnsWire/DnsMessage.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsMessage.cs
@@ -42,6 +42,8 @@ namespace DnsClientX {
         /// <param name="udpBufferSize">UDP buffer size for EDNS.</param>
         /// <param name="subnet">Optional EDNS client subnet.</param>
         /// <param name="checkingDisabled">Whether to set the CD bit in OPT TTL.</param>
+        /// <param name="signingKey">Optional key for DNS message signing.</param>
+        /// <param name="options">Additional EDNS options.</param>
         public DnsMessage(string name, DnsRecordType type, bool requestDnsSec, bool enableEdns, int udpBufferSize, string? subnet, bool checkingDisabled, AsymmetricAlgorithm? signingKey, System.Collections.Generic.IEnumerable<EdnsOption>? options = null)
             : this(name, type, new DnsMessageOptions(requestDnsSec, enableEdns, udpBufferSize,
                 string.IsNullOrEmpty(subnet) ? null : new EdnsClientSubnetOption(subnet), checkingDisabled, signingKey, options)) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -18,6 +18,7 @@ namespace DnsClientX {
         /// <param name="validateDnsSec"></param>
         /// <param name="debug"></param>
         /// <param name="endpointConfiguration">Provide configuration so it can be added to Question for display purposes</param>
+        /// <param name="maxRetries">Maximum number of retry attempts.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The DNS response.</returns>
         /// <exception cref="ArgumentNullException"></exception>
@@ -119,7 +120,8 @@ namespace DnsClientX {
         /// <summary>
         /// Sends a DNS query over UDP and returns the response.
         /// </summary>
-        /// <param name="query"></param>
+        /// <param name="udpClient">Client used for sending the query.</param>
+        /// <param name="query">Wire-format query bytes.</param>
         /// <param name="ipAddress"></param>
         /// <param name="port"></param>
         /// <param name="timeoutMilliseconds">Timeout in milliseconds.</param>


### PR DESCRIPTION
## Summary
- document maxConnectionsPerServer parameter
- add missing parameter tags for QueryDns APIs
- update docs for Resolve methods
- document typed record parameters for ResolveFirst helpers
- document DnsRecordFactory options and udp helper parameters

## Testing
- `dotnet build DnsClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_6878c6e0cc04832eb9da66dc7c05288e