### PR TITLE
Refactor protocol invocations in tests

### DIFF
--- a/DnsClientX.Tests/CdBitTests.cs
+++ b/DnsClientX.Tests/CdBitTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -84,10 +83,17 @@ namespace DnsClientX.Tests {
             var udpTask = RunUdpServerAsync(port, response, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, CheckingDisabled = true };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
             byte[] query = await udpTask;
 
             AssertCdBit(query, "example.com", 0x10u);
@@ -104,10 +110,16 @@ namespace DnsClientX.Tests {
             var tcpTask = RunTcpServerAsync(port, response, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port, CheckingDisabled = true };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
-            await task;
+            await DnsWireResolveTcp.ResolveWireFormatTcp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                cts.Token);
             byte[] query = await tcpTask;
 
             AssertCdBit(query, "example.com", 0x10u);

--- a/DnsClientX.Tests/DnsWireFallbackTests.cs
+++ b/DnsClientX.Tests/DnsWireFallbackTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -70,10 +69,17 @@ namespace DnsClientX.Tests {
             var tcpTask = RunTcpServerAsync(port, tcpResponse, () => tcpCalled = true, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            DnsResponse response = await task;
+            DnsResponse response = await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
 
             await Task.WhenAll(udpTask, tcpTask);
             Assert.True(tcpCalled, "Expected TCP fallback to be used");
@@ -91,10 +97,17 @@ namespace DnsClientX.Tests {
             var udpTask = RunUdpServerAsync(port, udpResponse, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, UseTcpFallback = false };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            DnsResponse response = await task;
+            DnsResponse response = await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
 
             await udpTask;
             Assert.True(response.IsTruncated);

--- a/DnsClientX.Tests/DnsWireReadTimeoutTests.cs
+++ b/DnsClientX.Tests/DnsWireReadTimeoutTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -44,12 +43,14 @@ namespace DnsClientX.Tests {
             var serverTask = RunStallingServerAsync(port, cts.Token);
 
             var queryBytes = new DnsMessage("example.com", DnsRecordType.A, false).SerializeDnsWireFormat();
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
-            MethodInfo method = type.GetMethod("SendQueryOverTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
 
             await Assert.ThrowsAsync<TimeoutException>(async () => {
-                var task = (Task<byte[]>)method.Invoke(null, new object[] { queryBytes, "127.0.0.1", port, 200, CancellationToken.None })!;
-                await task;
+                await DnsWireResolveTcp.SendQueryOverTcp(
+                    queryBytes,
+                    "127.0.0.1",
+                    port,
+                    200,
+                    CancellationToken.None);
             });
 
             cts.Cancel();

--- a/DnsClientX.Tests/DnsWireResolveMulticastTests.cs
+++ b/DnsClientX.Tests/DnsWireResolveMulticastTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -43,10 +42,16 @@ namespace DnsClientX.Tests {
             var serverTask = RunMulticastServerAsync(response, cts.Token);
 
             var config = new Configuration("224.0.0.251", DnsRequestFormat.Multicast);
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveMulticast")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatMulticast", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "224.0.0.251", 5353, "example.local", DnsRecordType.A, false, false, false, config, cts.Token })!;
-            DnsResponse dnsResponse = await task;
+            DnsResponse dnsResponse = await DnsWireResolveMulticast.ResolveWireFormatMulticast(
+                "224.0.0.251",
+                5353,
+                "example.local",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                cts.Token);
             byte[] query = await serverTask;
 
             Assert.NotNull(dnsResponse);

--- a/DnsClientX.Tests/DnsWireUdpRetryLimitTests.cs
+++ b/DnsClientX.Tests/DnsWireUdpRetryLimitTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -74,10 +73,17 @@ namespace DnsClientX.Tests {
                 Port = port,
                 TimeOut = 100
             };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 2, cts.Token })!;
-            DnsResponse response = await task;
+            DnsResponse response = await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                2,
+                cts.Token);
 
             int attempts = await serverTask;
             cts.Cancel();
@@ -99,10 +105,17 @@ namespace DnsClientX.Tests {
                 Port = port,
                 TimeOut = 100
             };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 2, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                2,
+                cts.Token);
 
             int[] clientPorts = await serverTask;
             cts.Cancel();
@@ -121,4 +134,5 @@ namespace DnsClientX.Tests {
                 Assert.Null(ex);
             }
         }
-    }}
+    }
+}

--- a/DnsClientX.Tests/EcsOptionTests.cs
+++ b/DnsClientX.Tests/EcsOptionTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -73,10 +72,17 @@ namespace DnsClientX.Tests {
                 EnableEdns = true,
                 Subnet = "192.0.2.1/24"
             };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
             byte[] query = await udpTask;
 
             AssertEcsOption(query, "example.com");

