### PR TITLE
Add multi-resolver functionality with flexible querying strategies

### DIFF
--- a/DnsClientX.Examples/DemoMaxConcurrency.cs
+++ b/DnsClientX.Examples/DemoMaxConcurrency.cs
@@ -7,6 +7,10 @@ namespace DnsClientX.Examples {
     /// Demonstrates how to cap parallelism when resolving multiple names.
     /// </summary>
     public static class DemoMaxConcurrency {
+        /// <summary>
+        /// Example entry that resolves several names with a configured max concurrency.
+        /// </summary>
+        /// <returns>A task that completes when the example finishes.</returns>
         public static async Task Example() {
             using var client = new ClientX(DnsEndpoint.Cloudflare);
 

--- a/DnsClientX.PowerShell/CmdletClearDnsMultiResolverCache.cs
+++ b/DnsClientX.PowerShell/CmdletClearDnsMultiResolverCache.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+
+namespace DnsClientX.PowerShell {
+    /// <summary>
+    /// <para type="synopsis">Clears the multi-resolver fastest-endpoint cache used by the FastestWins strategy.</para>
+    /// <para type="description">Clears the in-memory cache used to remember the fastest endpoint for a given set of endpoints. Use this when you change network conditions or want to force re-probing. Does not affect TTL-based response caching, which expires automatically.</para>
+    /// <example>
+    /// <code>Clear-DnsMultiResolverCache</code>
+    /// <para>Clears the entire FastestWins cache.</para>
+    /// </example>
+    /// <example>
+    /// <code>Clear-DnsMultiResolverCache -ResolverDnsProvider Cloudflare,Google</code>
+    /// <para>Clears cache entries only for the specified provider set.</para>
+    /// </example>
+    /// <example>
+    /// <code>Clear-DnsMultiResolverCache -ResolverEndpoint '1.1.1.1:53','https://dns.google/dns-query'</code>
+    /// <para>Clears cache entries only for the specified endpoints.</para>
+    /// </example>
+    /// </summary>
+    [Cmdlet(VerbsCommon.Clear, "DnsMultiResolverCache", DefaultParameterSetName = "All")]
+    public sealed class CmdletClearDnsMultiResolverCache : PSCmdlet {
+        /// <summary>
+        /// <para type="description">Clear all cached fastest-endpoint choices.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "All")]
+        public SwitchParameter All { get; set; }
+
+        /// <summary>
+        /// <para type="description">Specific endpoints to clear, e.g. "1.1.1.1:53", "[2606:4700:4700::1111]:53", or DoH URLs.</para>
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "ResolverEndpoint")]
+        public string[] ResolverEndpoint { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// <para type="description">Clear cache entries for the specified predefined providers (DnsEndpoint enum).</para>
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "ResolverDnsProvider")]
+        public DnsEndpoint[] ResolverDnsProvider { get; set; } = Array.Empty<DnsEndpoint>();
+
+        /// <summary>
+        /// <para type="description">Alternate parameter: providers to clear when using the classic -DnsProvider parameter style.</para>
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "DnsProvider")]
+        public DnsEndpoint[] DnsProvider { get; set; } = Array.Empty<DnsEndpoint>();
+
+        /// <inheritdoc />
+        protected override void ProcessRecord() {
+            if (this.ParameterSetName == "All" || (ResolverEndpoint.Length == 0 && ResolverDnsProvider.Length == 0 && DnsProvider.Length == 0)) {
+                DnsMultiResolver.ClearFastestCache();
+                WriteVerbose("Cleared entire FastestWins cache.");
+                return;
+            }
+
+            List<DnsResolverEndpoint> endpoints = new();
+            if (this.ParameterSetName == "ResolverEndpoint") {
+                var parsed = EndpointParser.TryParseMany(ResolverEndpoint, out var errors);
+                foreach (var e in errors) { WriteWarning(e); }
+                if (parsed.Length == 0) return;
+                endpoints.AddRange(parsed);
+            } else {
+                var providers = this.ParameterSetName == "ResolverDnsProvider" ? ResolverDnsProvider : DnsProvider;
+                foreach (var ep in providers) {
+                    endpoints.AddRange(DnsResolverEndpointFactory.From(ep));
+                }
+            }
+
+            if (endpoints.Count > 0) {
+                DnsMultiResolver.ClearFastestCacheFor(endpoints);
+                WriteVerbose($"Cleared FastestWins cache for {endpoints.Count} endpoint(s).");
+            }
+        }
+    }
+}

--- a/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
+++ b/DnsClientX.PowerShell/CmdletDiscoverDnsService.cs
@@ -6,8 +6,12 @@ namespace DnsClientX.PowerShell {
     /// <para type="synopsis">Retrieves services advertised via DNS Service Discovery.</para>
     /// <para type="description">Queries the <c>_services._dns-sd._udp</c> tree for the specified domain and returns SRV/TXT data describing each advertised service.</para>
     /// <example>
-    ///   <para>Discover HTTP services under example.com</para>
+    ///   <para>Discover services under a domain</para>
     ///   <code>Get-DnsService -Domain example.com</code>
+    /// </example>
+    /// <example>
+    ///   <para>Pipe results to select useful fields</para>
+    ///   <code>Get-DnsService -Domain example.com | Select-Object ServiceName,Target,Port</code>
     /// </example>
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "DnsService")]

--- a/DnsClientX.PowerShell/CmdletDnsUpdate.cs
+++ b/DnsClientX.PowerShell/CmdletDnsUpdate.cs
@@ -8,8 +8,12 @@ namespace DnsClientX.PowerShell;
 /// <para type="synopsis">Sends DNS UPDATE messages to a server.</para>
 /// <para type="description">Adds or removes records in a zone using RFC 2136 over TCP.</para>
 /// <example>
-///   <para>Add a record</para>
-///   <code>Invoke-DnsUpdate -Zone example.com -Server 127.0.0.1 -Name www -Type A -Data 1.2.3.4</code>
+///   <para>Add an A record</para>
+///   <code>Invoke-DnsUpdate -Zone example.com -Server 127.0.0.1 -Name www -Type A -Data 1.2.3.4 -Ttl 300</code>
+/// </example>
+/// <example>
+///   <para>Delete an existing record</para>
+///   <code>Invoke-DnsUpdate -Zone example.com -Server 127.0.0.1 -Name www -Type A -Delete</code>
 /// </example>
 /// </summary>
 [Cmdlet(VerbsLifecycle.Invoke, "DnsUpdate")]

--- a/DnsClientX.PowerShell/CmdletDnsZoneTransfer.cs
+++ b/DnsClientX.PowerShell/CmdletDnsZoneTransfer.cs
@@ -7,8 +7,12 @@ namespace DnsClientX.PowerShell;
 /// <para type="synopsis">Performs a DNS zone transfer (AXFR) for a given zone.</para>
 /// <para type="description">Retrieves all records for the specified zone using TCP based zone transfer.</para>
 /// <example>
-///   <para>Transfer zone from a DNS server</para>
-///   <code>Get-DnsZoneTransfer -Zone example.com -Server 127.0.0.1 -Port 5353</code>
+///   <para>Transfer a zone (default port 53)</para>
+///   <code>Get-DnsZone -Zone example.com -Server 127.0.0.1</code>
+/// </example>
+/// <example>
+///   <para>Transfer a zone from a custom port</para>
+///   <code>Get-DnsZone -Zone example.com -Server 127.0.0.1 -Port 5353</code>
 /// </example>
 /// </summary>
 [Alias("Get-DnsZoneTransfer")]

--- a/DnsClientX.PowerShell/CmdletFindDnsService.cs
+++ b/DnsClientX.PowerShell/CmdletFindDnsService.cs
@@ -6,8 +6,12 @@ namespace DnsClientX.PowerShell {
     /// <para type="synopsis">Discovers services advertised via DNS Service Discovery.</para>
     /// <para type="description">Wraps <see cref="ClientX.DiscoverServices"/> to return services under a domain.</para>
     /// <example>
-    ///   <para>Find HTTP services under example.com</para>
+    ///   <para>Find services under a domain</para>
     ///   <code>Find-DnsService -Domain example.com</code>
+    /// </example>
+    /// <example>
+    ///   <para>Filter for a specific service type</para>
+    ///   <code>Find-DnsService -Domain example.com | Where-Object {$_.ServiceName -like '*http*'}</code>
     /// </example>
     /// </summary>
     [Cmdlet(VerbsCommon.Find, "DnsService")]

--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -383,6 +383,10 @@ namespace DnsClientX.PowerShell {
                         all.AddRange(DnsResolverEndpointFactory.From(ep));
                     }
                     endpoints = all.ToArray();
+                    if (endpoints.Length == 0) {
+                        _logger?.WriteWarning("No endpoints were produced from the specified DnsProvider values.");
+                        return;
+                    }
                 }
 
                 // Apply DO bit preference uniformly when requested

--- a/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
+++ b/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs
@@ -9,12 +9,35 @@ using DnsClientX;
 
 namespace DnsClientX.PowerShell {
     /// <summary>
-    /// <para type="synopsis">Resolves a DNS query for a given name and type.</para>
-    /// <para type="description">Resolves a DNS query for a given name and type. The query can be sent to a specific server or to a specific provider. If no server or provider is specified, the default provider System (UDP) is used.</para>
+    /// <para type="synopsis">Resolves DNS records (A, AAAA, MX, TXT, …) over UDP/TCP/DoT/DoH with optional multi-resolver strategies.</para>
+    /// <para type="description">Supports single-provider queries, multiple providers with FirstSuccess/FastestWins/SequentialAll/RoundRobin, direct endpoints (IPv4/IPv6/DoH URLs), concurrency control, and TTL-based response caching.</para>
     /// <example>
-    ///  <para>Resolve a DNS query for a given name and type</para>
-    ///  <para></para>
-    ///  <code>Resolve-Dns -Name "google.com"</code>
+    ///  <para>Simple (system default)</para>
+    ///  <code>Resolve-Dns -Name "example.com" -Type A</code>
+    /// </example>
+    /// <example>
+    ///  <para>Single provider (classic)</para>
+    ///  <code>Resolve-Dns -Name "example.com" -Type A -DnsProvider Cloudflare</code>
+    /// </example>
+    /// <example>
+    ///  <para>FirstSuccess across providers</para>
+    ///  <code>Resolve-Dns -Name "example.com" -Type A -DnsProvider Cloudflare,Google -ResolverStrategy FirstSuccess</code>
+    /// </example>
+    /// <example>
+    ///  <para>FastestWins with cache</para>
+    ///  <code>Resolve-Dns -Name "example.com" -Type A -DnsProvider Cloudflare,Google -ResolverStrategy FastestWins -FastestCacheMinutes 10 -ResponseCache</code>
+    /// </example>
+    /// <example>
+    ///  <para>RoundRobin with per-endpoint cap</para>
+    ///  <code>Resolve-Dns -Name @('a.com','b.com') -Type A -DnsProvider System,Cloudflare,Quad9 -ResolverStrategy RoundRobin -MaxParallelism 16 -PerEndpointMaxInFlight 4</code>
+    /// </example>
+    /// <example>
+    ///  <para>Mixed endpoints (UDP + DoH)</para>
+    ///  <code>Resolve-Dns -Name 'example.com' -Type TXT -ResolverEndpoint '1.1.1.1:53','https://dns.google/dns-query' -ResolverStrategy FirstSuccess</code>
+    /// </example>
+    /// <example>
+    ///  <para>Enable TTL-based response cache with bounds</para>
+    ///  <code>Resolve-Dns -Name 'example.com' -Type MX -DnsProvider Cloudflare,Google -ResponseCache -CacheExpirationSeconds 30 -MinCacheTtlSeconds 1 -MaxCacheTtlSeconds 3600</code>
     /// </example>
     /// </summary>
     /// <seealso cref="DnsClientX.PowerShell.AsyncPSCmdlet" />
@@ -33,6 +56,10 @@ namespace DnsClientX.PowerShell {
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "PatternDnsProvider")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "PatternServerName")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "PatternResolverDnsProvider")]
         public string? Pattern { get; set; }
         /// <summary>
         /// <para type="description">The type of the record to query for. If not specified, A record is queried.</para>
@@ -41,13 +68,19 @@ namespace DnsClientX.PowerShell {
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "PatternDnsProvider")]
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "PatternServerName")]
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "PatternResolverDnsProvider")]
         public DnsRecordType[] Type = [DnsRecordType.A];
         /// <summary>
