### PR TITLE
Fix ECS test socket binding

### DIFF
--- a/DnsClientX.Tests/EcsOptionTests.cs
+++ b/DnsClientX.Tests/EcsOptionTests.cs
@@ -31,7 +31,9 @@ namespace DnsClientX.Tests {
         }
 
         private static async Task<byte[]> RunUdpServerAsync(int port, byte[] response, CancellationToken token) {
-            using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
+            using var udp = new UdpClient(AddressFamily.InterNetwork);
+            udp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            udp.Client.Bind(new IPEndPoint(IPAddress.Loopback, port));
             UdpReceiveResult result = await udp.ReceiveAsync();
             await udp.SendAsync(response, response.Length, result.RemoteEndPoint);
             return result.Buffer;


### PR DESCRIPTION
## Summary
- update UDP server setup in EcsOptionTests to allow port reuse

## Testing
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release --filter "FullyQualifiedName~EcsOptionTests" --verbosity minimal`
- `dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj -c Release -f net472 --filter "FullyQualifiedName~EcsOptionTests" --verbosity minimal` *(fails: reference assemblies for .NET Framework 4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878fea52854832eb05a938c46a577c4