### PR TITLE
Fix nullability warnings

### DIFF
--- a/DnsClientX.Examples/DemoTypedRecords.cs
+++ b/DnsClientX.Examples/DemoTypedRecords.cs
@@ -12,7 +12,7 @@ namespace DnsClientX.Examples {
                         Settings.Logger.WriteInformation($"TXT: {txt.Text}");
                         break;
                     default:
-                        Settings.Logger.WriteInformation(typed.ToString());
+                        Settings.Logger.WriteInformation(typed.ToString()!);
                         break;
                 }
             }

--- a/DnsClientX/Configuration.cs
+++ b/DnsClientX/Configuration.cs
@@ -196,7 +196,7 @@ namespace DnsClientX {
             if (string.IsNullOrEmpty(host)) return;
 
             lock (unavailable) {
-                unavailable[host] = DateTime.UtcNow.Add(UnavailableCooldown);
+                unavailable[host!] = DateTime.UtcNow.Add(UnavailableCooldown);
             }
         }
 

--- a/DnsClientX/ProtocolDnsWire/DnsMessage.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsMessage.cs
@@ -46,7 +46,7 @@ namespace DnsClientX {
         /// <param name="options">Additional EDNS options.</param>
         public DnsMessage(string name, DnsRecordType type, bool requestDnsSec, bool enableEdns, int udpBufferSize, string? subnet, bool checkingDisabled, AsymmetricAlgorithm? signingKey, System.Collections.Generic.IEnumerable<EdnsOption>? options = null)
             : this(name, type, new DnsMessageOptions(requestDnsSec, enableEdns, udpBufferSize,
-                string.IsNullOrEmpty(subnet) ? null : new EdnsClientSubnetOption(subnet), checkingDisabled, signingKey, options)) {
+                string.IsNullOrEmpty(subnet) ? null : new EdnsClientSubnetOption(subnet!), checkingDisabled, signingKey, options)) {
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- silence nullability warnings in `Configuration`, `DnsMessage`, and `DemoTypedRecords`

## Testing
- `dotnet test -c Debug` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68795a2b1584832e85b1cb6f742dca11