### PR TITLE
Add XML docs for test coverage

### DIFF
--- a/DnsClientX.Tests/IsValidDnsAddressTests.cs
+++ b/DnsClientX.Tests/IsValidDnsAddressTests.cs
@@ -3,12 +3,20 @@ using System.Reflection;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests the internal <c>SystemInformation.IsValidDnsAddress</c> method via reflection.
+    /// </summary>
     public class IsValidDnsAddressTests {
         private static bool InvokeIsValid(string ip) {
             MethodInfo method = typeof(SystemInformation).GetMethod("IsValidDnsAddress", BindingFlags.NonPublic | BindingFlags.Static)!;
             return (bool)method.Invoke(null, new object[] { IPAddress.Parse(ip) })!;
         }
 
+        /// <summary>
+        /// Validates a variety of addresses to ensure the helper behaves as expected.
+        /// </summary>
+        /// <param name="ip">The address to check.</param>
+        /// <param name="expected">Whether the address should be considered valid.</param>
         [Theory]
         [InlineData("1.1.1.1", true)]
         [InlineData("169.254.0.1", false)]

--- a/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
+++ b/DnsClientX.Tests/MaxConnectionsPerServerTests.cs
@@ -3,7 +3,13 @@ using System.Reflection;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests that the HTTP handler honors the configured <c>MaxConnectionsPerServer</c> value.
+    /// </summary>
     public class MaxConnectionsPerServerTests {
+        /// <summary>
+        /// Verifies that the handler uses the configuration value for maximum connections.
+        /// </summary>
         [Fact]
         public void HandlerUsesConfigurationValue() {
             using ClientX client = new ClientX(

--- a/DnsClientX.Tests/MeasureLatencyTests.cs
+++ b/DnsClientX.Tests/MeasureLatencyTests.cs
@@ -3,7 +3,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests the <see cref="ClientX.MeasureLatencyAsync"/> helper method.
+    /// </summary>
     public class MeasureLatencyTests {
+        /// <summary>
+        /// Ensures the measured latency is greater than zero.
+        /// </summary>
         [Fact]
         public async Task MeasureLatency_ReturnsPositiveTime() {
             using var client = new ClientX(DnsEndpoint.Cloudflare);

--- a/DnsClientX.Tests/NextDnsTests.cs
+++ b/DnsClientX.Tests/NextDnsTests.cs
@@ -2,7 +2,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Integration tests targeting the NextDNS public resolver.
+    /// </summary>
     public class NextDnsTests {
+        /// <summary>
+        /// Verifies that records can be resolved against NextDNS.
+        /// </summary>
         [Fact]
         public async Task ResolveUsingNextDns() {
             using var client = new ClientX(DnsEndpoint.NextDNS) { Debug = false };

--- a/DnsClientX.Tests/NoParallelCollection.cs
+++ b/DnsClientX.Tests/NoParallelCollection.cs
@@ -1,6 +1,9 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Test collection used to disable parallel execution for tests that are not thread safe.
+    /// </summary>
     [CollectionDefinition("NoParallel", DisableParallelization = true)]
     public class NoParallelCollection : ICollectionFixture<object> { }
 }

--- a/DnsClientX.Tests/OriginalNameTests.cs
+++ b/DnsClientX.Tests/OriginalNameTests.cs
@@ -1,7 +1,13 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests ensuring <see cref="DnsQuestion"/> and <see cref="DnsAnswer"/> preserve the original name value.
+    /// </summary>
     public class OriginalNameTests {
+        /// <summary>
+        /// Verifies that setting <see cref="DnsQuestion.Name"/> also populates <see cref="DnsQuestion.OriginalName"/>.
+        /// </summary>
         [Fact]
         public void QuestionSetterSetsOriginalName() {
             DnsQuestion q = new() { Name = "example.com." };
@@ -9,6 +15,9 @@ namespace DnsClientX.Tests {
             Assert.Equal("example.com", q.Name);
         }
 
+        /// <summary>
+        /// Verifies that setting <see cref="DnsAnswer.Name"/> also populates <see cref="DnsAnswer.OriginalName"/>.
+        /// </summary>
         [Fact]
         public void AnswerSetterSetsOriginalName() {
             DnsAnswer a = new() { Name = "example.net." };

--- a/DnsClientX.Tests/ParseResolvConfTests.cs
+++ b/DnsClientX.Tests/ParseResolvConfTests.cs
@@ -4,7 +4,13 @@ using System.Reflection;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for the internal <c>SystemInformation.ParseResolvConf</c> method.
+    /// </summary>
     public class ParseResolvConfTests {
+        /// <summary>
+        /// Ensures parsing a missing file results in an empty list of servers.
+        /// </summary>
         [Fact]
         public void MissingFile_ReturnsEmptyList() {
             string tempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/DnsClientX.Tests/Quad9ReliabilityFix.cs
+++ b/DnsClientX.Tests/Quad9ReliabilityFix.cs
@@ -4,6 +4,9 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Exploratory tests demonstrating retry logic for unreliable Quad9 DNS endpoints.
+    /// </summary>
     public class Quad9ReliabilityFix {
         private readonly ITestOutputHelper output;
 
@@ -11,6 +14,9 @@ namespace DnsClientX.Tests {
             this.output = output;
         }
 
+        /// <summary>
+        /// Demonstrates retry logic when querying Quad9 which tends to throttle automated requests.
+        /// </summary>
         [Theory(Skip = "External dependency - unreliable for automated testing")]
         [InlineData(DnsEndpoint.Quad9)]
         [InlineData(DnsEndpoint.Quad9ECS)]
@@ -58,6 +64,9 @@ namespace DnsClientX.Tests {
                                $"Consider using Cloudflare or Google DNS for more reliable automated testing.");
         }
 
+        /// <summary>
+        /// Checks that recommended providers respond reliably for automated tests.
+        /// </summary>
         [Fact(Skip = "External dependency - unreliable for automated testing")]
         public async Task RecommendedReliableProvidersTest() {
             // Test providers that are more reliable for automated testing
@@ -92,6 +101,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Outputs troubleshooting information about Quad9 reliability in automated scenarios.
+        /// </summary>
         [Fact(Skip = "External dependency - unreliable for automated testing")]
         public void ExplainQuad9Issues() {
             output.WriteLine("Quad9 Reliability Issues Explanation:");

--- a/DnsClientX.Tests/QueryDnsByEndpoint.cs
+++ b/DnsClientX.Tests/QueryDnsByEndpoint.cs
@@ -1,5 +1,14 @@
 namespace DnsClientX.Tests {
     public class QueryDnsByEndpoint {
+        /// <summary>
+        /// Ensures TXT queries succeed for the given endpoint.
+        /// </summary>
+        /// <summary>
+        /// Ensures A record queries succeed for the given endpoint.
+        /// </summary>
+        /// <summary>
+        /// Ensures PTR queries succeed for the given endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]

--- a/DnsClientX.Tests/QueryDnsByHostName.cs
+++ b/DnsClientX.Tests/QueryDnsByHostName.cs
@@ -1,5 +1,14 @@
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests resolving records by specifying host name and request format.
+    /// </summary>
     public class QueryDnsByHostName {
+        /// <summary>
+        /// Ensures TXT queries succeed when specifying the DNS host.
+        /// </summary>
+        /// <summary>
+        /// Ensures multiple domains can be resolved for a given host name.
+        /// </summary>
         [Theory]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("family.cloudflare-dns.com", DnsRequestFormat.DnsOverHttpsJSON)]
@@ -15,6 +24,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Ensures A record queries succeed when specifying the DNS host.
+        /// </summary>
         [Theory]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("family.cloudflare-dns.com", DnsRequestFormat.DnsOverHttpsJSON)]
@@ -32,6 +44,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Ensures multiple domains can be resolved for a given host name.
+        /// </summary>
         [Theory]
         [InlineData("1.1.1.1", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("family.cloudflare-dns.com", DnsRequestFormat.DnsOverHttpsJSON)]

--- a/DnsClientX.Tests/QueryDnsByUri.cs
+++ b/DnsClientX.Tests/QueryDnsByUri.cs
@@ -1,7 +1,13 @@
 using System;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests querying DNS endpoints by providing the full request URI.
+    /// </summary>
     public class QueryDnsByUri {
+        /// <summary>
+        /// Ensures TXT queries succeed when the endpoint is specified via URI.
+        /// </summary>
         [Theory]
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]
@@ -17,6 +23,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Ensures A record queries succeed when the endpoint is specified via URI.
+        /// </summary>
         [Theory]
         [InlineData("https://1.1.1.1/dns-query", DnsRequestFormat.DnsOverHttpsJSON)]
         [InlineData("https://8.8.8.8/resolve", DnsRequestFormat.DnsOverHttpsJSON)]

--- a/DnsClientX.Tests/QueryDnsCancellationTests.cs
+++ b/DnsClientX.Tests/QueryDnsCancellationTests.cs
@@ -3,7 +3,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests cancellation behavior for the <see cref="ClientX.QueryDns"/> method.
+    /// </summary>
     public class QueryDnsCancellationTests {
+        /// <summary>
+        /// Cancels a DNS query before execution and expects a cancelled task.
+        /// </summary>
         [Fact]
         public async Task QueryDns_RootServer_CancelledTask() {
             using var cts = new CancellationTokenSource();

--- a/DnsClientX.Tests/QueryDnsFailing.cs
+++ b/DnsClientX.Tests/QueryDnsFailing.cs
@@ -1,5 +1,11 @@
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests scenarios expected to fail such as unreachable servers.
+    /// </summary>
     public class QueryDnsFailing {
+        /// <summary>
+        /// Queries an invalid server expecting a timeout.
+        /// </summary>
         [Theory]
         [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]
         [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]
@@ -9,6 +15,9 @@ namespace DnsClientX.Tests {
         }
 
 
+        /// <summary>
+        /// Resolves using a <see cref="ClientX"/> instance pointing at an invalid server expecting failure.
+        /// </summary>
         [Theory]
         [InlineData("8.8.1.1", DnsRequestFormat.DnsOverUDP)]
         [InlineData("a1akam1.net", DnsRequestFormat.DnsOverUDP)]

--- a/DnsClientX.Tests/QueryDnsIDN.cs
+++ b/DnsClientX.Tests/QueryDnsIDN.cs
@@ -1,5 +1,11 @@
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests resolving internationalized domain names (IDN).
+    /// </summary>
     public class QueryDnsIDN {
+        /// <summary>
+        /// Ensures IDN queries resolve correctly to punycode using the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -11,9 +17,6 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Google)]
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
-
-
-
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {

--- a/DnsClientX.Tests/QueryDnsJsonPost.cs
+++ b/DnsClientX.Tests/QueryDnsJsonPost.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests that JSON-based DoH endpoints are invoked using HTTP POST.
+    /// </summary>
     public class QueryDnsJsonPost {
         private class JsonPostHandler : HttpMessageHandler {
             public HttpRequestMessage? Request { get; private set; }
@@ -31,6 +34,9 @@ namespace DnsClientX.Tests {
             clientField.SetValue(client, httpClient);
         }
 
+        /// <summary>
+        /// Sends a query and verifies that the request uses POST with a JSON payload.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.CloudflareJsonPost)]
         [InlineData(DnsEndpoint.GoogleJsonPost)]

--- a/DnsClientX.Tests/QueryDnsOverHttp3.cs
+++ b/DnsClientX.Tests/QueryDnsOverHttp3.cs
@@ -3,7 +3,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests DNS over HTTP/3 endpoints.
+    /// </summary>
     public class QueryDnsOverHttp3 {
+        /// <summary>
+        /// Ensures A record resolution works over HTTP/3.
+        /// </summary>
         [Theory(Skip = "External dependency - network unreachable in CI")]
         [InlineData("1.1.1.1")]
         [InlineData("8.8.8.8")]

--- a/DnsClientX.Tests/QueryDnsOverQuic.cs
+++ b/DnsClientX.Tests/QueryDnsOverQuic.cs
@@ -3,10 +3,16 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests DNS over QUIC endpoints.
+    /// </summary>
     public class QueryDnsOverQuic {
         [Theory]
         [InlineData(DnsEndpoint.CloudflareQuic)]
         [InlineData(DnsEndpoint.GoogleQuic)]
+        /// <summary>
+        /// Ensures A record resolution works over QUIC.
+        /// </summary>
         public async Task ShouldResolveA(DnsEndpoint endpoint) {
             var response = await ClientX.QueryDns("evotec.pl", DnsRecordType.A, endpoint);
             Assert.NotEmpty(response.Answers);

--- a/DnsClientX.Tests/QueryDnsSyncCancellationTests.cs
+++ b/DnsClientX.Tests/QueryDnsSyncCancellationTests.cs
@@ -3,7 +3,13 @@ using Xunit;
 using DnsClientX;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests cancellation behavior for the synchronous <see cref="ClientX.QueryDnsSync"/> method.
+    /// </summary>
     public class QueryDnsSyncCancellationTests {
+        /// <summary>
+        /// Cancels a synchronous DNS query prior to execution and expects an exception.
+        /// </summary>
         [Fact]
         public void QueryDnsSync_RootServer_CancelledTask() {
             using var cts = new CancellationTokenSource();

--- a/DnsClientX.Tests/QueryDnsWirePost.cs
+++ b/DnsClientX.Tests/QueryDnsWirePost.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests that wire format DoH endpoints are invoked using HTTP POST.
+    /// </summary>
     public class QueryDnsWirePost {
         private class WirePostHandler : HttpMessageHandler {
             public HttpRequestMessage? Request { get; private set; }
@@ -27,6 +30,9 @@ namespace DnsClientX.Tests {
             clientField.SetValue(client, httpClient);
         }
 
+        /// <summary>
+        /// Sends a query and verifies that the wire format request uses POST.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.CloudflareWireFormatPost)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]

--- a/DnsClientX.Tests/RegexCultureInvariantTests.cs
+++ b/DnsClientX.Tests/RegexCultureInvariantTests.cs
@@ -5,7 +5,13 @@ using System.Threading;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests that regex-based filtering behaves consistently across cultures.
+    /// </summary>
     public class RegexCultureInvariantTests {
+        /// <summary>
+        /// Verifies <see cref="DnsAnswer.Data"/> conversion is not affected by culture.
+        /// </summary>
         [Theory]
         [InlineData("en-US")]
         [InlineData("tr-TR")]
@@ -26,6 +32,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Ensures regex filtering yields the same results regardless of culture.
+        /// </summary>
         [Theory]
         [InlineData("en-US")]
         [InlineData("tr-TR")]
@@ -52,6 +61,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Ensures substring filtering yields the same results regardless of culture.
+        /// </summary>
         [Theory]
         [InlineData("en-US")]
         [InlineData("tr-TR")]

--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -1,7 +1,22 @@
 using System.Diagnostics;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for the <see cref="ClientX.ResolveAll"/> API.
+    /// </summary>
     public class ResolveAll {
+        /// <summary>
+        /// Resolves TXT records for the given endpoint.
+        /// </summary>
+        /// <summary>
+        /// Resolves A records for the given endpoint.
+        /// </summary>
+        /// <summary>
+        /// Synchronous TXT resolution across endpoints.
+        /// </summary>
+        /// <summary>
+        /// Synchronous A record resolution across endpoints.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -75,9 +90,6 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Google)]
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
-
-
-
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
 #if DNS_OVER_QUIC
@@ -124,6 +136,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Ensures no delay occurs when <c>maxRetries</c> is set to one.
+        /// </summary>
         [Fact]
         public async Task ShouldNotDelayWhenMaxRetriesIsOne() {
             using var Client = new ClientX(DnsEndpoint.Cloudflare);

--- a/DnsClientX.Tests/ResolveAsyncEnumerableTests.cs
+++ b/DnsClientX.Tests/ResolveAsyncEnumerableTests.cs
@@ -3,7 +3,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for <see cref="ClientX.ResolveAsyncEnumerable"/> which returns results lazily.
+    /// </summary>
     public class ResolveAsyncEnumerableTests {
+        /// <summary>
+        /// Ensures multiple responses are yielded for multiple names and types.
+        /// </summary>
         [Fact]
         public async Task ResolveAsyncEnumerable_MultipleResponses() {
             using var client = new ClientX(DnsEndpoint.System);
@@ -20,6 +26,9 @@ namespace DnsClientX.Tests {
             Assert.Equal(names.Length * types.Length, count);
         }
 
+        /// <summary>
+        /// Ensures an empty enumeration when no names are provided.
+        /// </summary>
         [Fact]
         public async Task ResolveAsyncEnumerable_EmptyNames_YieldsNothing() {
             using var client = new ClientX(DnsEndpoint.System);

--- a/DnsClientX.Tests/ResolveConcurrencyTests.cs
+++ b/DnsClientX.Tests/ResolveConcurrencyTests.cs
@@ -4,7 +4,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests that concurrent resolve operations do not throw errors.
+    /// </summary>
     public class ResolveConcurrencyTests {
+        /// <summary>
+        /// Resolves in parallel and ensures each result contains answers.
+        /// </summary>
         [Fact]
         public async Task ShouldResolveConcurrentlyWithoutErrors() {
             using var client = new ClientX(DnsEndpoint.System);

--- a/DnsClientX.Tests/ResolveEdgeCaseTests.cs
+++ b/DnsClientX.Tests/ResolveEdgeCaseTests.cs
@@ -4,13 +4,22 @@ using System.Text.RegularExpressions;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests edge cases and invalid parameters for resolve APIs.
+    /// </summary>
     public class ResolveEdgeCaseTests {
+        /// <summary>
+        /// Ensures <see cref="ClientX.ResolveAllSync"/> throws when the name is invalid.
+        /// </summary>
         [Fact]
         public void ResolveAllSync_InvalidName_Throws() {
             using var client = new ClientX();
             Assert.Throws<ArgumentNullException>(() => client.ResolveAllSync(string.Empty));
         }
 
+        /// <summary>
+        /// Ensures <see cref="ClientX.ResolveFilter(string,DnsRecordType,string,bool,int,int,bool,bool,int?,System.Threading.CancellationToken)"/> throws on invalid name.
+        /// </summary>
         [Fact]
         public async Task ResolveFilter_InvalidName_Throws() {
             using var client = new ClientX();
@@ -18,6 +27,9 @@ namespace DnsClientX.Tests {
                 () => client.ResolveFilter(string.Empty, DnsRecordType.A, "filter", retryOnTransient: false));
         }
 
+        /// <summary>
+        /// Ensures resolving with a regex filter throws when the name is invalid.
+        /// </summary>
         [Fact]
         public async Task ResolveFilterRegex_InvalidName_Throws() {
             using var client = new ClientX();

--- a/DnsClientX.Tests/ResolveFilterLineTests.cs
+++ b/DnsClientX.Tests/ResolveFilterLineTests.cs
@@ -3,9 +3,15 @@ using System.Text.RegularExpressions;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests filtering TXT answers line by line.
+    /// </summary>
     public class ResolveFilterLineTests {
         private static DnsAnswer CreateTxt(string data) => new() { Name = "example.com", Type = DnsRecordType.TXT, TTL = 300, DataRaw = data };
 
+        /// <summary>
+        /// Ensures substring filtering returns the line containing the text.
+        /// </summary>
         [Fact]
         public void FilterAnswers_ReturnsMatchingLine() {
             var client = new ClientX();
@@ -16,6 +22,9 @@ namespace DnsClientX.Tests {
             Assert.Equal("line2", result[0].Data);
         }
 
+        /// <summary>
+        /// Ensures regex filtering returns the line matching the pattern.
+        /// </summary>
         [Fact]
         public void FilterAnswersRegex_ReturnsMatchingLine() {
             var client = new ClientX();

--- a/DnsClientX.Tests/ResolveFilterNullDataTests.cs
+++ b/DnsClientX.Tests/ResolveFilterNullDataTests.cs
@@ -3,6 +3,9 @@ using System.Text.RegularExpressions;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests filtering helpers when answers contain empty data strings.
+    /// </summary>
     public class ResolveFilterNullDataTests {
         private static DnsAnswer CreateAnswer(string dataRaw, DnsRecordType type) {
             return new DnsAnswer {
@@ -13,6 +16,9 @@ namespace DnsClientX.Tests {
             };
         }
 
+        /// <summary>
+        /// Ensures answers with empty data are ignored by <c>FilterAnswers</c>.
+        /// </summary>
         [Fact]
         public void FilterAnswers_ShouldIgnoreEmptyData() {
             var client = new ClientX();
@@ -22,6 +28,9 @@ namespace DnsClientX.Tests {
             Assert.Empty(result);
         }
 
+        /// <summary>
+        /// Ensures answers with empty data are ignored by <c>FilterAnswersRegex</c>.
+        /// </summary>
         [Fact]
         public void FilterAnswersRegex_ShouldIgnoreEmptyData() {
             var client = new ClientX();
@@ -31,6 +40,9 @@ namespace DnsClientX.Tests {
             Assert.Empty(result);
         }
 
+        /// <summary>
+        /// Validates <c>HasMatchingAnswers</c> returns false when data is empty.
+        /// </summary>
         [Fact]
         public void HasMatchingAnswers_ShouldReturnFalseForEmptyData() {
             var client = new ClientX();
@@ -40,6 +52,9 @@ namespace DnsClientX.Tests {
             Assert.False(result);
         }
 
+        /// <summary>
+        /// Validates <c>HasMatchingAnswersRegex</c> returns false when data is empty.
+        /// </summary>
         [Fact]
         public void HasMatchingAnswersRegex_ShouldReturnFalseForEmptyData() {
             var client = new ClientX();

--- a/DnsClientX.Tests/ResolvePatternTests.cs
+++ b/DnsClientX.Tests/ResolvePatternTests.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for wildcard pattern expansion and resolution logic.
+    /// </summary>
     public class ResolvePatternTests {
         private class CountingHandler : HttpMessageHandler {
             public int CallCount;
@@ -28,6 +31,9 @@ namespace DnsClientX.Tests {
             clientField.SetValue(client, httpClient);
         }
 
+        /// <summary>
+        /// Ensures that patterns with wildcards are expanded and each name is queried.
+        /// </summary>
         [Fact]
         public async Task ResolvePattern_ExpandsWildcards() {
             var handler = new CountingHandler();
@@ -41,6 +47,9 @@ namespace DnsClientX.Tests {
             Assert.Equal(3, responses.Length);
         }
 
+        /// <summary>
+        /// Verifies brace expansion of multiple segments.
+        /// </summary>
         [Fact]
         public void ExpandPattern_MultipleBraces() {
             string pattern = "srv{a,b}{1,2}.example.com";

--- a/DnsClientX.Tests/ResolveRootCancellationTests.cs
+++ b/DnsClientX.Tests/ResolveRootCancellationTests.cs
@@ -3,7 +3,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests cancellation behavior of <see cref="ClientX.ResolveFromRoot"/>.
+    /// </summary>
     public class ResolveRootCancellationTests {
+        /// <summary>
+        /// Cancels before starting and expects the response to indicate failure.
+        /// </summary>
         [Fact]
         public async Task ResolveFromRoot_CancelsEarly() {
             using var client = new ClientX();

--- a/DnsClientX.Tests/ResolveRootInvalidReferralTests.cs
+++ b/DnsClientX.Tests/ResolveRootInvalidReferralTests.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests handling of invalid referral responses when resolving from the DNS root.
+    /// </summary>
     public class ResolveRootInvalidReferralTests {
         private static byte[] EncodeName(string name) {
             using var ms = new System.IO.MemoryStream();
@@ -80,6 +83,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Ensures that the last response is returned when referrals are invalid.
+        /// </summary>
         [Fact]
         public async Task ResolveFromRoot_ReturnsLastResponse_OnInvalidReferrals() {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/DnsClientX.Tests/ResolveStream.cs
+++ b/DnsClientX.Tests/ResolveStream.cs
@@ -3,7 +3,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests the streaming variant of resolve operations.
+    /// </summary>
     public class ResolveStream {
+        /// <summary>
+        /// Streams multiple responses and verifies the count.
+        /// </summary>
         [Fact]
         public async Task ShouldStreamMultipleResponses() {
             using var client = new ClientX(DnsEndpoint.System);


### PR DESCRIPTION
## Summary
- document test classes to remove CS1591 warnings
- add test method summaries across examples

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6878d43c8c18832ebcb8e1e3e123a155