### PR TITLE
Fix xml comment warnings

### DIFF
--- a/DnsClientX.Tests/ResolveAll.cs
+++ b/DnsClientX.Tests/ResolveAll.cs
@@ -2,12 +2,8 @@ using System.Diagnostics;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Tests for the
-    /// <see cref="ClientX.ResolveAll(string,DnsRecordType,bool,bool,bool,int,int,System.Threading.CancellationToken)"/>
-    /// API.
-    /// </summary>
-    /// <summary>
-    /// Tests covering the <see cref="ClientX.ResolveAll"/> method using different endpoints.
+    /// Tests covering the <see cref="ClientX.ResolveAll(string,DnsRecordType,bool,bool,bool,int,int,System.Threading.CancellationToken)"/>
+    /// API using different endpoints.
     /// </summary>
     public class ResolveAll {
         /// <summary>
@@ -41,6 +37,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Resolves A records from the specified endpoint using asynchronous API.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -62,9 +61,6 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.CloudflareQuic)]
         [InlineData(DnsEndpoint.GoogleQuic)]
 #endif
-        /// <summary>
-        /// Resolves A records from the specified endpoint using asynchronous API.
-        /// </summary>
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = await Client.ResolveAll("evotec.pl", DnsRecordType.A);
@@ -74,6 +70,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Resolves TXT records synchronously using the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -92,9 +91,6 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.CloudflareQuic)]
         [InlineData(DnsEndpoint.GoogleQuic)]
 #endif
-        /// <summary>
-        /// Resolves TXT records synchronously using the specified endpoint.
-        /// </summary>
         public void ShouldWorkForTXT_Sync(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = Client.ResolveAllSync("github.com", DnsRecordType.TXT);
@@ -105,6 +101,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Resolves A records synchronously using the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -117,18 +116,12 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Google)]
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
-
-
-
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
 #if DNS_OVER_QUIC
         [InlineData(DnsEndpoint.CloudflareQuic)]
         [InlineData(DnsEndpoint.GoogleQuic)]
 #endif
