### PR TITLE
Fix XML cref for Random.Shared

### DIFF
--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -15,7 +15,7 @@ namespace DnsClientX {
     public class Configuration {
         /// <summary>
         /// Random generator used for hostname selection on frameworks lacking
-        /// <see cref="Random.Shared"/>.
+        /// <c>Random.Shared</c>.
         /// </summary>
 #if NET6_0_OR_GREATER
         // Random.Shared provides a threadsafe instance starting with .NET 6


### PR DESCRIPTION
## Summary
- fix cref to Random.Shared to avoid CS1574 on older frameworks

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6878dc94b7fc832eb823654d56993f54