--- a/DnsClientX.Tests/EdnsDoBitTests.cs
+++ b/DnsClientX.Tests/EdnsDoBitTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -124,10 +123,17 @@ namespace DnsClientX.Tests {
             var udpTask = RunUdpServerAsync(port, response, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: true,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
             byte[] query = await udpTask;
 
             AssertDoBit(query, "example.com");
@@ -144,10 +150,16 @@ namespace DnsClientX.Tests {
             var tcpTask = RunTcpServerAsync(port, response, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, true, false, false, config, cts.Token })!;
-            await task;
+            await DnsWireResolveTcp.ResolveWireFormatTcp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: true,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                cts.Token);
             byte[] query = await tcpTask;
 
             AssertDoBit(query, "example.com");
@@ -164,10 +176,17 @@ namespace DnsClientX.Tests {
             var udpTask = RunUdpServerAsync(port, response, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, EnableEdns = true, UdpBufferSize = 1234 };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
             byte[] query = await udpTask;
 
             AssertBufferSize(query, "example.com", 1234);
@@ -187,10 +206,17 @@ namespace DnsClientX.Tests {
                 Port = port,
                 EdnsOptions = new EdnsOptions { EnableEdns = true, UdpBufferSize = 1234 }
             };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
             byte[] query = await udpTask;
 
             AssertBufferSize(query, "example.com", 1234);
@@ -207,10 +233,17 @@ namespace DnsClientX.Tests {
             var udpTask = RunUdpServerAsync(port, response, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port, EnableEdns = true };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
             byte[] query = await udpTask;
 
             AssertNoDoBit(query, "example.com");

--- a/DnsClientX.Tests/EdnsOptionsTests.cs
+++ b/DnsClientX.Tests/EdnsOptionsTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -70,10 +69,17 @@ namespace DnsClientX.Tests {
                 Port = port,
                 EdnsOptions = new EdnsOptions { EnableEdns = true, Subnet = new EdnsClientSubnetOption("192.0.2.1/24") }
             };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object?[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
             byte[] query = await udpTask;
 
             AssertEcsOption(query, "example.com");
@@ -93,10 +99,17 @@ namespace DnsClientX.Tests {
                 Port = port,
                 EdnsOptions = null
             };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object?[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
             await udpTask;
         }
     }

--- a/DnsClientX.Tests/SocketCountTests.cs
+++ b/DnsClientX.Tests/SocketCountTests.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -70,13 +69,19 @@ namespace DnsClientX.Tests {
             var serverTask = RunTcpServerAsync(port, iterations, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
 
             int before = GetTcpConnectionCount(port);
             for (int i = 0; i < iterations; i++) {
-                var task = (Task<DnsResponse>)method.Invoke(null, new object?[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
-                await task;
+                await DnsWireResolveTcp.ResolveWireFormatTcp(
+                    "127.0.0.1",
+                    port,
+                    "example.com",
+                    DnsRecordType.A,
+                    requestDnsSec: false,
+                    validateDnsSec: false,
+                    debug: false,
+                    config,
+                    cts.Token);
             }
             await serverTask;
 

--- a/DnsClientX.Tests/TcpCleanupRegressionTests.cs
+++ b/DnsClientX.Tests/TcpCleanupRegressionTests.cs
@@ -4,7 +4,6 @@ using System.Net.NetworkInformation;
 using System.Net;
 using System.Linq;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -90,11 +89,17 @@ namespace DnsClientX.Tests {
             var serverTask = RunClosingServerAsync(port, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port, TimeOut = 200 };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
 
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
-            await task;
+            await DnsWireResolveTcp.ResolveWireFormatTcp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                cts.Token);
             await serverTask;
             await Task.Delay(200);
 

--- a/DnsClientX.Tests/TcpDisposeCountTests.cs
+++ b/DnsClientX.Tests/TcpDisposeCountTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -87,10 +86,16 @@ public class TcpDisposeCountTests {
                 var serverTask = RunTcpServerAsync(port, cts.Token);
 
                 var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverTCP) { Port = port };
-                Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveTcp")!;
-                MethodInfo method = type.GetMethod("ResolveWireFormatTcp", BindingFlags.Static | BindingFlags.NonPublic)!;
-                var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, cts.Token })!;
-                await task;
+                await DnsWireResolveTcp.ResolveWireFormatTcp(
+                    "127.0.0.1",
+                    port,
+                    "example.com",
+                    DnsRecordType.A,
+                    requestDnsSec: false,
+                    validateDnsSec: false,
+                    debug: false,
+                    config,
+                    cts.Token);
                 await serverTask;
 
                 int finalDisposed;

--- a/DnsClientX.Tests/UdpClientDisposeTests.cs
+++ b/DnsClientX.Tests/UdpClientDisposeTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -48,10 +47,17 @@ namespace DnsClientX.Tests {
             var udpTask = RunUdpServerCapturePortAsync(port, response, cts.Token);
 
             var config = new Configuration("127.0.0.1", DnsRequestFormat.DnsOverUDP) { Port = port };
-            Type type = typeof(ClientX).Assembly.GetType("DnsClientX.DnsWireResolveUdp")!;
-            MethodInfo method = type.GetMethod("ResolveWireFormatUdp", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var task = (Task<DnsResponse>)method.Invoke(null, new object[] { "127.0.0.1", port, "example.com", DnsRecordType.A, false, false, false, config, 1, cts.Token })!;
-            await task;
+            await DnsWireResolveUdp.ResolveWireFormatUdp(
+                "127.0.0.1",
+                port,
+                "example.com",
+                DnsRecordType.A,
+                requestDnsSec: false,
+                validateDnsSec: false,
+                debug: false,
+                config,
+                1,
+                cts.Token);
 
             int clientPort = await udpTask;
 

--- a/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsWireResolveTcp.cs
@@ -88,7 +88,7 @@ namespace DnsClientX {
         /// <param name="timeoutMilliseconds">Timeout in milliseconds.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>Raw DNS response bytes.</returns>
-        private static async Task<byte[]> SendQueryOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
+        internal static async Task<byte[]> SendQueryOverTcp(byte[] query, string dnsServer, int port, int timeoutMilliseconds, CancellationToken cancellationToken) {
             using var tcpClient = TcpClientFactory();
             NetworkStream? stream = null;
             try {


### PR DESCRIPTION
## Summary
- call protocol helpers directly from test code
- expose `SendQueryOverTcp` for testing

## Testing
- `dotnet build DnsClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687cfd531e18832e896de0098ac56d94