-        /// <summary>
-        /// Resolves A records synchronously using the specified endpoint.
-        /// </summary>
         public void ShouldWorkForA_Sync(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             DnsAnswer[] aAnswers = Client.ResolveAllSync("evotec.pl", DnsRecordType.A);

--- a/DnsClientX.Tests/ResolveFirst.cs
+++ b/DnsClientX.Tests/ResolveFirst.cs
@@ -3,6 +3,9 @@ namespace DnsClientX.Tests {
     /// Tests the <see cref="ClientX.ResolveFirst"/> helper across various endpoints.
     /// </summary>
     public class ResolveFirst {
+        /// <summary>
+        /// Resolves the first TXT record for the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -19,10 +22,7 @@ namespace DnsClientX.Tests {
 
 
         [InlineData(DnsEndpoint.OpenDNS)]
-[InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Resolves the first TXT record for the specified endpoint.
-        /// </summary>
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXT(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             var answer = await Client.ResolveFirst("github.com", DnsRecordType.TXT, cancellationToken: CancellationToken.None);
@@ -32,6 +32,9 @@ namespace DnsClientX.Tests {
             Assert.True(answer.Value.Data.Length > 0);
         }
 
+        /// <summary>
+        /// Resolves the first A record for the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -48,10 +51,7 @@ namespace DnsClientX.Tests {
 
 
         [InlineData(DnsEndpoint.OpenDNS)]
-[InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Resolves the first A record for the specified endpoint.
-        /// </summary>
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForA(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             var answer = await Client.ResolveFirst("evotec.pl", DnsRecordType.A, cancellationToken: CancellationToken.None);
@@ -60,6 +60,9 @@ namespace DnsClientX.Tests {
             Assert.True(answer.Value.Type == DnsRecordType.A);
         }
 
+        /// <summary>
+        /// Resolves the first TXT record synchronously for the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -72,14 +75,8 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Google)]
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
-
-
-
         [InlineData(DnsEndpoint.OpenDNS)]
-[InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Resolves the first TXT record synchronously for the specified endpoint.
-        /// </summary>
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForTXT_Sync(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             var answer = Client.ResolveFirstSync("github.com", DnsRecordType.TXT, cancellationToken: CancellationToken.None);
@@ -89,6 +86,9 @@ namespace DnsClientX.Tests {
             Assert.True(answer.Value.Data.Length > 0);
         }
 
+        /// <summary>
+        /// Resolves the first A record synchronously for the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -101,14 +101,8 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.Google)]
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
-
-
-
         [InlineData(DnsEndpoint.OpenDNS)]
-[InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Resolves the first A record synchronously for the specified endpoint.
-        /// </summary>
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public void ShouldWorkForA_Sync(DnsEndpoint endpoint) {
             using var Client = new ClientX(endpoint);
             var answer = Client.ResolveFirstSync("evotec.pl", DnsRecordType.A, cancellationToken: CancellationToken.None);

--- a/DnsClientX.Tests/ResolveServiceAsyncTests.cs
+++ b/DnsClientX.Tests/ResolveServiceAsyncTests.cs
@@ -33,10 +33,10 @@ namespace DnsClientX.Tests {
             Assert.Equal("host1.example.com", records[2].Target);
         }
 
-        [Fact]
         /// <summary>
         /// Resolves host addresses from SRV records using the helper method.
         /// </summary>
+        [Fact]
         public async Task ShouldResolveHostAddresses() {
             var srvResponse = new DnsResponse {
                 Answers = new[] {
@@ -66,10 +66,10 @@ namespace DnsClientX.Tests {
             Assert.Contains(IPAddress.Parse("::1"), r.Addresses!);
         }
 
-        [Fact]
         /// <summary>
         /// Returns an empty collection when the DNS server provides no SRV records.
         /// </summary>
+        [Fact]
         public async Task ShouldReturnEmptyArrayWhenNoSrvRecords() {
             using var client = new ClientX(DnsEndpoint.System);
             client.ResolverOverride = (name, type, ct) =>

--- a/DnsClientX.Tests/ResolveSync.cs
+++ b/DnsClientX.Tests/ResolveSync.cs
@@ -79,6 +79,9 @@ namespace DnsClientX.Tests {
             return response;
         }
 
+        /// <summary>
+        /// Performs synchronous TXT resolution for the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -92,10 +95,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
-[InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Performs synchronous TXT resolution for the specified endpoint.
-        /// </summary>
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForTXTSync(DnsEndpoint endpoint)
         {
             using var client = new ClientX(endpoint);
@@ -110,6 +110,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Performs synchronous TXT resolution returning only the first record.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -123,10 +126,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
-[InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Performs synchronous TXT resolution returning only the first record.
-        /// </summary>
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForFirstSyncTXT(DnsEndpoint endpoint)
         {
             using var client = new ClientX(endpoint);
@@ -139,6 +139,9 @@ namespace DnsClientX.Tests {
             Assert.True(answer.Data.Length > 0, "Expected answer data to not be empty");
         }
 
+        /// <summary>
+        /// Performs synchronous TXT resolution returning all records.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -152,10 +155,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
-[InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Performs synchronous TXT resolution returning all records.
-        /// </summary>
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForAllSyncTXT(DnsEndpoint endpoint)
         {
             using var client = new ClientX(endpoint);
@@ -170,6 +170,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Performs asynchronous A record resolution for the specified endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -183,10 +186,7 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormat)]
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
-[InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Performs asynchronous A record resolution for the specified endpoint.
-        /// </summary>
+        [InlineData(DnsEndpoint.OpenDNSFamily)]
         public async Task ShouldWorkForASync(DnsEndpoint endpoint)
         {
             using var client = new ClientX(endpoint);
@@ -201,6 +201,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Synchronously resolves PTR records for reverse lookups.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -215,9 +218,6 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Synchronously resolves PTR records for reverse lookups.
-        /// </summary>
         public void ShouldWorkForPTRSync(DnsEndpoint endpoint) {
             using var client = new ClientX(endpoint);
             var response = client.ResolveSync("1.1.1.1", DnsRecordType.PTR);
@@ -229,11 +229,11 @@ namespace DnsClientX.Tests {
             }
         }
 
-        [Theory]
-        [InlineData(DnsEndpoint.Cloudflare)]
         /// <summary>
         /// Resolves multiple domains synchronously for the given endpoint.
         /// </summary>
+        [Theory]
+        [InlineData(DnsEndpoint.Cloudflare)]
         public void ShouldWorkForMultipleDomainsSync(DnsEndpoint endpoint) {
             using var client = new ClientX(endpoint);
             var domains = new[] { "evotec.pl", "google.com" };
@@ -248,11 +248,11 @@ namespace DnsClientX.Tests {
             }
         }
 
-        [Theory]
-        [InlineData(DnsEndpoint.Cloudflare)]
         /// <summary>
         /// Resolves multiple record types synchronously for a single domain.
         /// </summary>
+        [Theory]
+        [InlineData(DnsEndpoint.Cloudflare)]
         public void ShouldWorkForMultipleTypesSync(DnsEndpoint endpoint) {
             using var client = new ClientX(endpoint);
             var types = new[] { DnsRecordType.A, DnsRecordType.TXT };
@@ -267,6 +267,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Resolves the first A record synchronously for the given endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -281,9 +284,6 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Resolves the first A record synchronously for the given endpoint.
-        /// </summary>
         public void ShouldWorkForFirstSyncA(DnsEndpoint endpoint) {
             using var client = new ClientX(endpoint);
             var answer = client.ResolveFirstSync("evotec.pl", DnsRecordType.A, cancellationToken: CancellationToken.None);
@@ -293,6 +293,9 @@ namespace DnsClientX.Tests {
             Assert.True(answer.Value.Data.Length > 0);
         }
 
+        /// <summary>
+        /// Resolves all A records synchronously for the given endpoint.
+        /// </summary>
         [Theory]
         [InlineData(DnsEndpoint.System)]
         [InlineData(DnsEndpoint.SystemTcp)]
@@ -307,9 +310,6 @@ namespace DnsClientX.Tests {
         [InlineData(DnsEndpoint.GoogleWireFormatPost)]
         [InlineData(DnsEndpoint.OpenDNS)]
         [InlineData(DnsEndpoint.OpenDNSFamily)]
-        /// <summary>
-        /// Resolves all A records synchronously for the given endpoint.
-        /// </summary>
         public void ShouldWorkForAllSyncA(DnsEndpoint endpoint) {
             using var client = new ClientX(endpoint);
             var answers = client.ResolveAllSync("evotec.pl", DnsRecordType.A);


### PR DESCRIPTION
## Summary
- correct XML comments across test projects
- ensure method docs precede attributes

## Testing
- `dotnet build DnsClientX.sln -warnaserror:0`

------
https://chatgpt.com/codex/tasks/task_e_6878e91130ec832eb9c3ca98511d0f2d