### PR TITLE
Fix cref warnings in tests

### DIFF
--- a/DnsClientX.Tests/ResolveEdgeCaseTests.cs
+++ b/DnsClientX.Tests/ResolveEdgeCaseTests.cs
@@ -20,7 +20,7 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// Ensures <see cref="ClientX.ResolveFilter(string,DnsRecordType,string,bool,int,int,bool,bool,int?,System.Threading.CancellationToken)"/> throws on invalid name.
+        /// Ensures <see cref="ClientX.ResolveFilter(string,DnsRecordType,string,bool,bool,bool,int,int,System.Threading.CancellationToken)"/> throws on invalid name.
         /// </summary>
         [Fact]
         public async Task ResolveFilter_InvalidName_Throws() {

--- a/DnsClientX.Tests/ResolveStreamEmptyTests.cs
+++ b/DnsClientX.Tests/ResolveStreamEmptyTests.cs
@@ -4,7 +4,8 @@ using Xunit;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Tests <see cref="ClientX.ResolveStream"/> when provided with no domain names.
+    /// Tests <see cref="ClientX.ResolveStream(string[],DnsRecordType[],bool,bool,bool,bool,int,int,System.Threading.CancellationToken)"/>
+    /// when provided with no domain names.
     /// </summary>
     public class ResolveStreamEmptyTests {
         /// <summary>

--- a/DnsClientX.Tests/ResolveStreamEnumeratorDisposeTests.cs
+++ b/DnsClientX.Tests/ResolveStreamEnumeratorDisposeTests.cs
@@ -8,7 +8,8 @@ using Xunit;
 
 namespace DnsClientX.Tests {
     /// <summary>
-    /// Tests that enumerators returned from <see cref="ClientX.ResolveStream"/> are disposed correctly.
+    /// Tests that enumerators returned from <see cref="ClientX.ResolveStream(string[],DnsRecordType[],bool,bool,bool,bool,int,int,System.Threading.CancellationToken)"/>
+    /// are disposed correctly.
     /// </summary>
     public class ResolveStreamEnumeratorDisposeTests {
         private class TrackingEnumerable<T> : IEnumerable<T> {


### PR DESCRIPTION
## Summary
- fix invalid cref in `ResolveEdgeCaseTests`
- disambiguate `ResolveStream` cref references

## Testing
- `dotnet build DnsClientX.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878eea910c8832e8523d66989f797ec