-        /// <para type="description">DnsProvider to use for the query. If not specified, the default provider System (UDP) is used.</para>
+        /// <para type="description">Predefined provider(s) (DnsEndpoint) for the query.</para>
+        /// <para type="description">When a single provider is specified, the classic single-resolver path is used. When multiple providers are specified, the multi-resolver path is used.</para>
+        /// <para type="description">If not specified, the default provider System (UDP) is used.</para>
         /// </summary>
         [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
         [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
-        public DnsEndpoint? DnsProvider;
+        public DnsEndpoint[] DnsProvider { get; set; } = Array.Empty<DnsEndpoint>();
 
         /// <summary>
         /// <para type="description">Server to use for the query. If not specified, the default provider System (UDP) is used.</para>
@@ -57,6 +90,121 @@ namespace DnsClientX.PowerShell {
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         [Parameter(Mandatory = false, ParameterSetName = "PatternServerName")]
         public List<string> Server = new List<string>();
+
+        /// <summary>
+        /// <para type="description">One or more resolver endpoints in string format. Accepted: "1.1.1.1:53", "[2606:4700:4700::1111]:53", "dns.google:53", or DoH URLs like "https://dns.google/dns-query".</para>
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = true, ParameterSetName = "PatternResolverEndpoint")]
+        public string[] ResolverEndpoint { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// <para type="description">One or more predefined providers (DnsEndpoint enum) to expand into endpoints for the multi-resolver.</para>
+        /// <para type="description">This enables strategy control (FirstSuccess/FastestWins/SequentialAll) and other multi-resolver options.</para>
+        /// </summary>
+        [Alias("DnsProviders")]
+        [Parameter(Mandatory = true, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = true, ParameterSetName = "PatternResolverDnsProvider")]
+        public DnsEndpoint[] ResolverDnsProvider { get; set; } = Array.Empty<DnsEndpoint>();
+
+        /// <summary>
+        /// <para type="description">Multi-resolver strategy to use when multiple endpoints are provided.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public MultiResolverStrategy ResolverStrategy { get; set; } = MultiResolverStrategy.FirstSuccess;
+
+        /// <summary>
+        /// <para type="description">Limits concurrent queries across endpoints. Defaults to 4.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public int MaxParallelism { get; set; } = 4;
+
+        /// <summary>
+        /// <para type="description">Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public SwitchParameter RespectEndpointTimeout { get; set; }
+
+        /// <summary>
+        /// <para type="description">Cache duration in minutes for FastestWins strategy.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public int FastestCacheMinutes { get; set; } = 5;
+
+        /// <summary>
+        /// <para type="description">Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public int PerEndpointMaxInFlight { get; set; } = 0;
+
+        /// <summary>
+        /// <para type="description">Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public SwitchParameter ResponseCache { get; set; }
+
+        /// <summary>
+        /// <para type="description">Optional override for default cache expiration when TTL is unavailable (seconds).</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public int CacheExpirationSeconds { get; set; } = 0;
+
+        /// <summary>
+        /// <para type="description">Minimal TTL allowed for cached entries (seconds). 0 leaves library default.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public int MinCacheTtlSeconds { get; set; } = 0;
+
+        /// <summary>
+        /// <para type="description">Maximal TTL allowed for cached entries (seconds). 0 leaves library default.</para>
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverEndpoint")]
+        [Parameter(Mandatory = false, ParameterSetName = "ResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternResolverDnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "DnsProvider")]
+        [Parameter(Mandatory = false, ParameterSetName = "PatternDnsProvider")]
+        public int MaxCacheTtlSeconds { get; set; } = 0;
 
         /// <summary>
         /// <para type="description">If specified, all servers listed in <see cref="Server"/> are queried sequentially and the responses are aggregated in server order.</para>
@@ -209,7 +357,85 @@ namespace DnsClientX.PowerShell {
             string types = string.Join(", ", Type);
             bool requestDnsSec = RequestDnsSec.IsPresent || ValidateDnsSec.IsPresent;
             bool validateDnsSec = ValidateDnsSec.IsPresent;
-            if (Server.Count > 0) {
+            if (this.ParameterSetName == "ResolverEndpoint" || this.ParameterSetName == "PatternResolverEndpoint" || this.ParameterSetName == "ResolverDnsProvider" || this.ParameterSetName == "PatternResolverDnsProvider" || ((this.ParameterSetName == "DnsProvider" || this.ParameterSetName == "PatternDnsProvider") && DnsProvider != null && DnsProvider.Length > 1)) {
+                var namesToUse2 = Pattern is null ? Name : ClientX.ExpandPattern(Pattern).ToArray();
+                string names2 = string.Join(", ", namesToUse2);
+                string types2 = string.Join(", ", Type);
+                bool requestDnsSec2 = RequestDnsSec.IsPresent || ValidateDnsSec.IsPresent;
+                bool validateDnsSec2 = ValidateDnsSec.IsPresent; // not used in multi-resolver yet
+
+                DnsResolverEndpoint[] endpoints;
+                if (this.ParameterSetName == "ResolverEndpoint" || this.ParameterSetName == "PatternResolverEndpoint") {
+                    endpoints = EndpointParser.TryParseMany(ResolverEndpoint, out var errors);
+                    if (errors.Count > 0) {
+                        foreach (var err in errors) _logger?.WriteError(err);
+                        return;
+                    }
+                } else if (this.ParameterSetName == "ResolverDnsProvider" || this.ParameterSetName == "PatternResolverDnsProvider") {
+                    var all = new List<DnsResolverEndpoint>();
+                    foreach (var ep in ResolverDnsProvider) {
+                        all.AddRange(DnsResolverEndpointFactory.From(ep));
+                    }
+                    endpoints = all.ToArray();
+                } else {
+                    var all = new List<DnsResolverEndpoint>();
+                    foreach (var ep in DnsProvider) {
+                        all.AddRange(DnsResolverEndpointFactory.From(ep));
+                    }
+                    endpoints = all.ToArray();
+                }
+
+                // Apply DO bit preference uniformly when requested
+                if (requestDnsSec2) {
+                    for (int i = 0; i < endpoints.Length; i++) {
+                        endpoints[i] = new DnsResolverEndpoint {
+                            Host = endpoints[i].Host,
+                            Port = endpoints[i].Port,
+                            Family = endpoints[i].Family,
+                            Transport = endpoints[i].Transport,
+                            Timeout = endpoints[i].Timeout,
+                            AllowTcpFallback = endpoints[i].AllowTcpFallback,
+                            EdnsBufferSize = endpoints[i].EdnsBufferSize,
+                            DnsSecOk = true,
+                            DohUrl = endpoints[i].DohUrl
+                        };
+                    }
+                }
+
+                var opts = new MultiResolverOptions {
+                    Strategy = ResolverStrategy,
+                    MaxParallelism = Math.Max(1, MaxParallelism),
+                    RespectEndpointTimeout = RespectEndpointTimeout.IsPresent,
+                    DefaultTimeout = TimeSpan.FromMilliseconds(TimeOut),
+                    FastestCacheDuration = TimeSpan.FromMinutes(Math.Max(1, FastestCacheMinutes)),
+                    PerEndpointMaxInFlight = PerEndpointMaxInFlight > 0 ? PerEndpointMaxInFlight : null,
+                    EnableResponseCache = ResponseCache.IsPresent,
+                    CacheExpiration = CacheExpirationSeconds > 0 ? TimeSpan.FromSeconds(CacheExpirationSeconds) : null,
+                    MinCacheTtl = MinCacheTtlSeconds > 0 ? TimeSpan.FromSeconds(MinCacheTtlSeconds) : null,
+                    MaxCacheTtl = MaxCacheTtlSeconds > 0 ? TimeSpan.FromSeconds(MaxCacheTtlSeconds) : null
+                };
+
+                IDnsMultiResolver mr = new DnsMultiResolver(endpoints, opts);
+
+                foreach (var t in Type) {
+                    _logger?.WriteVerbose("Querying DNS for {0} with type {1} across {2} endpoints", names2, t, endpoints.Length);
+                    var result = await mr.QueryBatchAsync(namesToUse2, t, this.CancelToken);
+                    foreach (var record in result) {
+                        if (record.Status == DnsResponseCode.NoError) {
+                            _logger?.WriteVerbose("Query successful for {0} with type {1}", string.Join(", ", record.Questions.Select(q => q.OriginalName)), t);
+                        } else {
+                            _logger?.WriteWarning("Query failed for {0} with type {1}: {2}", string.Join(", ", record.Questions.Select(q => q.OriginalName)), t, record.Error);
+                        }
+                        if (FullResponse.IsPresent) {
+                            WriteObject(record);
+                        } else if (TypedRecords.IsPresent && record.TypedAnswers != null) {
+                            WriteObject(record.TypedAnswers, true);
+                        } else {
+                            WriteObject(record.AnswersMinimal);
+                        }
+                    }
+                }
+            } else if (Server.Count > 0) {
                 var validServers = new List<string>();
                 foreach (string serverEntry in Server) {
                     string trimmed = serverEntry.Trim();
@@ -282,31 +508,23 @@ namespace DnsClientX.PowerShell {
                 }
             } else {
                 DnsResponse[] result;
-                if (DnsProvider == null) {
+                if (DnsProvider == null || DnsProvider.Length == 0) {
                     _logger?.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, "Default");
                     result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, parseTypedTxtRecords: ParseTypedTxtRecords.IsPresent));
                 } else {
-                    _logger?.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, DnsProvider.Value);
-                    result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, DnsProvider.Value, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, parseTypedTxtRecords: ParseTypedTxtRecords.IsPresent));
+                    var provider = DnsProvider[0];
+                    _logger?.WriteVerbose("Querying DNS for {0} with type {1} and provider {2}", names, types, provider);
+                    result = await ExecuteWithRetry(() => ClientX.QueryDns(namesToUse, Type, provider, timeOutMilliseconds: TimeOut, retryOnTransient: false, maxRetries: 1, retryDelayMs: RetryDelayMs, requestDnsSec: requestDnsSec, validateDnsSec: validateDnsSec, typedRecords: TypedRecords.IsPresent, parseTypedTxtRecords: ParseTypedTxtRecords.IsPresent));
                 }
 
                 foreach (var record in result) {
                     if (record.Status == DnsResponseCode.NoError)
                     {
-                        if (DnsProvider == null)
-                        {
-                            _logger?.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, "Default", record.RetryCount);
-                        }
-                        else
-                        {
-                            _logger?.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, DnsProvider.Value, record.RetryCount);
-                        }
+                        string providerLabel = (DnsProvider != null && DnsProvider.Length > 0) ? DnsProvider[0].ToString() : "Default";
+                        _logger?.WriteVerbose("Query successful for {0} with type {1}, {2} (retries {3})", names, types, providerLabel, record.RetryCount);
                     } else {
-                        if (DnsProvider == null) {
-                            _logger?.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, "Default", record.Error);
-                        } else {
-                            _logger?.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, DnsProvider.Value, record.Error);
-                        }
+                        string providerLabel = (DnsProvider != null && DnsProvider.Length > 0) ? DnsProvider[0].ToString() : "Default";
+                        _logger?.WriteWarning("Query failed for {0} with type {1}, {2} and error: {3}", names, types, providerLabel, record.Error);
                     }
                     if (FullResponse.IsPresent) {
                         WriteObject(record);

--- a/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
+++ b/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
@@ -3,11 +3,13 @@
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             netstandard2.0;net472;net8.0
         </TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+        <TargetFrameworks
+            Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
             net8.0
         </TargetFrameworks>
         <Title>DnsClientX PowerShell Module</Title>
-        <Description>PowerShell module for DnsClientX DNS library. Provides cmdlets for DNS queries, service discovery, zone transfers, and DNS updates.</Description>
+        <Description>PowerShell module for DnsClientX DNS library. Provides cmdlets for DNS queries,
+            service discovery, zone transfers, and DNS updates.</Description>
         <AssemblyName>DnsClientX.PowerShell</AssemblyName>
         <AssemblyTitle>DnsClientX PowerShell Module</AssemblyTitle>
         <VersionPrefix>1.0.1</VersionPrefix>
@@ -32,6 +34,19 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
+
+    <!-- We need to remove PowerShell conflicting libraries as it will break output -->
+    <Target Name="RemoveFilesAfterBuild" AfterTargets="Build">
+        <Delete Files="$(OutDir)System.Management.Automation.dll" />
+        <Delete Files="$(OutDir)System.Management.dll" />
+    </Target>
+
+    <!-- Copy help documentation to publish output after publish -->
+    <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
+        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml"
+            DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml"
+            Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
+    </Target>
 
     <ItemGroup>
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -34,23 +34,22 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4"
-        Condition="'$(TargetFramework)' == 'net472'" />
-  </ItemGroup>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="System.Net.Http" Version="4.3.4"
+            Condition="'$(TargetFramework)' == 'net472'" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DnsClientX\DnsClientX.csproj" />
-    <ProjectReference Include="..\DnsClientX.Cli\DnsClientX.Cli.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\DnsClientX\DnsClientX.csproj" />
+        <ProjectReference Include="..\DnsClientX.Cli\DnsClientX.Cli.csproj" />
+    </ItemGroup>
 
     <ItemGroup>
         <Using Include="Xunit" />
-  </ItemGroup>
+    </ItemGroup>
 
-  
 
 </Project>

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -49,6 +49,8 @@
 
     <ItemGroup>
         <Using Include="Xunit" />
-    </ItemGroup>
+  </ItemGroup>
+
+  
 
 </Project>

--- a/DnsClientX.Tests/DnsEndpointParserTests.cs
+++ b/DnsClientX.Tests/DnsEndpointParserTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for <see cref="EndpointParser"/> verifying supported resolver endpoint formats.
+    /// </summary>
+    public class DnsEndpointParserTests {
+        /// <summary>
+        /// Ensures IPv4, IPv6, hostname and DoH URL inputs parse into endpoints without errors.
+        /// </summary>
+        [Fact]
+        public void TryParseMany_ParsesVariousFormats() {
+            string[] inputs = new[] {
+                "1.1.1.1:53",
+                "[2606:4700:4700::1111]:53",
+                "dns.google:53",
+                "https://dns.google/dns-query"
+            };
+
+            var endpoints = EndpointParser.TryParseMany(inputs, out var errors);
+            Assert.Empty(errors);
+            Assert.Equal(4, endpoints.Length);
+
+            Assert.Equal("1.1.1.1", endpoints[0].Host);
+            Assert.Equal(53, endpoints[0].Port);
+            Assert.Equal(Transport.Udp, endpoints[0].Transport);
+
+            Assert.Equal("2606:4700:4700::1111", endpoints[1].Host);
+            Assert.Equal(53, endpoints[1].Port);
+            Assert.Equal(Transport.Udp, endpoints[1].Transport);
+
+            Assert.Equal("dns.google", endpoints[2].Host);
+            Assert.Equal(53, endpoints[2].Port);
+            Assert.Equal(Transport.Udp, endpoints[2].Transport);
+
+            Assert.NotNull(endpoints[3].DohUrl);
+            Assert.Equal(Transport.Doh, endpoints[3].Transport);
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsMultiResolverBasicTests.cs
+++ b/DnsClientX.Tests/DnsMultiResolverBasicTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Basic integration-style validation for <see cref="DnsMultiResolver"/>, skipped by default.
+    /// </summary>
+    public class DnsMultiResolverBasicTests {
+        /// <summary>
+        /// Batch queries preserve input order and isolate per-item failures.
+        /// </summary>
+        [Fact(Skip = "Integration test - network dependent; run locally if needed")]
+        public async Task Batch_PreservesOrder_And_IsolatesFailures() {
+            var eps = EndpointParser.TryParseMany(new []{ "1.1.1.1:53", "8.8.8.8:53" }, out var errors);
+            Assert.Empty(errors);
+            var opts = new MultiResolverOptions { Strategy = MultiResolverStrategy.FirstSuccess, MaxParallelism = 2 };
+            var mr = new DnsMultiResolver(eps, opts);
+
+            string[] names = new[] { "example.com", "cloudflare.com", "nonexistent.name.invalid." };
+            var res = await mr.QueryBatchAsync(names, DnsRecordType.A, CancellationToken.None);
+            Assert.Equal(names.Length, res.Length);
+            Assert.Equal("example.com", res[0].Questions[0].OriginalName);
+            Assert.Equal("cloudflare.com", res[1].Questions[0].OriginalName);
+            Assert.Equal("nonexistent.name.invalid.", res[2].Questions[0].OriginalName);
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsMultiResolverConcurrencyTests.cs
+++ b/DnsClientX.Tests/DnsMultiResolverConcurrencyTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Concurrency and in-flight caps for DnsMultiResolver.
+    /// </summary>
+    public class DnsMultiResolverConcurrencyTests {
+        [Fact]
+        public async Task MaxParallelism_Caps_InFlight() {
+            try {
+                var eps = new[] { new DnsResolverEndpoint { Host="e1", Port=53, Transport=Transport.Udp } };
+                var opts = new MultiResolverOptions { Strategy = MultiResolverStrategy.FirstSuccess, MaxParallelism = 3 };
+                int inFlight = 0, maxInFlight = 0;
+                object gate = new object();
+                DnsMultiResolver.ResolveOverride = async (ep, name, type, ct) => {
+                    int now;
+                    lock (gate) { now = ++inFlight; if (now > maxInFlight) maxInFlight = now; }
+                    try { await Task.Delay(50, ct); } finally { lock (gate) { inFlight--; } }
+                    return new DnsResponse { Questions = new[] { new DnsQuestion { Name = name, Type = type, OriginalName = name } }, Status = DnsResponseCode.NoError };
+                };
+                var mr = new DnsMultiResolver(eps, opts);
+                var names = new[] { "a","b","c","d","e","f" };
+                await mr.QueryBatchAsync(names, DnsRecordType.A);
+                Assert.True(maxInFlight <= 3, $"maxInFlight={maxInFlight}");
+            } finally { DnsMultiResolver.ResolveOverride = null; }
+        }
+
+        [Fact]
+        public async Task PerEndpointMaxInFlight_Caps_Per_Endpoint() {
+            try {
+                var eps = new[] { new DnsResolverEndpoint { Host="only", Port=53, Transport=Transport.Udp } };
+                var opts = new MultiResolverOptions { Strategy = MultiResolverStrategy.FirstSuccess, MaxParallelism = 8, PerEndpointMaxInFlight = 2 };
+                int inFlight = 0, maxInFlight = 0;
+                object gate = new object();
+                DnsMultiResolver.ResolveOverride = async (ep, name, type, ct) => {
+                    int now;
+                    lock (gate) { now = ++inFlight; if (now > maxInFlight) maxInFlight = now; }
+                    try { await Task.Delay(50, ct); } finally { lock (gate) { inFlight--; } }
+                    return new DnsResponse { Questions = new[] { new DnsQuestion { Name = name, Type = type, OriginalName = name } }, Status = DnsResponseCode.NoError };
+                };
+                var mr = new DnsMultiResolver(eps, opts);
+                var names = new[] { "a","b","c","d","e","f" };
+                await mr.QueryBatchAsync(names, DnsRecordType.A);
+                Assert.True(maxInFlight <= 2, $"maxInFlight={maxInFlight}");
+            } finally { DnsMultiResolver.ResolveOverride = null; }
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsMultiResolverErrorHandlingTests.cs
+++ b/DnsClientX.Tests/DnsMultiResolverErrorHandlingTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Error scenarios for DnsMultiResolver.
+    /// </summary>
+    public class DnsMultiResolverErrorHandlingTests {
+        [Fact]
+        public async Task Error_Network_Sets_ErrorCode_Network() {
+            try {
+                var eps = new[] { new DnsResolverEndpoint { Host="n1", Port=53, Transport=Transport.Udp } };
+                var opts = new MultiResolverOptions { Strategy = MultiResolverStrategy.SequentialAll };
+                DnsMultiResolver.ResolveOverride = (ep, name, type, ct) => throw new SocketException((int)SocketError.NetworkUnreachable);
+                var mr = new DnsMultiResolver(eps, opts);
+                var res = await mr.QueryAsync("x.com", DnsRecordType.A);
+                Assert.Equal(DnsQueryErrorCode.Network, res.ErrorCode);
+            } finally { DnsMultiResolver.ResolveOverride = null; }
+        }
+
+        [Fact]
+        public async Task Error_InvalidResponse_Sets_ErrorCode_InvalidResponse() {
+            try {
+                var eps = new[] { new DnsResolverEndpoint { Host="n1", Port=53, Transport=Transport.Udp } };
+                var opts = new MultiResolverOptions { Strategy = MultiResolverStrategy.SequentialAll };
+                DnsMultiResolver.ResolveOverride = (ep, name, type, ct) => throw new DnsClientException("bad response");
+                var mr = new DnsMultiResolver(eps, opts);
+                var res = await mr.QueryAsync("x.com", DnsRecordType.A);
+                Assert.Equal(DnsQueryErrorCode.InvalidResponse, res.ErrorCode);
+            } finally { DnsMultiResolver.ResolveOverride = null; }
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsMultiResolverRoundRobinTests.cs
+++ b/DnsClientX.Tests/DnsMultiResolverRoundRobinTests.cs
@@ -6,7 +6,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests RoundRobin behavior with a simulated resolver to avoid network access.
+    /// </summary>
     public class DnsMultiResolverRoundRobinTests {
+        /// <summary>
+        /// Ensures distribution across endpoints and fallback on failure without using network.
+        /// </summary>
         [Fact]
         public async Task RoundRobin_Distributes_And_FallsBack() {
             try {
@@ -50,12 +56,11 @@ namespace DnsClientX.Tests {
                 Assert.True(results.Count(r => r.Status == DnsResponseCode.NoError) >= names.Length - 3);
 
                 // Distribution happened (e1 and e3 should have non-zero)
-                Assert.True(counts.GetValueOrDefault("e1") > 0);
-                Assert.True(counts.GetValueOrDefault("e3") > 0);
+                Assert.True(counts.TryGetValue("e1", out var v1) && v1 > 0);
+                Assert.True(counts.TryGetValue("e3", out var v3) && v3 > 0);
             } finally {
                 DnsMultiResolver.ResolveOverride = null;
             }
         }
     }
 }
-

--- a/DnsClientX.Tests/DnsMultiResolverRoundRobinTests.cs
+++ b/DnsClientX.Tests/DnsMultiResolverRoundRobinTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsMultiResolverRoundRobinTests {
+        [Fact]
+        public async Task RoundRobin_Distributes_And_FallsBack() {
+            try {
+                // Arrange endpoints
+                var eps = new [] {
+                    new DnsResolverEndpoint { Host = "e1", Port = 53, Transport = Transport.Udp },
+                    new DnsResolverEndpoint { Host = "e2", Port = 53, Transport = Transport.Udp },
+                    new DnsResolverEndpoint { Host = "e3", Port = 53, Transport = Transport.Udp }
+                };
+                var opts = new MultiResolverOptions {
+                    Strategy = MultiResolverStrategy.RoundRobin,
+                    MaxParallelism = 8,
+                    PerEndpointMaxInFlight = 4,
+                    EnableResponseCache = false
+                };
+
+                // Count assignments and simulate fallback: make e2 fail to force fallback
+                var counts = new ConcurrentDictionary<string, int>();
+                DnsMultiResolver.ResolveOverride = (ep, name, type, ct) => {
+                    counts.AddOrUpdate(ep.Host ?? string.Empty, 1, (_, v) => v + 1);
+                    if (ep.Host == "e2") {
+                        return Task.FromResult(new DnsResponse {
+                            Questions = new[] { new DnsQuestion { Name = name, Type = type, OriginalName = name } },
+                            Status = DnsResponseCode.ServerFailure,
+                            Error = "fail"
+                        });
+                    }
+                    return Task.FromResult(new DnsResponse {
+                        Questions = new[] { new DnsQuestion { Name = name, Type = type, OriginalName = name } },
+                        Answers = new[] { new DnsAnswer { Name = name, Type = type, TTL = 60, DataRaw = "127.0.0.1" } },
+                        Status = DnsResponseCode.NoError
+                    });
+                };
+
+                var mr = new DnsMultiResolver(eps, opts);
+                string[] names = Enumerable.Range(0, 9).Select(i => $"n{i}.example").ToArray();
+                var results = await mr.QueryBatchAsync(names, DnsRecordType.A, CancellationToken.None);
+
+                // Assert successful responses
+                Assert.Equal(names.Length, results.Length);
+                Assert.True(results.Count(r => r.Status == DnsResponseCode.NoError) >= names.Length - 3);
+
+                // Distribution happened (e1 and e3 should have non-zero)
+                Assert.True(counts.GetValueOrDefault("e1") > 0);
+                Assert.True(counts.GetValueOrDefault("e3") > 0);
+            } finally {
+                DnsMultiResolver.ResolveOverride = null;
+            }
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsMultiResolverStrategiesTests.cs
+++ b/DnsClientX.Tests/DnsMultiResolverStrategiesTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests multi-resolver strategies: FirstSuccess, FastestWins, SequentialAll.
+    /// </summary>
+    public class DnsMultiResolverStrategiesTests {
+        private static DnsResponse Ok(string name, DnsRecordType type)
+            => new DnsResponse {
+                Questions = new[] { new DnsQuestion { Name = name, Type = type, OriginalName = name } },
+                Answers = new[] { new DnsAnswer { Name = name, Type = type, TTL = 30, DataRaw = "127.0.0.1" } },
+                Status = DnsResponseCode.NoError
+            };
+
+        [Fact]
+        public async Task FirstSuccess_Picks_First_Valid_Response() {
+            try {
+                var eps = new[] {
+                    new DnsResolverEndpoint { Host="s1", Port=53, Transport=Transport.Udp },
+                    new DnsResolverEndpoint { Host="s2", Port=53, Transport=Transport.Udp }
+                };
+                var opts = new MultiResolverOptions { Strategy = MultiResolverStrategy.FirstSuccess, MaxParallelism = 2 };
+                DnsMultiResolver.ResolveOverride = async (ep, name, type, ct) => {
+                    if (ep.Host == "s1") {
+                        await Task.Delay(50, ct);
+                        return Ok(name, type);
+                    }
+                    await Task.Delay(200, ct);
+                    return Ok(name, type);
+                };
+                var mr = new DnsMultiResolver(eps, opts);
+                var res = await mr.QueryAsync("example.com", DnsRecordType.A);
+                Assert.Equal(DnsResponseCode.NoError, res.Status);
+            } finally { DnsMultiResolver.ResolveOverride = null; }
+        }
+
+        [Fact]
+        public async Task FastestWins_Warms_And_Uses_Cached_Fastest() {
+            try {
+                var eps = new[] {
+                    new DnsResolverEndpoint { Host="fast", Port=53, Transport=Transport.Udp },
+                    new DnsResolverEndpoint { Host="slow", Port=53, Transport=Transport.Udp }
+                };
+                var opts = new MultiResolverOptions { Strategy = MultiResolverStrategy.FastestWins, MaxParallelism = 2, FastestCacheDuration = TimeSpan.FromMinutes(5) };
+                var calls = new ConcurrentDictionary<string,int>();
+                DnsMultiResolver.ResolveOverride = async (ep, name, type, ct) => {
+                    calls.AddOrUpdate(ep.Host ?? string.Empty, 1, (_, v) => v + 1);
+                    if (ep.Host == "slow") await Task.Delay(80, ct); else await Task.Delay(10, ct);
+                    return Ok(name, type);
+                };
+                var mr = new DnsMultiResolver(eps, opts);
+                var r1 = await mr.QueryAsync("a.com", DnsRecordType.A);
+                Assert.Equal(DnsResponseCode.NoError, r1.Status);
+                // Second query should hit only the cached fastest endpoint
+                var prevFast = calls.TryGetValue("fast", out var v1) ? v1 : 0;
+                var prevSlow = calls.TryGetValue("slow", out var v2) ? v2 : 0;
+                var r2 = await mr.QueryAsync("b.com", DnsRecordType.A);
+                Assert.Equal(DnsResponseCode.NoError, r2.Status);
+                Assert.True(calls.TryGetValue("fast", out var vFast) && vFast > prevFast);
+                Assert.True(calls.TryGetValue("slow", out var vSlow) && vSlow == prevSlow);
+            } finally { DnsMultiResolver.ResolveOverride = null; DnsMultiResolver.ClearFastestCache(); }
+        }
+
+        [Fact]
+        public async Task SequentialAll_Tries_In_Order_And_Returns_Success() {
+            try {
+                var eps = new[] {
+                    new DnsResolverEndpoint { Host="bad", Port=53, Transport=Transport.Udp },
+                    new DnsResolverEndpoint { Host="ok", Port=53, Transport=Transport.Udp }
+                };
+                var opts = new MultiResolverOptions { Strategy = MultiResolverStrategy.SequentialAll };
+                DnsMultiResolver.ResolveOverride = (ep, name, type, ct) => {
+                    if (ep.Host == "bad") {
+                        return Task.FromResult(new DnsResponse { Questions = new[]{ new DnsQuestion { Name=name, Type=type, OriginalName=name } }, Status = DnsResponseCode.ServerFailure, Error = "fail", ErrorCode = DnsQueryErrorCode.ServFail });
+                    }
+                    return Task.FromResult(Ok(name, type));
+                };
+                var mr = new DnsMultiResolver(eps, opts);
+                var res = await mr.QueryAsync("example.com", DnsRecordType.A);
+                Assert.Equal(DnsResponseCode.NoError, res.Status);
+            } finally { DnsMultiResolver.ResolveOverride = null; }
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsQueryExceptionTests.cs
+++ b/DnsClientX.Tests/DnsQueryExceptionTests.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsQueryExceptionTests {
+        [Fact]
+        public void Properties_AreSet() {
+            var ex = new DnsQueryException(DnsQueryErrorCode.Timeout, "timed out");
+            Assert.Equal(DnsQueryErrorCode.Timeout, ex.ErrorCode);
+            Assert.Equal("timed out", ex.Message);
+            Assert.Null(ex.Response);
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsQueryExceptionTests.cs
+++ b/DnsClientX.Tests/DnsQueryExceptionTests.cs
@@ -1,7 +1,13 @@
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests covering <see cref="DnsQueryException"/> construction and properties.
+    /// </summary>
     public class DnsQueryExceptionTests {
+        /// <summary>
+        /// Error code and message are preserved; response is optional.
+        /// </summary>
         [Fact]
         public void Properties_AreSet() {
             var ex = new DnsQueryException(DnsQueryErrorCode.Timeout, "timed out");
@@ -11,4 +17,3 @@ namespace DnsClientX.Tests {
         }
     }
 }
-

--- a/DnsClientX.Tests/DnsResolverEndpointFactoryTests.cs
+++ b/DnsClientX.Tests/DnsResolverEndpointFactoryTests.cs
@@ -3,7 +3,13 @@ using System.Linq;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for converting built-in providers to multi-resolver endpoints and endpoint formatting.
+    /// </summary>
     public class DnsResolverEndpointFactoryTests {
+        /// <summary>
+        /// Cloudflare providers map to DoH endpoints on port 443.
+        /// </summary>
         [Fact]
         public void From_Cloudflare_ReturnsDoHEndpoints() {
             var eps = DnsResolverEndpointFactory.From(DnsEndpoint.Cloudflare);
@@ -12,6 +18,9 @@ namespace DnsClientX.Tests {
             Assert.All(eps, e => Assert.True(e.Port == 443));
         }
 
+        /// <summary>
+        /// Root servers map to UDP endpoints on port 53.
+        /// </summary>
         [Fact]
         public void From_RootServer_ReturnsUdpEndpoints() {
             var eps = DnsResolverEndpointFactory.From(DnsEndpoint.RootServer);
@@ -20,6 +29,9 @@ namespace DnsClientX.Tests {
             Assert.All(eps, e => Assert.Equal(53, e.Port));
         }
 
+        /// <summary>
+        /// Endpoint ToString should format DoH and host:port consistently.
+        /// </summary>
         [Fact]
         public void DnsResolverEndpoint_ToString_Formats() {
             var doh = new DnsResolverEndpoint { Transport = Transport.Doh, DohUrl = new Uri("https://dns.google/dns-query"), Port = 443, Host = "dns.google" };
@@ -30,4 +42,3 @@ namespace DnsClientX.Tests {
         }
     }
 }
-

--- a/DnsClientX.Tests/DnsResolverEndpointFactoryTests.cs
+++ b/DnsClientX.Tests/DnsResolverEndpointFactoryTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsResolverEndpointFactoryTests {
+        [Fact]
+        public void From_Cloudflare_ReturnsDoHEndpoints() {
+            var eps = DnsResolverEndpointFactory.From(DnsEndpoint.Cloudflare);
+            Assert.NotEmpty(eps);
+            Assert.All(eps, e => Assert.Equal(Transport.Doh, e.Transport));
+            Assert.All(eps, e => Assert.True(e.Port == 443));
+        }
+
+        [Fact]
+        public void From_RootServer_ReturnsUdpEndpoints() {
+            var eps = DnsResolverEndpointFactory.From(DnsEndpoint.RootServer);
+            Assert.NotEmpty(eps);
+            Assert.All(eps, e => Assert.Equal(Transport.Udp, e.Transport));
+            Assert.All(eps, e => Assert.Equal(53, e.Port));
+        }
+
+        [Fact]
+        public void DnsResolverEndpoint_ToString_Formats() {
+            var doh = new DnsResolverEndpoint { Transport = Transport.Doh, DohUrl = new Uri("https://dns.google/dns-query"), Port = 443, Host = "dns.google" };
+            Assert.Equal("https://dns.google/dns-query", doh.ToString());
+
+            var udp = new DnsResolverEndpoint { Transport = Transport.Udp, Host = "1.1.1.1", Port = 53 };
+            Assert.Equal("1.1.1.1:53", udp.ToString());
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsResponseTtlTests.cs
+++ b/DnsClientX.Tests/DnsResponseTtlTests.cs
@@ -1,0 +1,26 @@
+using System;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    public class DnsResponseTtlTests {
+        [Fact]
+        public void ComputeTtlMetrics_ComputesMinAndAvg() {
+            var response = new DnsResponse {
+                Answers = new [] {
+                    new DnsAnswer { Name = "a", Type = DnsRecordType.A, TTL = 60, DataRaw = "127.0.0.1" },
+                    new DnsAnswer { Name = "a", Type = DnsRecordType.A, TTL = 120, DataRaw = "127.0.0.2" }
+                }
+            };
+            response.ComputeTtlMetrics();
+            Assert.Equal(60, response.TtlMin);
+            Assert.Equal(90, Math.Round(response.TtlAvg!.Value));
+        }
+
+        [Fact]
+        public void Truncated_Mirrors_IsTruncated() {
+            var r = new DnsResponse { IsTruncated = true };
+            Assert.True(r.Truncated);
+        }
+    }
+}
+

--- a/DnsClientX.Tests/DnsResponseTtlTests.cs
+++ b/DnsClientX.Tests/DnsResponseTtlTests.cs
@@ -2,7 +2,13 @@ using System;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for TTL metric computations on <see cref="DnsResponse"/>.
+    /// </summary>
     public class DnsResponseTtlTests {
+        /// <summary>
+        /// Computes TtlMin as minimum and TtlAvg as arithmetic mean.
+        /// </summary>
         [Fact]
         public void ComputeTtlMetrics_ComputesMinAndAvg() {
             var response = new DnsResponse {
@@ -16,6 +22,9 @@ namespace DnsClientX.Tests {
             Assert.Equal(90, Math.Round(response.TtlAvg!.Value));
         }
 
+        /// <summary>
+        /// Truncated property mirrors IsTruncated for convenience.
+        /// </summary>
         [Fact]
         public void Truncated_Mirrors_IsTruncated() {
             var r = new DnsResponse { IsTruncated = true };
@@ -23,4 +32,3 @@ namespace DnsClientX.Tests {
         }
     }
 }
-

--- a/DnsClientX.Tests/EndpointParserMoreTests.cs
+++ b/DnsClientX.Tests/EndpointParserMoreTests.cs
@@ -7,6 +7,9 @@ namespace DnsClientX.Tests {
     /// Additional tests for EndpointParser covering error cases and validation.
     /// </summary>
     public class EndpointParserMoreTests {
+        /// <summary>
+        /// Invalid (non-HTTPS) scheme in DoH URL should be rejected.
+        /// </summary>
         [Fact]
         public void TryParseMany_InvalidScheme_ShouldReportError() {
             var inputs = new[] { "http://dns.google/dns-query" }; // only https is allowed
@@ -16,6 +19,9 @@ namespace DnsClientX.Tests {
             Assert.Empty(eps);
         }
 
+        /// <summary>
+        /// Malformed IPv6 with brackets should be reported as invalid.
+        /// </summary>
         [Fact]
         public void TryParseMany_InvalidIpv6Format_ShouldReportError() {
             var inputs = new[] { "[2001:4860:4860::8888:53" }; // missing closing bracket
@@ -23,6 +29,9 @@ namespace DnsClientX.Tests {
             Assert.Single(errors);
         }
 
+        /// <summary>
+        /// Invalid port number should be reported as an error.
+        /// </summary>
         [Fact]
         public void TryParseMany_InvalidPort_ShouldReportError() {
             var inputs = new[] { "1.1.1.1:99999" };
@@ -31,4 +40,3 @@ namespace DnsClientX.Tests {
         }
     }
 }
-

--- a/DnsClientX.Tests/EndpointParserMoreTests.cs
+++ b/DnsClientX.Tests/EndpointParserMoreTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Additional tests for EndpointParser covering error cases and validation.
+    /// </summary>
+    public class EndpointParserMoreTests {
+        [Fact]
+        public void TryParseMany_InvalidScheme_ShouldReportError() {
+            var inputs = new[] { "http://dns.google/dns-query" }; // only https is allowed
+            var eps = EndpointParser.TryParseMany(inputs, out var errors);
+            Assert.Single(errors);
+            Assert.Contains("Unsupported scheme", errors[0], StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(eps);
+        }
+
+        [Fact]
+        public void TryParseMany_InvalidIpv6Format_ShouldReportError() {
+            var inputs = new[] { "[2001:4860:4860::8888:53" }; // missing closing bracket
+            _ = EndpointParser.TryParseMany(inputs, out var errors);
+            Assert.Single(errors);
+        }
+
+        [Fact]
+        public void TryParseMany_InvalidPort_ShouldReportError() {
+            var inputs = new[] { "1.1.1.1:99999" };
+            _ = EndpointParser.TryParseMany(inputs, out var errors);
+            Assert.Single(errors);
+        }
+    }
+}
+

--- a/DnsClientX.Tests/EndpointParserValidationTests.cs
+++ b/DnsClientX.Tests/EndpointParserValidationTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Additional validation tests for EndpointParser.
+    /// </summary>
+    public class EndpointParserValidationTests {
+        [Fact]
+        public void EmptyString_ReportsError() {
+            var eps = EndpointParser.TryParseMany(new [] { "" }, out var errors);
+            Assert.Single(errors);
+            Assert.Empty(eps);
+        }
+
+        [Fact]
+        public void Hostname_WithoutPort_DefaultsTo53Udp() {
+            var eps = EndpointParser.TryParseMany(new [] { "dns.google" }, out var errors);
+            Assert.Empty(errors);
+            Assert.Single(eps);
+            Assert.Equal(53, eps[0].Port);
+            Assert.Equal(Transport.Udp, eps[0].Transport);
+        }
+
+        [Fact]
+        public void DohHttps_Parses() {
+            var eps = EndpointParser.TryParseMany(new [] { "https://dns.google/dns-query" }, out var errors);
+            Assert.Empty(errors);
+            Assert.Single(eps);
+            Assert.Equal(Transport.Doh, eps[0].Transport);
+            Assert.Equal("dns.google", eps[0].Host);
+        }
+    }
+}
+

--- a/DnsClientX.Tests/MaxConcurrencyHintTests.cs
+++ b/DnsClientX.Tests/MaxConcurrencyHintTests.cs
@@ -5,7 +5,13 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests for optional max concurrency hints on array-based resolution helpers.
+    /// </summary>
     public class MaxConcurrencyHintTests {
+        /// <summary>
+        /// Caps concurrency to 1 and preserves order for Resolve(name[]).
+        /// </summary>
         [Fact]
         public async Task Resolve_Array_CapsConcurrency_And_PreservesOrder() {
             using var client = new ClientX(DnsEndpoint.System);
@@ -46,6 +52,9 @@ namespace DnsClientX.Tests {
             }
         }
 
+        /// <summary>
+        /// Caps concurrency to 2 and preserves order for ResolveFilter(name[]).
+        /// </summary>
         [Fact]
         public async Task ResolveFilter_Array_CapsConcurrency_And_PreservesOrder() {
             using var client = new ClientX(DnsEndpoint.System);

--- a/DnsClientX/ClientXBuilder.cs
+++ b/DnsClientX/ClientXBuilder.cs
@@ -170,7 +170,16 @@ namespace DnsClientX {
             if (field != null) {
                 var names = (IEnumerable<string>)field.GetValue(client.EndpointConfiguration)!;
                 foreach (var name in names) {
-                    if (Uri.CheckHostName(name) == UriHostNameType.Unknown) {
+                    // Accept valid IPs immediately
+                    if (System.Net.IPAddress.TryParse(name, out _)) {
+                        continue;
+                    }
+                    // Basic host validation: must be recognized DNS name and contain only allowed characters
+                    bool allowedChars = true;
+                    foreach (char ch in name) {
+                        if (!(char.IsLetterOrDigit(ch) || ch == '-' || ch == '.')) { allowedChars = false; break; }
+                    }
+                    if (Uri.CheckHostName(name) == UriHostNameType.Unknown || !allowedChars) {
                         throw new ArgumentException($"Invalid hostname: {name}");
                     }
                 }

--- a/DnsClientX/Definitions/DnsQueryErrorCode.cs
+++ b/DnsClientX/Definitions/DnsQueryErrorCode.cs
@@ -1,0 +1,27 @@
+namespace DnsClientX {
+    /// <summary>
+    /// Normalized error categories for DNS queries.
+    /// </summary>
+    public enum DnsQueryErrorCode {
+        /// <summary>
+        /// No error.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Operation timed out.
+        /// </summary>
+        Timeout,
+        /// <summary>
+        /// Network-related failure (socket, connectivity, etc.).
+        /// </summary>
+        Network,
+        /// <summary>
+        /// Response could not be parsed or was invalid.
+        /// </summary>
+        InvalidResponse,
+        /// <summary>
+        /// Generic server failure or unspecified error.
+        /// </summary>
+        ServFail
+    }
+}

--- a/DnsClientX/Definitions/DnsQueryException.cs
+++ b/DnsClientX/Definitions/DnsQueryException.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Wraps network/parse/timeout exceptions during DNS querying with a normalized error code.
+    /// </summary>
+    public sealed class DnsQueryException : Exception {
+        /// <summary>
+        /// Normalized error category.
+        /// </summary>
+        public DnsQueryErrorCode ErrorCode { get; }
+        /// <summary>
+        /// Optional response associated with the failure.
+        /// </summary>
+        public DnsResponse? Response { get; }
+
+        /// <summary>
+        /// Creates a new instance with the specified error category and message.
+        /// </summary>
+        public DnsQueryException(DnsQueryErrorCode errorCode, string message, Exception? inner = null, DnsResponse? response = null)
+            : base(message, inner) {
+            ErrorCode = errorCode;
+            Response = response;
+        }
+    }
+}

--- a/DnsClientX/Definitions/DnsResolverEndpoint.cs
+++ b/DnsClientX/Definitions/DnsResolverEndpoint.cs
@@ -56,7 +56,11 @@ namespace DnsClientX {
         /// </summary>
         public override string ToString() {
             if (Transport == Transport.Doh && DohUrl != null) return DohUrl.ToString();
-            return string.IsNullOrWhiteSpace(Host) ? base.ToString()! : (Port > 0 ? $"{Host}:{Port}" : Host);
+            var h = Host;
+            if (string.IsNullOrWhiteSpace(h)) {
+                h = "(unknown)";
+            }
+            return Port > 0 ? $"{h}:{Port}" : h;
         }
     }
 }

--- a/DnsClientX/Definitions/DnsResolverEndpoint.cs
+++ b/DnsClientX/Definitions/DnsResolverEndpoint.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Net.Sockets;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Describes a DNS resolver endpoint and its behavior.
+    /// </summary>
+    public sealed class DnsResolverEndpoint {
+        /// <summary>
+        /// Hostname or IP address for UDP/TCP/DoT. For DoH, the host part of <see cref="DohUrl"/>.
+        /// </summary>
+        public string? Host { get; init; }
+
+        /// <summary>
+        /// Port number. Defaults to 53 for UDP/TCP, 853 for DoT, and 443 for DoH when not specified.
+        /// </summary>
+        public int Port { get; init; } = 53;
+
+        /// <summary>
+        /// Optional preferred address family when resolving hostnames.
+        /// </summary>
+        public AddressFamily? Family { get; init; }
+
+        /// <summary>
+        /// Transport protocol used to query this endpoint.
+        /// </summary>
+        public Transport Transport { get; init; } = Transport.Udp;
+
+        /// <summary>
+        /// Optional per-endpoint timeout. When null, a library default is used.
+        /// </summary>
+        public TimeSpan? Timeout { get; init; }
+
+        /// <summary>
+        /// Allow automatic TCP fallback when UDP responses are truncated.
+        /// </summary>
+        public bool AllowTcpFallback { get; init; } = true;
+
+        /// <summary>
+        /// Optional EDNS buffer size for UDP queries.
+        /// </summary>
+        public int? EdnsBufferSize { get; init; }
+
+        /// <summary>
+        /// Sets the DO bit (DNSSEC OK) in queries to request DNSSEC records.
+        /// </summary>
+        public bool? DnsSecOk { get; init; }
+
+        /// <summary>
+        /// For DoH transports, the full resolver URL (e.g. https://dns.google/dns-query).
+        /// </summary>
+        public Uri? DohUrl { get; init; }
+
+        /// <summary>
+        /// Returns a human-readable endpoint string.
+        /// </summary>
+        public override string ToString() {
+            if (Transport == Transport.Doh && DohUrl != null) return DohUrl.ToString();
+            return string.IsNullOrWhiteSpace(Host) ? base.ToString()! : (Port > 0 ? $"{Host}:{Port}" : Host);
+        }
+    }
+}

--- a/DnsClientX/Definitions/MultiResolverOptions.cs
+++ b/DnsClientX/Definitions/MultiResolverOptions.cs
@@ -35,12 +35,20 @@ namespace DnsClientX {
         /// Fallback per-query timeout used when an endpoint doesn't provide one.
         /// When null, uses <see cref="Configuration.DefaultTimeout"/>.
         /// </summary>
-        public TimeSpan? DefaultTimeout { get; set; }
+        private TimeSpan? _defaultTimeout;
+        public TimeSpan? DefaultTimeout {
+            get => _defaultTimeout;
+            set => _defaultTimeout = (value.HasValue && value.Value < TimeSpan.Zero) ? TimeSpan.Zero : value;
+        }
 
         /// <summary>
         /// Cache duration for FastestWins fastest-endpoint selection.
         /// </summary>
-        public TimeSpan FastestCacheDuration { get; set; } = TimeSpan.FromMinutes(5);
+        private TimeSpan _fastestCacheDuration = TimeSpan.FromMinutes(5);
+        public TimeSpan FastestCacheDuration {
+            get => _fastestCacheDuration <= TimeSpan.Zero ? TimeSpan.FromMinutes(5) : _fastestCacheDuration;
+            set => _fastestCacheDuration = value <= TimeSpan.Zero ? TimeSpan.FromMinutes(1) : value;
+        }
 
         /// <summary>
         /// Enables or disables the FastestWins cache.
@@ -72,16 +80,28 @@ namespace DnsClientX {
         /// <summary>
         /// Default cache expiration used when TTL is unavailable. When null, uses the library default.
         /// </summary>
-        public TimeSpan? CacheExpiration { get; set; }
+        private TimeSpan? _cacheExpiration;
+        public TimeSpan? CacheExpiration {
+            get => _cacheExpiration;
+            set => _cacheExpiration = (value.HasValue && value.Value < TimeSpan.Zero) ? TimeSpan.Zero : value;
+        }
 
         /// <summary>
         /// Minimal TTL allowed for cached entries. Entries with smaller TTLs are rounded up to this value.
         /// </summary>
-        public TimeSpan? MinCacheTtl { get; set; }
+        private TimeSpan? _minCacheTtl;
+        public TimeSpan? MinCacheTtl {
+            get => _minCacheTtl;
+            set => _minCacheTtl = (value.HasValue && value.Value < TimeSpan.Zero) ? TimeSpan.Zero : value;
+        }
 
         /// <summary>
         /// Maximal TTL allowed for cached entries. Entries with larger TTLs are clipped to this value.
         /// </summary>
-        public TimeSpan? MaxCacheTtl { get; set; }
+        private TimeSpan? _maxCacheTtl;
+        public TimeSpan? MaxCacheTtl {
+            get => _maxCacheTtl;
+            set => _maxCacheTtl = (value.HasValue && value.Value < TimeSpan.Zero) ? TimeSpan.Zero : value;
+        }
     }
 }

--- a/DnsClientX/Definitions/MultiResolverOptions.cs
+++ b/DnsClientX/Definitions/MultiResolverOptions.cs
@@ -5,6 +5,8 @@ namespace DnsClientX {
     /// Options controlling behavior of <see cref="DnsMultiResolver"/>.
     /// </summary>
     public sealed class MultiResolverOptions {
+        private int _maxParallelism = 4;
+        private int? _perEndpointMaxInFlight;
         /// <summary>
         /// Strategy used when multiple endpoints are configured.
         /// </summary>
@@ -14,7 +16,10 @@ namespace DnsClientX {
         /// Upper bound on the number of endpoints queried concurrently.
         /// Applies to FirstSuccess and FastestWins warm-up.
         /// </summary>
-        public int MaxParallelism { get; set; } = 4;
+        public int MaxParallelism {
+            get => _maxParallelism;
+            set => _maxParallelism = value <= 0 ? 1 : value;
+        }
 
         /// <summary>
         /// Prefer IPv6 when resolving hostnames (when applicable).
@@ -47,7 +52,16 @@ namespace DnsClientX {
         /// the resolver limits the number of in-flight queries against any single endpoint
         /// to this value. When null or less than or equal to zero, no per-endpoint cap is applied.
         /// </summary>
-        public int? PerEndpointMaxInFlight { get; set; }
+        public int? PerEndpointMaxInFlight {
+            get => _perEndpointMaxInFlight;
+            set {
+                if (value.HasValue && value.Value <= 0) {
+                    _perEndpointMaxInFlight = null;
+                } else {
+                    _perEndpointMaxInFlight = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Enables response caching based on record TTLs. When enabled, the resolver leverages the

--- a/DnsClientX/Definitions/MultiResolverOptions.cs
+++ b/DnsClientX/Definitions/MultiResolverOptions.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Options controlling behavior of <see cref="DnsMultiResolver"/>.
+    /// </summary>
+    public sealed class MultiResolverOptions {
+        /// <summary>
+        /// Strategy used when multiple endpoints are configured.
+        /// </summary>
+        public MultiResolverStrategy Strategy { get; set; } = MultiResolverStrategy.FirstSuccess;
+
+        /// <summary>
+        /// Upper bound on the number of endpoints queried concurrently.
+        /// Applies to FirstSuccess and FastestWins warm-up.
+        /// </summary>
+        public int MaxParallelism { get; set; } = 4;
+
+        /// <summary>
+        /// Prefer IPv6 when resolving hostnames (when applicable).
+        /// </summary>
+        public bool PreferIpv6 { get; set; }
+
+        /// <summary>
+        /// Respect per-endpoint timeout value if specified; otherwise use <see cref="DefaultTimeout"/>.
+        /// </summary>
+        public bool RespectEndpointTimeout { get; set; } = true;
+
+        /// <summary>
+        /// Fallback per-query timeout used when an endpoint doesn't provide one.
+        /// When null, uses <see cref="Configuration.DefaultTimeout"/>.
+        /// </summary>
+        public TimeSpan? DefaultTimeout { get; set; }
+
+        /// <summary>
+        /// Cache duration for FastestWins fastest-endpoint selection.
+        /// </summary>
+        public TimeSpan FastestCacheDuration { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Enables or disables the FastestWins cache.
+        /// </summary>
+        public bool EnableFastestCache { get; set; } = true;
+
+        /// <summary>
+        /// Optional cap on concurrent queries per endpoint. When set to a positive value,
+        /// the resolver limits the number of in-flight queries against any single endpoint
+        /// to this value. When null or less than or equal to zero, no per-endpoint cap is applied.
+        /// </summary>
+        public int? PerEndpointMaxInFlight { get; set; }
+
+        /// <summary>
+        /// Enables response caching based on record TTLs. When enabled, the resolver leverages the
+        /// library's built-in cache to avoid repeated lookups for the same (name,type) across instances.
+        /// </summary>
+        public bool EnableResponseCache { get; set; }
+
+        /// <summary>
+        /// Default cache expiration used when TTL is unavailable. When null, uses the library default.
+        /// </summary>
+        public TimeSpan? CacheExpiration { get; set; }
+
+        /// <summary>
+        /// Minimal TTL allowed for cached entries. Entries with smaller TTLs are rounded up to this value.
+        /// </summary>
+        public TimeSpan? MinCacheTtl { get; set; }
+
+        /// <summary>
+        /// Maximal TTL allowed for cached entries. Entries with larger TTLs are clipped to this value.
+        /// </summary>
+        public TimeSpan? MaxCacheTtl { get; set; }
+    }
+}

--- a/DnsClientX/Definitions/MultiResolverStrategy.cs
+++ b/DnsClientX/Definitions/MultiResolverStrategy.cs
@@ -1,0 +1,28 @@
+namespace DnsClientX {
+    /// <summary>
+    /// Strategy for choosing among multiple resolver endpoints.
+    /// </summary>
+    public enum MultiResolverStrategy {
+        /// <summary>
+        /// Race endpoints (bounded by MaxParallelism) and return the first successful response, cancelling the rest.
+        /// </summary>
+        FirstSuccess,
+        /// <summary>
+        /// Warm all endpoints and prefer the endpoint that produced the fastest successful response, caching that choice for a duration.
+        /// </summary>
+        FastestWins,
+        /// <summary>
+        /// Try endpoints sequentially and return the first success or the best error if all fail.
+        /// </summary>
+        SequentialAll
+        ,
+        /// <summary>
+        /// Distribute queries across endpoints in round-robin fashion to balance load. The
+        /// chosen endpoint handles the query; on failure, the resolver falls back to the first
+        /// endpoint (or the second if the first was chosen). Combine with <see cref="MultiResolverOptions.MaxParallelism"/>
+        /// to cap overall concurrency and <see cref="MultiResolverOptions.PerEndpointMaxInFlight"/>
+        /// to limit per-endpoint concurrency.
+        /// </summary>
+        RoundRobin
+    }
+}

--- a/DnsClientX/Definitions/Transport.cs
+++ b/DnsClientX/Definitions/Transport.cs
@@ -1,0 +1,23 @@
+namespace DnsClientX {
+    /// <summary>
+    /// DNS transport protocol used to reach a resolver endpoint.
+    /// </summary>
+    public enum Transport {
+        /// <summary>
+        /// DNS over UDP (port 53).
+        /// </summary>
+        Udp,
+        /// <summary>
+        /// DNS over TCP (port 53).
+        /// </summary>
+        Tcp,
+        /// <summary>
+        /// DNS over TLS (RFC 7858, typically port 853).
+        /// </summary>
+        Dot,
+        /// <summary>
+        /// DNS over HTTPS (RFC 8484, HTTPS endpoints).
+        /// </summary>
+        Doh
+    }
+}

--- a/DnsClientX/DnsResolverEndpointFactory.cs
+++ b/DnsClientX/DnsResolverEndpointFactory.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Factory helpers to convert predefined <see cref="DnsEndpoint"/> values into <see cref="DnsResolverEndpoint"/> instances.
+    /// Only transports supported by the multi-resolver (UDP, TCP, DoT, DoH) are emitted.
+    /// </summary>
+    public static class DnsResolverEndpointFactory {
+        /// <summary>
+        /// Creates one or more <see cref="DnsResolverEndpoint"/> entries for a predefined <see cref="DnsEndpoint"/>.
+        /// Quic, gRPC, and DNSCrypt variants are not included as the multi-resolver currently supports UDP/TCP/DoT/DoH only.
+        /// </summary>
+        public static DnsResolverEndpoint[] From(DnsEndpoint endpoint) {
+            var list = new List<DnsResolverEndpoint>();
+            void AddHost(string host, int port, Transport transport) => list.Add(new DnsResolverEndpoint { Host = host, Port = port, Transport = transport });
+            void AddDoh(string host) => list.Add(new DnsResolverEndpoint { Transport = Transport.Doh, DohUrl = new Uri($"https://{host}/dns-query"), Host = host, Port = 443 });
+
+            switch (endpoint) {
+                case DnsEndpoint.System:
+                    foreach (var host in SystemInformation.GetDnsFromActiveNetworkCard()) AddHost(host, 53, Transport.Udp);
+                    break;
+                case DnsEndpoint.SystemTcp:
+                    foreach (var host in SystemInformation.GetDnsFromActiveNetworkCard()) AddHost(host, 53, Transport.Tcp);
+                    break;
+                case DnsEndpoint.Cloudflare:
+                case DnsEndpoint.CloudflareWireFormat:
+                case DnsEndpoint.CloudflareWireFormatPost:
+                case DnsEndpoint.CloudflareJsonPost:
+                    AddDoh("1.1.1.1");
+                    AddDoh("1.0.0.1");
+                    break;
+                case DnsEndpoint.CloudflareSecurity:
+                    AddDoh("1.1.1.2");
+                    AddDoh("1.0.0.2");
+                    break;
+                case DnsEndpoint.CloudflareFamily:
+                    AddDoh("1.1.1.3");
+                    AddDoh("1.0.0.3");
+                    break;
+                case DnsEndpoint.Google:
+                case DnsEndpoint.GoogleWireFormat:
+                case DnsEndpoint.GoogleWireFormatPost:
+                case DnsEndpoint.GoogleJsonPost:
+                    AddDoh("dns.google");
+                    break;
+                case DnsEndpoint.Quad9:
+                case DnsEndpoint.Quad9ECS:
+                case DnsEndpoint.Quad9Unsecure:
+                    AddDoh("dns.quad9.net");
+                    break;
+                case DnsEndpoint.OpenDNS:
+                case DnsEndpoint.OpenDNSFamily:
+                    AddDoh("208.67.222.222");
+                    AddDoh("208.67.220.220");
+                    break;
+                case DnsEndpoint.AdGuard:
+                case DnsEndpoint.AdGuardFamily:
+                case DnsEndpoint.AdGuardNonFiltering:
+                    AddDoh("dns.adguard.com");
+                    break;
+                case DnsEndpoint.NextDNS:
+                    AddDoh("dns.nextdns.io");
+                    break;
+                case DnsEndpoint.RootServer:
+                    foreach (var host in RootServers.Servers) AddHost(host, 53, Transport.Udp);
+                    break;
+                // Not supported transports for multi-resolver (yet)
+                case DnsEndpoint.CloudflareQuic:
+                case DnsEndpoint.GoogleQuic:
+                case DnsEndpoint.DnsCryptCloudflare:
+                case DnsEndpoint.DnsCryptQuad9:
+                case DnsEndpoint.DnsCryptRelay:
+                case DnsEndpoint.CloudflareOdoh:
+                case DnsEndpoint.Custom:
+                default:
+                    break;
+            }
+
+            return list.ToArray();
+        }
+    }
+}

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -63,14 +63,19 @@ namespace DnsClientX {
 
                 // Split host:port (IPv4 or hostname)
                 var parts = raw.Split(':');
-                if (parts.Length == 2 && int.TryParse(parts[1], out int port) && port > 0 && port <= 65535) {
-                    string host = parts[0];
-                    AddressFamily? family = null;
-                    if (IPAddress.TryParse(host, out var ipAddr)) {
-                        family = ipAddr.AddressFamily;
+                if (parts.Length == 2) {
+                    if (int.TryParse(parts[1], out int port) && port > 0 && port <= 65535) {
+                        string host = parts[0];
+                        AddressFamily? family = null;
+                        if (IPAddress.TryParse(host, out var ipAddr)) {
+                            family = ipAddr.AddressFamily;
+                        }
+                        list.Add(new DnsResolverEndpoint { Host = host, Port = port, Transport = Transport.Udp, Family = family });
+                        continue;
+                    } else {
+                        errs.Add($"Invalid port in endpoint: {raw}");
+                        continue;
                     }
-                    list.Add(new DnsResolverEndpoint { Host = host, Port = port, Transport = Transport.Udp, Family = family });
-                    continue;
                 }
 
                 // Plain host with default port

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -21,9 +21,14 @@ namespace DnsClientX {
             var list = new List<DnsResolverEndpoint>();
             var errs = new List<string>();
 
-            foreach (var raw in inputs ?? Array.Empty<string>()) {
+            foreach (var rawIn in inputs ?? Array.Empty<string>()) {
+                string raw = rawIn?.Trim() ?? string.Empty;
                 if (string.IsNullOrWhiteSpace(raw)) {
                     errs.Add("Empty endpoint string");
+                    continue;
+                }
+                if (raw.Any(char.IsWhiteSpace)) {
+                    errs.Add($"Endpoint contains whitespace: {rawIn}");
                     continue;
                 }
 

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Parses user-provided resolver endpoint strings into validated endpoints.
+    /// </summary>
+    public static class EndpointParser {
+        /// <summary>
+        /// Tries to parse multiple endpoint input strings.
+        /// Accepted formats:
+        ///  - IPv4: "1.1.1.1:53"
+        ///  - IPv6: "[2606:4700:4700::1111]:53"
+        ///  - Hostname: "dns.google:53"
+        ///  - DoH URL: "https://dns.google/dns-query"
+        /// </summary>
+        public static DnsResolverEndpoint[] TryParseMany(IEnumerable<string> inputs, out IReadOnlyList<string> errors) {
+            var list = new List<DnsResolverEndpoint>();
+            var errs = new List<string>();
+
+            foreach (var raw in inputs ?? Array.Empty<string>()) {
+                if (string.IsNullOrWhiteSpace(raw)) {
+                    errs.Add("Empty endpoint string");
+                    continue;
+                }
+
+                // DoH URL
+                if (raw.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || raw.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) {
+                    if (Uri.TryCreate(raw, UriKind.Absolute, out var uri)) {
+                        if (!string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase)) {
+                            errs.Add($"Unsupported scheme for DoH: {raw}");
+                            continue;
+                        }
+                        list.Add(new DnsResolverEndpoint {
+                            Transport = Transport.Doh,
+                            DohUrl = uri,
+                            Host = uri.Host,
+                            Port = uri.IsDefaultPort ? 443 : uri.Port
+                        });
+                        continue;
+                    }
+                    errs.Add($"Invalid DoH URL: {raw}");
+                    continue;
+                }
+
+                // IPv6 in brackets
+                if (raw.StartsWith("[")) {
+                    int end = raw.IndexOf(']');
+                    if (end > 1) {
+                        string ip = raw.Substring(1, end - 1);
+                        string portPart = raw.Length > end + 1 && raw[end + 1] == ':' ? raw.Substring(end + 2) : "53";
+                        if (IPAddress.TryParse(ip, out var addr) && addr.AddressFamily == AddressFamily.InterNetworkV6 && int.TryParse(portPart, out int p) && p > 0 && p <= 65535) {
+                            list.Add(new DnsResolverEndpoint { Host = ip, Port = p, Transport = Transport.Udp, Family = AddressFamily.InterNetworkV6 });
+                            continue;
+                        }
+                    }
+                    errs.Add($"Invalid IPv6 endpoint: {raw}");
+                    continue;
+                }
+
+                // Split host:port (IPv4 or hostname)
+                var parts = raw.Split(':');
+                if (parts.Length == 2 && int.TryParse(parts[1], out int port) && port > 0 && port <= 65535) {
+                    string host = parts[0];
+                    AddressFamily? family = null;
+                    if (IPAddress.TryParse(host, out var ipAddr)) {
+                        family = ipAddr.AddressFamily;
+                    }
+                    list.Add(new DnsResolverEndpoint { Host = host, Port = port, Transport = Transport.Udp, Family = family });
+                    continue;
+                }
+
+                // Plain host with default port
+                if (!string.IsNullOrWhiteSpace(raw)) {
+                    AddressFamily? family = null;
+                    if (IPAddress.TryParse(raw, out var ipAddr)) {
+                        family = ipAddr.AddressFamily;
+                    }
+                    list.Add(new DnsResolverEndpoint { Host = raw, Port = 53, Transport = Transport.Udp, Family = family });
+                    continue;
+                }
+
+                errs.Add($"Unrecognized endpoint format: {raw}");
+            }
+
+            errors = errs;
+            return list.ToArray();
+        }
+    }
+}

--- a/DnsClientX/MultiResolver/DnsMultiResolver.cs
+++ b/DnsClientX/MultiResolver/DnsMultiResolver.cs
@@ -60,6 +60,13 @@ namespace DnsClientX {
                     if (ep.DohUrl == null || !string.Equals(ep.DohUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase)) {
                         throw new ArgumentException($"Invalid DoH endpoint: {ep}. HTTPS URL is required.", nameof(endpoints));
                     }
+                    // Validate custom DoH port when specified
+                    if (!ep.DohUrl.IsDefaultPort) {
+                        int p = ep.DohUrl.Port;
+                        if (p <= 0 || p > 65535) {
+                            throw new ArgumentOutOfRangeException(nameof(ep.DohUrl), p, "DoH URL port must be between 1 and 65535.");
+                        }
+                    }
                 } else {
                     if (string.IsNullOrWhiteSpace(ep.Host)) {
                         throw new ArgumentException("Endpoint Host is required for non-DoH transports.", nameof(endpoints));

--- a/DnsClientX/MultiResolver/DnsMultiResolver.cs
+++ b/DnsClientX/MultiResolver/DnsMultiResolver.cs
@@ -1,0 +1,386 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Multi-endpoint resolver supporting FirstSuccess, FastestWins, and SequentialAll strategies.
+    /// </summary>
+    public sealed class DnsMultiResolver : IDnsMultiResolver {
+        private readonly DnsResolverEndpoint[] _endpoints;
+        private readonly MultiResolverOptions _options;
+
+        private const int DefaultPerQueryTimeoutMs = Configuration.DefaultTimeout; // fallback when endpoint timeout not specified
+        private int _roundRobinIndex = -1;
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _endpointLimiters = new();
+
+        // Simple metrics
+        private static readonly ConcurrentDictionary<string, EndpointMetrics> Metrics = new();
+
+        // Cache for FastestWins strategy
+        private static readonly ConcurrentDictionary<string, FastestCacheEntry> FastestCache = new();
+
+        private readonly struct FastestCacheEntry {
+            public FastestCacheEntry(string key, DateTime expiresAt) {
+                Key = key; ExpiresAt = expiresAt;
+            }
+            public string Key { get; }
+            public DateTime ExpiresAt { get; }
+        }
+
+        private sealed class EndpointMetrics {
+            public long SuccessCount;
+            public long FailureCount;
+            public TimeSpan LastRtt;
+        }
+
+        /// <summary>
+        /// Creates a multi-endpoint resolver with provided endpoints and options.
+        /// </summary>
+        /// <param name="endpoints">One or more endpoints to target.</param>
+        /// <param name="options">Behavioral options controlling strategy, parallelism, timeouts, and caching.</param>
+        public DnsMultiResolver(IEnumerable<DnsResolverEndpoint> endpoints, MultiResolverOptions? options = null) {
+            _endpoints = (endpoints ?? Array.Empty<DnsResolverEndpoint>()).ToArray();
+            if (_endpoints.Length == 0) throw new ArgumentException("No endpoints provided", nameof(endpoints));
+            _options = options ?? new MultiResolverOptions();
+        }
+
+        /// <summary>
+        /// Queries a single name for the specified record type according to the configured strategy.
+        /// </summary>
+        public Task<DnsResponse> QueryAsync(string name, DnsRecordType type, CancellationToken ct = default) {
+            return _options.Strategy switch {
+                MultiResolverStrategy.FirstSuccess => QueryFirstSuccessAsync(name, type, ct),
+                MultiResolverStrategy.FastestWins => QueryFastestWinsAsync(name, type, ct),
+                MultiResolverStrategy.SequentialAll => QuerySequentialAsync(name, type, ct),
+                MultiResolverStrategy.RoundRobin => QueryRoundRobinAsync(name, type, ct),
+                _ => QueryFirstSuccessAsync(name, type, ct)
+            };
+        }
+
+        /// <summary>
+        /// Queries multiple names of the same record type, preserving input order, and isolating failures per-element.
+        /// </summary>
+        public async Task<DnsResponse[]> QueryBatchAsync(string[] names, DnsRecordType type, CancellationToken ct = default) {
+            if (names == null || names.Length == 0) return Array.Empty<DnsResponse>();
+            var results = new DnsResponse[names.Length];
+            int maxPar = Math.Max(1, _options.MaxParallelism);
+            using var sem = new SemaphoreSlim(maxPar, maxPar);
+            var tasks = new List<Task>();
+            for (int i = 0; i < names.Length; i++) {
+                int idx = i;
+                await sem.WaitAsync(ct).ConfigureAwait(false);
+                tasks.Add(Task.Run(async () => {
+                    try {
+                        results[idx] = await QueryAsync(names[idx], type, ct).ConfigureAwait(false);
+                    } finally {
+                        sem.Release();
+                    }
+                }, ct));
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+            return results;
+        }
+
+        private async Task<DnsResponse> QueryFirstSuccessAsync(string name, DnsRecordType type, CancellationToken ct) {
+            // Chunk endpoints to respect MaxParallelism and cancel losers
+            int batch = Math.Max(1, _options.MaxParallelism);
+            var queue = new Queue<DnsResolverEndpoint>(_endpoints);
+            using var globalCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+            List<Exception> exceptions = new();
+            DnsResponse? bestError = null;
+
+            while (queue.Count > 0) {
+                var current = new List<Task<(DnsResponse resp, DnsResolverEndpoint ep)>>();
+                for (int i = 0; i < batch && queue.Count > 0; i++) {
+                    var ep = queue.Dequeue();
+                    current.Add(InvokeEndpoint(ep, name, type, globalCts.Token));
+                }
+
+                while (current.Count > 0) {
+                    var finished = await Task.WhenAny(current).ConfigureAwait(false);
+                    current.Remove(finished);
+                    (DnsResponse resp, DnsResolverEndpoint ep) = await finished.ConfigureAwait(false);
+                    if (IsSuccess(resp)) {
+                        globalCts.Cancel(); // cancel remaining tasks
+                        return resp;
+                    }
+                    bestError = ChooseBetterError(bestError, resp);
+                }
+            }
+
+            return bestError ?? MakeError(name, type, DnsQueryErrorCode.ServFail, "All endpoints failed");
+        }
+
+        private async Task<DnsResponse> QuerySequentialAsync(string name, DnsRecordType type, CancellationToken ct) {
+            DnsResponse? bestError = null;
+            foreach (var ep in _endpoints) {
+                ct.ThrowIfCancellationRequested();
+                var (resp, _) = await InvokeEndpoint(ep, name, type, ct).ConfigureAwait(false);
+                if (IsSuccess(resp)) return resp;
+                bestError = ChooseBetterError(bestError, resp);
+            }
+            return bestError ?? MakeError(name, type, DnsQueryErrorCode.ServFail, "All endpoints failed");
+        }
+
+        private async Task<DnsResponse> QueryFastestWinsAsync(string name, DnsRecordType type, CancellationToken ct) {
+            string key = ComputeSetKey(_endpoints);
+            if (_options.EnableFastestCache && FastestCache.TryGetValue(key, out var cached) && cached.ExpiresAt > DateTime.UtcNow) {
+                // The cache stores endpoint key - resolve to endpoint
+                var ep = _endpoints.FirstOrDefault(e => EndpointKey(e) == cached.Key);
+                if (ep != null) {
+                    var (resp, _) = await InvokeEndpoint(ep, name, type, ct).ConfigureAwait(false);
+                    if (IsSuccess(resp)) return resp;
+                    // fallback to warm all below if cached failed
+                }
+            }
+
+            // Warm all endpoints (bounded by parallelism) and pick the fastest success
+            int batch = Math.Max(1, _options.MaxParallelism);
+            var queue = new Queue<DnsResolverEndpoint>(_endpoints);
+            using var globalCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var inflight = new List<Task<(DnsResponse resp, DnsResolverEndpoint ep, TimeSpan rtt)>>();
+
+            // prime first batch
+            for (int i = 0; i < batch && queue.Count > 0; i++) {
+                var ep = queue.Dequeue();
+                inflight.Add(InvokeEndpointTimed(ep, name, type, globalCts.Token));
+            }
+
+            DnsResponse? best = null;
+            DnsResolverEndpoint? bestEp = null;
+            TimeSpan bestRtt = TimeSpan.MaxValue;
+            DnsResponse? bestError = null;
+
+            while (inflight.Count > 0) {
+                var finished = await Task.WhenAny(inflight).ConfigureAwait(false);
+                inflight.Remove(finished);
+                var (resp, ep, rtt) = await finished.ConfigureAwait(false);
+                if (IsSuccess(resp)) {
+                    if (rtt < bestRtt) { best = resp; bestEp = ep; bestRtt = rtt; }
+                } else {
+                    bestError = ChooseBetterError(bestError, resp);
+                }
+
+                // launch next if available
+                if (queue.Count > 0) {
+                    var next = queue.Dequeue();
+                    inflight.Add(InvokeEndpointTimed(next, name, type, globalCts.Token));
+                }
+            }
+
+            if (best != null && bestEp != null) {
+                string ek = EndpointKey(bestEp);
+                if (_options.EnableFastestCache) {
+                    FastestCache[key] = new FastestCacheEntry(ek, DateTime.UtcNow.Add(_options.FastestCacheDuration));
+                }
+                return best;
+            }
+
+            return bestError ?? MakeError(name, type, DnsQueryErrorCode.ServFail, "All endpoints failed");
+        }
+
+        private async Task<DnsResponse> QueryRoundRobinAsync(string name, DnsRecordType type, CancellationToken ct) {
+            // Pick assigned endpoint by round-robin
+            int idx = (System.Threading.Interlocked.Increment(ref _roundRobinIndex)) % _endpoints.Length;
+            if (idx < 0) idx = -idx; // ensure non-negative
+            var assigned = _endpoints[idx];
+            var (resp, _) = await InvokeEndpoint(assigned, name, type, ct).ConfigureAwait(false);
+            if (IsSuccess(resp)) return resp;
+
+            // Fallback to first endpoint if different
+            var first = _endpoints[0];
+            if (!ReferenceEquals(first, assigned)) {
+                var (fallback, _) = await InvokeEndpoint(first, name, type, ct).ConfigureAwait(false);
+                if (IsSuccess(fallback)) return fallback;
+                return ChooseBetterError(resp, fallback);
+            }
+
+            // If assigned was first, try second if available as a modest fallback
+            if (_endpoints.Length > 1) {
+                var second = _endpoints[1];
+                var (fallback2, _) = await InvokeEndpoint(second, name, type, ct).ConfigureAwait(false);
+                if (IsSuccess(fallback2)) return fallback2;
+                return ChooseBetterError(resp, fallback2);
+            }
+
+            return resp;
+        }
+
+        private static bool IsSuccess(DnsResponse resp) {
+            return resp != null && resp.Status == DnsResponseCode.NoError && string.IsNullOrEmpty(resp.Error);
+        }
+
+        private async Task<(DnsResponse resp, DnsResolverEndpoint ep)> InvokeEndpoint(DnsResolverEndpoint ep, string name, DnsRecordType type, CancellationToken ct) {
+            var (resp, _, _) = await InvokeEndpointTimed(ep, name, type, ct).ConfigureAwait(false);
+            return (resp, ep);
+        }
+
+        private async Task<(DnsResponse resp, DnsResolverEndpoint ep, TimeSpan rtt)> InvokeEndpointTimed(DnsResolverEndpoint ep, string name, DnsRecordType type, CancellationToken ct) {
+            TimeSpan timeout = (_options.RespectEndpointTimeout && ep.Timeout.HasValue)
+                ? ep.Timeout!.Value
+                : (_options.DefaultTimeout ?? TimeSpan.FromMilliseconds(DefaultPerQueryTimeoutMs));
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            if (timeout > TimeSpan.Zero) cts.CancelAfter(timeout);
+
+            var sw = Stopwatch.StartNew();
+            DnsResponse response;
+            try {
+                SemaphoreSlim? limiter = GetLimiter(ep);
+                if (limiter != null) await limiter.WaitAsync(cts.Token).ConfigureAwait(false);
+                try {
+                    response = await PerformQuery(ep, name, type, cts.Token).ConfigureAwait(false);
+                } finally {
+                    if (limiter != null) limiter.Release();
+                }
+            } catch (OperationCanceledException oce) when (!ct.IsCancellationRequested) {
+                response = MakeError(ep, name, type, DnsQueryErrorCode.Timeout, oce.Message, oce);
+            } catch (SocketException se) {
+                response = MakeError(ep, name, type, DnsQueryErrorCode.Network, se.Message, se);
+            } catch (DnsClientException dce) {
+                response = MakeError(ep, name, type, DnsQueryErrorCode.InvalidResponse, dce.Message, dce);
+            } catch (Exception ex) {
+                response = MakeError(ep, name, type, DnsQueryErrorCode.ServFail, ex.Message, ex);
+            }
+            sw.Stop();
+
+            StampResponse(ep, response, sw.Elapsed);
+            RecordMetrics(ep, response, sw.Elapsed);
+            return (response, ep, sw.Elapsed);
+        }
+
+        private SemaphoreSlim? GetLimiter(DnsResolverEndpoint ep) {
+            if (!_options.PerEndpointMaxInFlight.HasValue) return null;
+            int cap = _options.PerEndpointMaxInFlight!.Value;
+            if (cap <= 0) return null;
+            string key = EndpointKey(ep);
+            return _endpointLimiters.GetOrAdd(key, _ => new SemaphoreSlim(cap, cap));
+        }
+
+        private static void StampResponse(DnsResolverEndpoint ep, DnsResponse response, TimeSpan rtt) {
+            if (response == null) return;
+            response.UsedTransport = ep.Transport;
+            response.UsedEndpoint = ep;
+            response.RoundTripTime = rtt;
+            response.ComputeTtlMetrics();
+        }
+
+        private void RecordMetrics(DnsResolverEndpoint ep, DnsResponse response, TimeSpan rtt) {
+            var m = Metrics.GetOrAdd(EndpointKey(ep), _ => new EndpointMetrics());
+            if (IsSuccess(response)) System.Threading.Interlocked.Increment(ref m.SuccessCount); else System.Threading.Interlocked.Increment(ref m.FailureCount);
+            m.LastRtt = rtt;
+        }
+
+        private static string ComputeSetKey(IEnumerable<DnsResolverEndpoint> endpoints) => string.Join("|", endpoints.Select(EndpointKey));
+        private static string EndpointKey(DnsResolverEndpoint ep) => ep.Transport + ":" + (ep.DohUrl?.ToString() ?? (ep.Host ?? string.Empty)) + ":" + ep.Port.ToString();
+
+        private static DnsResponse ChooseBetterError(DnsResponse? current, DnsResponse candidate) {
+            if (current == null) return candidate;
+            int Rank(DnsResponse r) => r.ErrorCode switch {
+                DnsQueryErrorCode.Timeout => 1,
+                DnsQueryErrorCode.Network => 2,
+                DnsQueryErrorCode.ServFail => 3,
+                DnsQueryErrorCode.InvalidResponse => 4,
+                _ => 0
+            };
+            return Rank(candidate) >= Rank(current) ? candidate : current;
+        }
+
+        private static DnsResponse MakeError(string name, DnsRecordType type, DnsQueryErrorCode code, string message) => new DnsResponse {
+            Status = DnsResponseCode.ServerFailure,
+            Questions = [ new DnsQuestion { Name = name, Type = type, OriginalName = name } ],
+            Error = message,
+            ErrorCode = code
+        };
+
+        private static DnsResponse MakeError(DnsResolverEndpoint ep, string name, DnsRecordType type, DnsQueryErrorCode code, string message, Exception? ex) {
+            var r = MakeError(name, type, code, message);
+            r.Exception = ex;
+            r.UsedTransport = ep.Transport;
+            r.UsedEndpoint = ep;
+            return r;
+        }
+
+        /// <summary>
+        /// Clears the in-memory FastestWins cache for all endpoint sets.
+        /// </summary>
+        public static void ClearFastestCache() => FastestCache.Clear();
+
+        /// <summary>
+        /// Clears the FastestWins cache for the provided set of endpoints only.
+        /// </summary>
+        public static void ClearFastestCacheFor(IEnumerable<DnsResolverEndpoint> endpoints) {
+            if (endpoints == null) return;
+            string key = ComputeSetKey(endpoints);
+            FastestCache.TryRemove(key, out _);
+        }
+
+        private static DnsRequestFormat MapTransport(Transport t) => t switch {
+            Transport.Udp => DnsRequestFormat.DnsOverUDP,
+            Transport.Tcp => DnsRequestFormat.DnsOverTCP,
+            Transport.Dot => DnsRequestFormat.DnsOverTLS,
+            Transport.Doh => DnsRequestFormat.DnsOverHttps,
+            _ => DnsRequestFormat.DnsOverUDP
+        };
+
+        private async Task<DnsResponse> PerformQuery(DnsResolverEndpoint ep, string name, DnsRecordType type, CancellationToken ct) {
+            // Configure ClientX according to endpoint
+            ClientX client;
+            if (ep.Transport == Transport.Doh) {
+                var dohUri = ep.DohUrl ?? new Uri($"https://{ep.Host}/dns-query");
+                client = new ClientX(
+                    baseUri: dohUri,
+                    requestFormat: MapTransport(ep.Transport),
+                    timeOutMilliseconds: DefaultPerQueryTimeoutMs,
+                    userAgent: null,
+                    httpVersion: null,
+                    ignoreCertificateErrors: false,
+                    enableCache: _options.EnableResponseCache,
+                    useTcpFallback: true,
+                    webProxy: null,
+                    maxConnectionsPerServer: Configuration.DefaultMaxConnectionsPerServer);
+            } else {
+                if (string.IsNullOrWhiteSpace(ep.Host)) throw new ArgumentException("Endpoint.Host is required for non-DoH transports");
+                client = new ClientX(
+                    hostname: ep.Host!,
+                    requestFormat: MapTransport(ep.Transport),
+                    timeOutMilliseconds: DefaultPerQueryTimeoutMs,
+                    userAgent: null,
+                    httpVersion: null,
+                    ignoreCertificateErrors: false,
+                    enableCache: _options.EnableResponseCache,
+                    useTcpFallback: true,
+                    webProxy: null,
+                    maxConnectionsPerServer: Configuration.DefaultMaxConnectionsPerServer);
+            }
+
+            // Fine-tune endpoint configuration
+            if (ep.Transport != Transport.Doh) {
+                client.EndpointConfiguration.Port = ep.Port > 0 ? ep.Port : (ep.Transport == Transport.Dot ? 853 : 53);
+            } else {
+                // DoH: keep 443 or URL port
+                client.EndpointConfiguration.Port = (ep.DohUrl?.IsDefaultPort ?? true) ? 443 : ep.DohUrl!.Port;
+            }
+            client.EndpointConfiguration.UseTcpFallback = ep.AllowTcpFallback;
+            if (ep.EdnsBufferSize.HasValue) client.EndpointConfiguration.UdpBufferSize = ep.EdnsBufferSize.Value;
+            if (ep.DnsSecOk.HasValue) client.EndpointConfiguration.CheckingDisabled = !ep.DnsSecOk.Value;
+            if (ep.Timeout.HasValue) client.EndpointConfiguration.TimeOut = (int)Math.Max(1, ep.Timeout.Value.TotalMilliseconds);
+
+            // Configure caching bounds when enabled
+            if (_options.EnableResponseCache) {
+                if (_options.CacheExpiration.HasValue) client.CacheExpiration = _options.CacheExpiration.Value;
+                if (_options.MinCacheTtl.HasValue) client.MinCacheTtl = _options.MinCacheTtl.Value;
+                if (_options.MaxCacheTtl.HasValue) client.MaxCacheTtl = _options.MaxCacheTtl.Value;
+            }
+
+            // A single query; retries disabled, we rely on strategy behavior
+            return await client.Resolve(name, type, requestDnsSec: ep.DnsSecOk ?? false, validateDnsSec: false, returnAllTypes: false, retryOnTransient: false, cancellationToken: ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/DnsClientX/MultiResolver/IDnsMultiResolver.cs
+++ b/DnsClientX/MultiResolver/IDnsMultiResolver.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Provides a resolver interface that can query multiple endpoints based on a selection strategy.
+    /// </summary>
+    public interface IDnsMultiResolver {
+        /// <summary>
+        /// Queries a single name for the specified record type.
+        /// </summary>
+        Task<DnsResponse> QueryAsync(string name, DnsRecordType type, CancellationToken ct = default);
+
+        /// <summary>
+        /// Queries multiple names of the same record type, preserving input order.
+        /// </summary>
+        Task<DnsResponse[]> QueryBatchAsync(string[] names, DnsRecordType type, CancellationToken ct = default);
+    }
+}

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -79,12 +79,14 @@ Build-Module -ModuleName 'DnsClientX' {
         NETFramework                      = 'net472', 'net8.0'
         DotSourceLibraries                = $true
         NETSearchClass                    = 'DnsClientX.PowerShell.CmdletResolveDnsQuery'
+        NETBinaryModuleDocumentation      = $true
+        RefreshPSD1Only                   = $true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat
 
     # Copy formatting file to module output
-   # New-ConfigurationModule -Type RequiredFile -Path "$PSScriptRoot\..\..\DnsClientX.PowerShell\DnsClientX.Format.ps1xml" -Destination 'DnsClientX.Format.ps1xml'
+    # New-ConfigurationModule -Type RequiredFile -Path "$PSScriptRoot\..\..\DnsClientX.PowerShell\DnsClientX.Format.ps1xml" -Destination 'DnsClientX.Format.ps1xml'
 
     New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" -RequiredModulesPath "$PSScriptRoot\..\Artefacts\Unpacked\Modules"
     New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName -ArtefactName "DnsClientX-PowerShellModule.<TagModuleVersionWithPreRelease>.zip" -ID 'ToGitHub'


### PR DESCRIPTION
- Introduced `DnsMultiResolver` to support querying multiple DNS endpoints using strategies: FirstSuccess, FastestWins, SequentialAll, and RoundRobin.
- Implemented `MultiResolverOptions` to configure behavior such as max parallelism, endpoint timeouts, and response caching.
- Added `IDnsMultiResolver` interface for multi-resolver operations.
- Enhanced `DnsResponse` to include TTL metrics and transport information.
- Created `DnsResolverEndpoint` to encapsulate endpoint details and behaviors.
- Added `EndpointParser` for parsing user-provided resolver endpoint strings.
- Updated README with usage examples and detailed explanations of new features.
- Added tests for max concurrency hints in array-based resolution helpers.