### PR TITLE
Fix CS8602 and CS1574 warnings

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -216,7 +216,7 @@ namespace DnsClientX.PowerShell {
                     if (IPAddress.TryParse(trimmed, out _)) {
                         validServers.Add(trimmed);
                     } else {
-                        _logger.WriteError("Malformed server address '{0}'.", serverEntry);
+                    _logger?.WriteError("Malformed server address '{0}'.", serverEntry);
                     }
                 }
 
@@ -238,7 +238,7 @@ namespace DnsClientX.PowerShell {
                     }
                     var aggregatedResults = new List<DnsResponse>();
                     foreach (string serverName in serverOrder) {
-                        _logger.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, serverName);
+                        _logger?.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, serverName);
                         var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, serverName, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                         aggregatedResults.AddRange(result);
                     }
@@ -246,7 +246,7 @@ namespace DnsClientX.PowerShell {
                 } else if (Fallback.IsPresent) {
                     var aggregatedResults = new List<DnsResponse>();
                     foreach (string serverName in serverOrder) {
-                        _logger.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, serverName);
+                        _logger?.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, serverName);
                         var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, serverName, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                         aggregatedResults.AddRange(result);
                         if (aggregatedResults.Any(r => r.Status == DnsResponseCode.NoError)) {
@@ -256,7 +256,7 @@ namespace DnsClientX.PowerShell {
                     results = aggregatedResults;
                 } else {
                     string myServer = serverOrder.First();
-                    _logger.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, myServer);
+                    _logger?.WriteVerbose("Querying DNS for {0} with type {1}, {2}", names, types, myServer);
                     var result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, myServer, DnsRequestFormat.DnsOverUDP, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                     results = result;
                 }
@@ -265,11 +265,11 @@ namespace DnsClientX.PowerShell {
                     string serverUsed = record.Questions.FirstOrDefault().HostName;
                     if (record.Status == DnsResponseCode.NoError)
                     {
-                        _logger.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, serverUsed, record.RetryCount);
+                        _logger?.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, serverUsed, record.RetryCount);
                     }
                     else
                     {
-                        _logger.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, serverUsed, record.Error);
+                        _logger?.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, serverUsed, record.Error);
                     }
 
                     if (FullResponse.IsPresent) {
@@ -281,10 +281,10 @@ namespace DnsClientX.PowerShell {
             } else {
                 DnsResponse[] result;
                 if (DnsProvider == null) {
-                    _logger.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, "Default");
+                    _logger?.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, "Default");
                     result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                 } else {
-                    _logger.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, DnsProvider.Value);
+                    _logger?.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, DnsProvider.Value);
                     result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, DnsProvider.Value, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, typedTxtAsTxt: TypedTxtAsTxt.IsPresent));
                 }
 
