### PR TITLE
Fix cref ambiguity warnings

### DIFF
--- a/DnsClientX.Tests/QueryDnsCancellationTests.cs
+++ b/DnsClientX.Tests/QueryDnsCancellationTests.cs
@@ -4,7 +4,9 @@ using Xunit;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Tests cancellation behavior for the <see cref="ClientX.QueryDns"/> method.
+    /// Tests cancellation behavior for the
+    /// <see cref="ClientX.QueryDns(string,DnsRecordType,DnsEndpoint,DnsSelectionStrategy,int,bool,int,int,bool,bool,bool,bool,System.Threading.CancellationToken)"/>
+    /// method.
     /// </summary>
     public class QueryDnsCancellationTests {
         /// <summary>

--- a/DnsClientX.Tests/QueryDnsSyncCancellationTests.cs
+++ b/DnsClientX.Tests/QueryDnsSyncCancellationTests.cs
@@ -4,7 +4,9 @@ using DnsClientX;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Tests cancellation behavior for the synchronous <see cref="ClientX.QueryDnsSync"/> method.
+    /// Tests cancellation behavior for the synchronous
+    /// <see cref="ClientX.QueryDnsSync(string,DnsRecordType,DnsEndpoint,DnsSelectionStrategy,int,bool,int,int,bool,bool,bool,bool,System.Threading.CancellationToken)"/>
+    /// method.
     /// </summary>
     public class QueryDnsSyncCancellationTests {
         /// <summary>

--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -2,7 +2,9 @@ using System.Diagnostics;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Tests for the <see cref="ClientX.ResolveAll"/> API.
+    /// Tests for the
+    /// <see cref="ClientX.ResolveAll(string,DnsRecordType,bool,bool,bool,int,int,System.Threading.CancellationToken)"/>
+    /// API.
     /// </summary>
     public class ResolveAll {
         /// <summary>

--- a/DnsClientX.Tests/ResolveAsyncEnumerableTests.cs
+++ b/DnsClientX.Tests/ResolveAsyncEnumerableTests.cs
@@ -4,7 +4,9 @@ using Xunit;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Tests for <see cref="ClientX.ResolveAsyncEnumerable"/> which returns results lazily.
+    /// Tests for
+    /// <see cref="ClientX.ResolveAsyncEnumerable(string,DnsRecordType[],bool,bool,bool,bool,int,int,System.Threading.CancellationToken)"/>
+    /// which returns results lazily.
     /// </summary>
     public class ResolveAsyncEnumerableTests {
         /// <summary>

--- a/DnsClientX.Tests/ResolveEdgeCaseTests.cs
+++ b/DnsClientX.Tests/ResolveEdgeCaseTests.cs
@@ -9,7 +9,9 @@ namespace DnsClientX.Tests {
     /// </summary>
     public class ResolveEdgeCaseTests {
         /// <summary>
-        /// Ensures <see cref="ClientX.ResolveAllSync"/> throws when the name is invalid.
+        /// Ensures
+        /// <see cref="ClientX.ResolveAllSync(string,DnsRecordType,bool,bool,bool,int,int,System.Threading.CancellationToken)"/>
+        /// throws when the name is invalid.
         /// </summary>
         [Fact]
         public void ResolveAllSync_InvalidName_Throws() {


### PR DESCRIPTION
## Summary
- disambiguate `ClientX` method crefs in test XML comments

## Testing
- `dotnet build DnsClientX.sln -c Release`
- `dotnet test DnsClientX.sln -c Release --no-build` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6878dfe66d28832e95243a700bf103b8