### PR TITLE
Refactor query building for DNS resolvers

### DIFF
--- a/DnsClientX/ProtocolDnsGrpc/DnsWireResolveGrpc.cs
+++ b/DnsClientX/ProtocolDnsGrpc/DnsWireResolveGrpc.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,18 +27,7 @@ namespace DnsClientX {
             bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var edns = endpointConfiguration.EdnsOptions;
-            bool enableEdns = endpointConfiguration.EnableEdns;
-            int udpSize = endpointConfiguration.UdpBufferSize;
-            string? subnet = endpointConfiguration.Subnet;
-            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
-            if (edns != null) {
-                enableEdns = edns.EnableEdns;
-                udpSize = edns.UdpBufferSize;
-                subnet = edns.Subnet?.Subnet;
-                options = edns.Options;
-            }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
+            var query = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
+++ b/DnsClientX/ProtocolDnsHttp2/DnsWireResolveHttp2.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
@@ -26,8 +25,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatHttp2(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
-            System.Collections.Generic.IEnumerable<EdnsOption>? options = endpointConfiguration.EdnsOptions?.Options;
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, endpointConfiguration.EnableEdns, endpointConfiguration.UdpBufferSize, endpointConfiguration.Subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
+            var dnsMessage = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
+++ b/DnsClientX/ProtocolDnsHttp3/DnsWireResolveHttp3.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
@@ -26,18 +25,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatHttp3(this HttpClient client, string name,
             DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug,
             Configuration endpointConfiguration, CancellationToken cancellationToken) {
-            var edns = endpointConfiguration.EdnsOptions;
-            bool enableEdns = endpointConfiguration.EnableEdns;
-            int udpSize = endpointConfiguration.UdpBufferSize;
-            string? subnet = endpointConfiguration.Subnet;
-            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
-            if (edns != null) {
-                enableEdns = edns.EnableEdns;
-                udpSize = edns.UdpBufferSize;
-                subnet = edns.Subnet?.Subnet;
-                options = edns.Options;
-            }
-            var dnsMessage = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
+            var dnsMessage = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var base64UrlDnsMessage = dnsMessage.ToBase64Url();
             string url = $"?dns={base64UrlDnsMessage}";
 

--- a/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
+++ b/DnsClientX/ProtocolDnsQuic/DnsWireResolveQuic.cs
@@ -6,7 +6,6 @@ using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
-using System.Collections.Generic;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,18 +52,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatQuic(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var edns = endpointConfiguration.EdnsOptions;
-            bool enableEdns = endpointConfiguration.EnableEdns;
-            int udpSize = endpointConfiguration.UdpBufferSize;
-            string? subnet = endpointConfiguration.Subnet;
-            System.Collections.Generic.IEnumerable<EdnsOption>? ednsOptions = null;
-            if (edns != null) {
-                enableEdns = edns.EnableEdns;
-                udpSize = edns.UdpBufferSize;
-                subnet = edns.Subnet?.Subnet;
-                ednsOptions = edns.Options;
-            }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, ednsOptions);
+            var query = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var queryBytes = query.SerializeDnsWireFormat();
 
             var lengthPrefix = BitConverter.GetBytes((ushort)queryBytes.Length);

--- a/DnsClientX/ProtocolDnsWire/DnsWireQueryBuilder.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireQueryBuilder.cs
@@ -1,0 +1,19 @@
+namespace DnsClientX {
+    internal static class DnsWireQueryBuilder {
+        internal static DnsMessage BuildQuery(string name, DnsRecordType type, bool requestDnsSec, Configuration cfg) {
+            var edns = cfg.EdnsOptions;
+            bool enableEdns = cfg.EnableEdns;
+            int udpSize = cfg.UdpBufferSize;
+            string? subnet = cfg.Subnet;
+            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
+            if (edns != null) {
+                enableEdns = edns.EnableEdns;
+                udpSize = edns.UdpBufferSize;
+                subnet = edns.Subnet?.Subnet;
+                options = edns.Options;
+            }
+            return new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet,
+                cfg.CheckingDisabled, cfg.SigningKey, options);
+        }
+    }
+}

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveDot.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -36,18 +35,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatDoT(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, bool ignoreCertificateErrors, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var edns = endpointConfiguration.EdnsOptions;
-            bool enableEdns = endpointConfiguration.EnableEdns;
-            int udpSize = endpointConfiguration.UdpBufferSize;
-            string? subnet = endpointConfiguration.Subnet;
-            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
-            if (edns != null) {
-                enableEdns = edns.EnableEdns;
-                udpSize = edns.UdpBufferSize;
-                subnet = edns.Subnet?.Subnet;
-                options = edns.Options;
-            }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
+            var query = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var queryBytes = query.SerializeDnsWireFormat();
 
             // Calculate the length prefix for the query

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveMulticast.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,18 +12,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatMulticast(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var edns = endpointConfiguration.EdnsOptions;
-            bool enableEdns = endpointConfiguration.EnableEdns;
-            int udpSize = endpointConfiguration.UdpBufferSize;
-            string? subnet = endpointConfiguration.Subnet;
-            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
-            if (edns != null) {
-                enableEdns = edns.EnableEdns;
-                udpSize = edns.UdpBufferSize;
-                subnet = edns.Subnet?.Subnet;
-                options = edns.Options;
-            }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
+            var query = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolvePost.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Http.Headers;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,18 +26,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatPost(this HttpClient client, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var edns = endpointConfiguration.EdnsOptions;
-            bool enableEdns = endpointConfiguration.EnableEdns;
-            int udpSize = endpointConfiguration.UdpBufferSize;
-            string? subnet = endpointConfiguration.Subnet;
-            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
-            if (edns != null) {
-                enableEdns = edns.EnableEdns;
-                udpSize = edns.UdpBufferSize;
-                subnet = edns.Subnet?.Subnet;
-                options = edns.Options;
-            }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
+            var query = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Net.Sockets;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -28,18 +27,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatTcp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var edns = endpointConfiguration.EdnsOptions;
-            bool enableEdns = endpointConfiguration.EnableEdns;
-            int udpSize = endpointConfiguration.UdpBufferSize;
-            string? subnet = endpointConfiguration.Subnet;
-            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
-            if (edns != null) {
-                enableEdns = edns.EnableEdns;
-                udpSize = edns.UdpBufferSize;
-                subnet = edns.Subnet?.Subnet;
-                options = edns.Options;
-            }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
+            var query = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveUdp.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Sockets;
 using System.Net;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -28,18 +27,7 @@ namespace DnsClientX {
         internal static async Task<DnsResponse> ResolveWireFormatUdp(string dnsServer, int port, string name, DnsRecordType type, bool requestDnsSec, bool validateDnsSec, bool debug, Configuration endpointConfiguration, int maxRetries, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
 
-            var edns = endpointConfiguration.EdnsOptions;
-            bool enableEdns = endpointConfiguration.EnableEdns;
-            int udpSize = endpointConfiguration.UdpBufferSize;
-            string? subnet = endpointConfiguration.Subnet;
-            System.Collections.Generic.IEnumerable<EdnsOption>? options = null;
-            if (edns != null) {
-                enableEdns = edns.EnableEdns;
-                udpSize = edns.UdpBufferSize;
-                subnet = edns.Subnet?.Subnet;
-                options = edns.Options;
-            }
-            var query = new DnsMessage(name, type, requestDnsSec, enableEdns, udpSize, subnet, endpointConfiguration.CheckingDisabled, endpointConfiguration.SigningKey, options);
+            var query = DnsWireQueryBuilder.BuildQuery(name, type, requestDnsSec, endpointConfiguration);
             var queryBytes = query.SerializeDnsWireFormat();
 
             if (debug) {


### PR DESCRIPTION
## Summary
- add shared `DnsWireQueryBuilder.BuildQuery` helper
- refactor protocol resolvers to reuse new helper

## Testing
- `dotnet build DnsClientX.sln -c Debug`
- `dotnet test` *(fails: 140 failed, 442 passed, 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687c8fb31f04832e80755fa177f2a8bb