@@ -293,17 +293,17 @@ namespace DnsClientX.PowerShell {
                     {
                         if (DnsProvider == null)
                         {
-                            _logger.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, "Default", record.RetryCount);
+                            _logger?.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, "Default", record.RetryCount);
                         }
                         else
                         {
-                            _logger.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, DnsProvider.Value, record.RetryCount);
+                            _logger?.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, DnsProvider.Value, record.RetryCount);
                         }
                     } else {
                         if (DnsProvider == null) {
-                            _logger.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, "Default", record.Error);
+                            _logger?.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, "Default", record.Error);
                         } else {
-                            _logger.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, DnsProvider.Value, record.Error);
+                            _logger?.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, DnsProvider.Value, record.Error);
                         }
                     }
                     if (FullResponse.IsPresent) {

--- a/DnsClientX.Tests/CancellationTests.cs
+++ b/DnsClientX.Tests/CancellationTests.cs
@@ -22,7 +22,7 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// Ensures that <see cref="ClientX.Resolve(string,DnsRecordType,bool,bool,bool,bool,int,int,CancellationToken)"/> respects early cancellation.
+        /// Ensures that <see cref="ClientX.Resolve(string,DnsRecordType,bool,bool,bool,bool,int,int,bool,bool,System.Threading.CancellationToken)"/> respects early cancellation.
         /// </summary>
         [Fact]
         public async Task ResolveShouldCancelEarly() {
@@ -41,7 +41,7 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// Verifies that <see cref="ClientX.QueryDns(string,DnsRecordType,DnsEndpoint,DnsSelectionStrategy,int,bool,int,int,bool,bool,bool,CancellationToken)"/> throws when the token is already cancelled.
+        /// Verifies that <see cref="ClientX.QueryDns(string,DnsRecordType,DnsEndpoint,DnsSelectionStrategy,int,bool,int,int,bool,bool,bool,bool,System.Threading.CancellationToken)"/> throws when the token is already cancelled.
         /// </summary>
         [Fact]
         public async Task QueryDnsShouldCancelEarly() {

--- a/DnsClientX.Tests/CompareProvidersResolveAll.cs
+++ b/DnsClientX.Tests/CompareProvidersResolveAll.cs
@@ -2,7 +2,7 @@ using Xunit.Abstractions;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Compares <see cref="ClientX.ResolveAll(string,DnsRecordType,bool,bool,bool,bool,int,int,System.Threading.CancellationToken)"/> results across providers.
+    /// Compares <see cref="ClientX.ResolveAll(string,DnsRecordType,bool,bool,bool,int,int,System.Threading.CancellationToken)"/> results across providers.
     /// </summary>
     public class CompareProviders(ITestOutputHelper output) {
         /// <summary>

--- a/DnsClientX/DnsClientX.ResolveAll.cs
+++ b/DnsClientX/DnsClientX.ResolveAll.cs
@@ -43,7 +43,7 @@ namespace DnsClientX {
             }
 
             // If the response is null, return an empty array
-            if (res.Answers is null) return Array.Empty<DnsAnswer>();
+            if (res?.Answers is null) return Array.Empty<DnsAnswer>();
 
             return res.Answers.Where(x => x.Type == type).ToArray();
         }
@@ -79,7 +79,7 @@ namespace DnsClientX {
             }
 
             // If the response is null, return an empty array
-            if (res.Answers is null) return Array.Empty<DnsAnswer>();
+            if (res?.Answers is null) return Array.Empty<DnsAnswer>();
 
             return res.Answers
                 .Where(x => x.Type == type && x.Data.Contains(filter))
@@ -117,7 +117,7 @@ namespace DnsClientX {
             }
 
             // If the response is null, return an empty array
-            if (res.Answers is null) return Array.Empty<DnsAnswer>();
+            if (res?.Answers is null) return Array.Empty<DnsAnswer>();
 
             return res.Answers
                 .Where(x => x.Type == type && regexPattern.IsMatch(x.Data))

--- a/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
+++ b/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
@@ -118,8 +118,8 @@ namespace DnsClientX {
                         new DnsQuestion {
                             Name = name,
                             RequestFormat = DnsRequestFormat.DnsOverHttp2,
-                            HostName = client.BaseAddress.Host,
-                            Port = client.BaseAddress.Port,
+                            HostName = client.BaseAddress?.Host ?? string.Empty,
+                            Port = client.BaseAddress?.Port ?? 0,
                             Type = type,
                             OriginalName = name
                         }
@@ -135,8 +135,8 @@ namespace DnsClientX {
                         new DnsQuestion {
                             Name = name,
                             RequestFormat = DnsRequestFormat.DnsOverHttp2,
-                            HostName = client.BaseAddress.Host,
-                            Port = client.BaseAddress.Port,
+                            HostName = client.BaseAddress?.Host ?? string.Empty,
+                            Port = client.BaseAddress?.Port ?? 0,
                             Type = type,
                             OriginalName = name
                         }

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -137,8 +137,8 @@ namespace DnsClientX {
                         new DnsQuestion {
                             Name = name,
                             RequestFormat = DnsRequestFormat.DnsOverHttp3,
-                            HostName = client.BaseAddress.Host,
-                            Port = client.BaseAddress.Port,
+                            HostName = client.BaseAddress?.Host ?? string.Empty,
+                            Port = client.BaseAddress?.Port ?? 0,
                             Type = type,
                             OriginalName = name
                         }
@@ -154,8 +154,8 @@ namespace DnsClientX {
                         new DnsQuestion {
                             Name = name,
                             RequestFormat = DnsRequestFormat.DnsOverHttp3,
-                            HostName = client.BaseAddress.Host,
-                            Port = client.BaseAddress.Port,
+                            HostName = client.BaseAddress?.Host ?? string.Empty,
+                            Port = client.BaseAddress?.Port ?? 0,
                             Type = type,
                             OriginalName = name
                         }

--- a/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
+++ b/DnsClientX/ProtocolDnsJson/DnsJsonResolve.cs
@@ -58,8 +58,8 @@ namespace DnsClientX {
                         new DnsQuestion {
                             Name = name,
                             RequestFormat = DnsRequestFormat.DnsOverHttps,
-                            HostName = client.BaseAddress.Host,
-                            Port = client.BaseAddress.Port,
+                            HostName = client.BaseAddress?.Host ?? string.Empty,
+                            Port = client.BaseAddress?.Port ?? 0,
                             Type = type,
                             OriginalName = name
                         }
@@ -123,8 +123,8 @@ namespace DnsClientX {
                         new DnsQuestion {
                             Name = name,
                             RequestFormat = DnsRequestFormat.DnsOverHttps,
-                            HostName = client.BaseAddress.Host,
-                            Port = client.BaseAddress.Port,
+                            HostName = client.BaseAddress?.Host ?? string.Empty,
+                            Port = client.BaseAddress?.Port ?? 0,
                             Type = type,
                             OriginalName = name
                         }

--- a/DnsClientX/ProtocolDnsWire/DnsWire.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWire.cs
@@ -36,7 +36,8 @@ namespace DnsClientX {
                 if (bytes != null) {
                     dnsWireFormatBytes = bytes;
                 } else {
-                    using Stream stream = await res.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    HttpResponseMessage notNullRes = res ?? throw new ArgumentNullException(nameof(res));
+                    using Stream stream = await notNullRes.Content.ReadAsStreamAsync().ConfigureAwait(false);
                     if (stream.Length == 0) throw new DnsClientException("Response content is empty, can't parse as DNS wire format.");
                     // Ensure the stream's position is at the start
                     stream.Position = 0;
@@ -46,9 +47,9 @@ namespace DnsClientX {
                 }
 
                 if (debug) {
-                    if (res != null) {
+                    if (res?.RequestMessage?.RequestUri is { } requestUri) {
                         // Print the DNS wire format bytes to the logger
-                        Settings.Logger.WriteDebug("Response Uri: " + res.RequestMessage.RequestUri);
+                        Settings.Logger.WriteDebug("Response Uri: " + requestUri);
                     }
 
                     Settings.Logger.WriteDebug("Response DnsWireFormatBytes: " + BitConverter.ToString(dnsWireFormatBytes));

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolve.cs
@@ -102,8 +102,8 @@ namespace DnsClientX {
                     new DnsQuestion() {
                         Name = name,
                         RequestFormat = DnsRequestFormat.DnsOverHttps,
-                        HostName = client.BaseAddress.Host,
-                        Port = client.BaseAddress.Port,
+                        HostName = client.BaseAddress?.Host ?? string.Empty,
+                        Port = client.BaseAddress?.Port ?? 0,
                         Type = type,
                         OriginalName = name
                     }


### PR DESCRIPTION
## Summary
- handle possible null `BaseAddress` across DNS HTTP handlers
- guard against null response in `ResolveAll`
- correct XML cref references in tests
- ensure PowerShell cmdlet handles optional logger

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6878d3500c18832eb0ba6e75e53665d1