### PR TITLE
chore(ci): add test verbosity and failure summary

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -17,6 +17,8 @@ on:
 env:
     DOTNET_VERSION: '8.x'
     BUILD_CONFIGURATION: 'Release'
+    TEST_VERBOSITY: minimal # set to 'detailed' to restore full test output
+    SUMMARIZE_FAILURES: true # set to 'false' to disable summarizing failing tests
 
 jobs:
     test-windows:
@@ -39,9 +41,43 @@ jobs:
               run: dotnet build DnsClientX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
               env:
                   DNSCLIENTX_DEBUG_SYSTEMDNS: '1'
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -83,9 +119,43 @@ jobs:
               run: dotnet build DnsClientX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
               env:
                   DNSCLIENTX_DEBUG_SYSTEMDNS: '1'
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -127,9 +197,43 @@ jobs:
               run: dotnet build DnsClientX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
               env:
                   DNSCLIENTX_DEBUG_SYSTEMDNS: '1'
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
 
             - name: Upload test results
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- allow adjusting test verbosity
- summarize failing tests in CI

## Testing
- `dotnet restore DnsClientX.sln`
- `dotnet build DnsClientX.sln --configuration Release --no-restore`
- `DNSCLIENTX_DEBUG_SYSTEMDNS=1 dotnet test DnsClientX.Tests/DnsClientX.Tests.csproj --configuration Release --framework net8.0 --no-build --verbosity minimal` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a345c48a48832eb4f576e7c574845b