### PR TITLE
Fix typed record enumeration in PowerShell

### DIFF
--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -275,7 +275,7 @@ namespace DnsClientX.PowerShell {
                     if (FullResponse.IsPresent) {
                         WriteObject(record);
                     } else if (TypedRecords.IsPresent && record.TypedAnswers != null) {
-                        WriteObject(record.TypedAnswers);
+                        WriteObject(record.TypedAnswers, true);
                     } else {
                         WriteObject(record.AnswersMinimal);
                     }
@@ -311,7 +311,7 @@ namespace DnsClientX.PowerShell {
                     if (FullResponse.IsPresent) {
                         WriteObject(record);
                     } else if (TypedRecords.IsPresent && record.TypedAnswers != null) {
-                        WriteObject(record.TypedAnswers);
+                        WriteObject(record.TypedAnswers, true);
                     } else {
                         WriteObject(record.AnswersMinimal);
                     }

--- a/Module/Tests/ResolveDns.Tests.ps1
+++ b/Module/Tests/ResolveDns.Tests.ps1
@@ -22,4 +22,22 @@ Describe 'Resolve-Dns cmdlet' {
         $typed = [DnsClientX.DnsRecordFactory]::Create($answer)
         $typed | Should -Not -BeNullOrEmpty
     }
+
+    It 'Enumerates typed answers as individual objects' {
+        $ans1 = [DnsClientX.DnsAnswer]@{
+            Type    = [DnsClientX.DnsRecordType]::TXT
+            DataRaw = 'foo=bar'
+        }
+        $ans2 = [DnsClientX.DnsAnswer]@{
+            Type    = [DnsClientX.DnsRecordType]::TXT
+            DataRaw = 'v=spf1 -all'
+        }
+        $response = [DnsClientX.DnsResponse]@{
+            Answers = @($ans1, $ans2)
+        }
+        $response.TypedAnswers = $response.Answers | ForEach-Object { [DnsClientX.DnsRecordFactory]::Create($_) }
+        $types = $response.TypedAnswers | ForEach-Object { $_.GetType().Name }
+        $types | Should -Contain 'KeyValueTxtRecord'
+        $types | Should -Contain 'SpfRecord'
+    }
 }


### PR DESCRIPTION
## Summary
- ensure typed records output enumerates all records
- add Pester test covering enumeration behavior

## Testing
- `dotnet test` *(fails: Network is unreachable)*
- `pwsh -NoLogo -Command "Import-Module ./Module/DnsClientX.psd1 -Force; Invoke-Pester -Path Module/Tests -Passthru | Format-Table"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879092b03f4832e83d54a24c73be509