### PR TITLE
Align DNSSEC validation behavior and docs

### DIFF
--- a/DnsClientX.Tests/CdBitTests.cs
+++ b/DnsClientX.Tests/CdBitTests.cs
@@ -132,7 +132,7 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// When DNSSEC validation is requested, the CD bit must also be set.
+        /// When DNSSEC validation is requested, the query should request DNSSEC data and set the CD bit.
         /// </summary>
         [Fact]
         public async Task UdpRequest_ShouldIncludeCdBit_WhenValidateDnsSecTrue() {
@@ -148,7 +148,7 @@ namespace DnsClientX.Tests {
 
             byte[] query = await udpTask;
 
-            AssertCdBit(query, "example.com", 0x10u);
+            AssertCdBit(query, "example.com", 0x00008010u);
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace DnsClientX.Tests {
 
             byte[] query = await udpTask;
 
-            AssertCdBit(query, "example.com", 0x10u);
+            AssertCdBit(query, "example.com", 0x00008010u);
             Assert.True(client.EndpointConfiguration.CheckingDisabled);
         }
 

--- a/DnsClientX.Tests/EdnsDoBitTests.cs
+++ b/DnsClientX.Tests/EdnsDoBitTests.cs
@@ -62,6 +62,14 @@ namespace DnsClientX.Tests {
         }
 
         private static void AssertDoBit(byte[] query, string name) {
+            AssertTtlFlags(query, name, 0x00008000u);
+        }
+
+        private static void AssertDoAndCdBits(byte[] query, string name) {
+            AssertTtlFlags(query, name, 0x00008010u);
+        }
+
+        private static void AssertTtlFlags(byte[] query, string name, uint expectedTtl) {
             int additionalCount = (query[10] << 8) | query[11];
             Assert.Equal(1, additionalCount);
 
@@ -77,7 +85,7 @@ namespace DnsClientX.Tests {
             ushort type = (ushort)((query[offset + 1] << 8) | query[offset + 2]);
             Assert.Equal((ushort)DnsRecordType.OPT, type);
             uint ttl = (uint)((query[offset + 5] << 24) | (query[offset + 6] << 16) | (query[offset + 7] << 8) | query[offset + 8]);
-            Assert.Equal(0x00008000u, ttl);
+            Assert.Equal(expectedTtl, ttl);
         }
 
         private static void AssertNoDoBit(byte[] query, string name) {
@@ -169,6 +177,26 @@ namespace DnsClientX.Tests {
             byte[] query = await tcpTask;
 
             AssertDoBit(query, "example.com");
+        }
+
+        /// <summary>
+        /// Ensures the core client path requests DNSSEC data when validation is enabled.
+        /// </summary>
+        [Fact]
+        public async Task UdpRequest_ShouldIncludeDoBit_WhenValidateDnsSecTrue() {
+            int port = GetFreeUdpPort();
+            var response = CreateDnsHeader();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var udpTask = RunUdpServerAsync(port, response, cts.Token);
+
+            using var client = new ClientX("127.0.0.1", DnsRequestFormat.DnsOverUDP, useTcpFallback: false);
+            client.EndpointConfiguration.Port = port;
+
+            await client.Resolve("example.com", DnsRecordType.A, requestDnsSec: false, validateDnsSec: true, retryOnTransient: false, cancellationToken: cts.Token);
+
+            byte[] query = await udpTask;
+
+            AssertDoAndCdBits(query, "example.com");
         }
 
         /// <summary>

--- a/DnsClientX/DnsClientX.Resolve.cs
+++ b/DnsClientX/DnsClientX.Resolve.cs
@@ -80,6 +80,7 @@ namespace DnsClientX {
             cancellationToken.ThrowIfCancellationRequested();
 
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "Name is null or empty.");
+            requestDnsSec = requestDnsSec || validateDnsSec;
 
             var auditEntry = EnableAudit ? new AuditEntry(name, type) { StartedAtUtc = DateTimeOffset.UtcNow } : null;
             var stopwatch = Stopwatch.StartNew();

--- a/README.md
+++ b/README.md
@@ -812,7 +812,10 @@ using var client = new ClientX(DnsEndpoint.Cloudflare);
 var response = await client.Resolve("google.com", DnsRecordType.A,
     requestDnsSec: true,
     validateDnsSec: true);
-Console.WriteLine($"DNSSEC Valid: {response.IsSecure}");
+Console.WriteLine($"Authentic Data (AD): {response.AuthenticData}");
+Console.WriteLine(string.IsNullOrEmpty(response.Error)
+    ? "DNSSEC validation passed."
+    : $"DNSSEC validation failed: {response.Error}");
 ```
 
 #### Pattern-Based Queries
@@ -857,7 +860,10 @@ var domains = new[] { "google.com", "github.com", "microsoft.com" };
 var recordTypes = new[] { DnsRecordType.A, DnsRecordType.AAAA };
 
 await foreach (var response in client.ResolveStream(domains, recordTypes)) {
-    Console.WriteLine($"Resolved: {response.Question.Name} ({response.Question.Type})");
+    var question = response.Questions.Length > 0 ? response.Questions[0] : null;
+    Console.WriteLine(question is null
+        ? "Resolved response"
+        : $"Resolved: {question.Name} ({question.Type})");
     response.DisplayTable();
 }
 ```
@@ -1011,8 +1017,8 @@ try {
     using var client = new ClientX(DnsEndpoint.Cloudflare);
     var response = await client.Resolve("nonexistent.domain", DnsRecordType.A);
 
-    if (response.HasError) {
-        Console.WriteLine($"DNS Error: {response.ErrorMessage}");
+    if (!string.IsNullOrEmpty(response.Error)) {
+        Console.WriteLine($"DNS Error: {response.Error}");
     } else if (!response.Answers.Any()) {
         Console.WriteLine("No records found");
     } else {
@@ -1154,13 +1160,14 @@ $Response = Resolve-Dns -Name 'google.com' -Type A -DnsProvider Cloudflare -Full
 $Response.Questions | Format-Table
 $Response.Answers | Format-Table
 $Response.AnswersMinimal | Format-Table
-$Response.Authority | Format-Table
+$Response.Authorities | Format-Table
 $Response.Additional | Format-Table
 
 # Check response metadata
-Write-Host "Response Time: $($Response.ResponseTime)ms"
-Write-Host "Server: $($Response.Server)"
-Write-Host "DNSSEC: $($Response.IsSecure)"
+Write-Host "Response Time: $([math]::Round($Response.RoundTripTime.TotalMilliseconds, 2))ms"
+Write-Host "Server: $($Response.ServerAddress)"
+Write-Host "Authentic Data (AD): $($Response.AuthenticData)"
+Write-Host "DNSSEC Error: $(if([string]::IsNullOrEmpty($Response.Error)) { 'None' } else { $Response.Error })"
 ```
 
 #### Timeout and Retry Configuration
@@ -1279,8 +1286,8 @@ Invoke-DnsUpdate -Zone 'example.com' -Server '127.0.0.1' -Name 'www' -Type A -Da
 $Servers = @('1.1.1.1', '8.8.8.8', '9.9.9.9')
 foreach ($Server in $Servers) {
     try {
-        $Result = Resolve-Dns -Name 'google.com' -Type A -Server $Server -TimeOut 2000
-        Write-Host "✓ $Server responded in $($Result.ResponseTime)ms" -ForegroundColor Green
+        $Result = Resolve-Dns -Name 'google.com' -Type A -Server $Server -TimeOut 2000 -FullResponse
+        Write-Host "✓ $Server responded in $([math]::Round($Result.RoundTripTime.TotalMilliseconds, 2))ms" -ForegroundColor Green
     } catch {
         Write-Host "✗ $Server failed: $($_.Exception.Message)" -ForegroundColor Red
     }
@@ -1343,7 +1350,11 @@ Write-Host "=== DNS Security Assessment for $Domain ===" -ForegroundColor Cyan
 
 # DNSSEC validation
 $DnssecResult = Resolve-Dns -Name $Domain -Type A -DnsProvider Cloudflare -RequestDnsSec -ValidateDnsSec
-Write-Host "DNSSEC Status: $(if($DnssecResult.IsSecure) { 'SECURE' } else { 'NOT SECURE' })" -ForegroundColor $(if($DnssecResult.IsSecure) { 'Green' } else { 'Red' })
+Write-Host "Authentic Data (AD): $($DnssecResult.AuthenticData)" -ForegroundColor $(if($DnssecResult.AuthenticData) { 'Green' } else { 'Yellow' })
+Write-Host "DNSSEC Validation: $(if([string]::IsNullOrEmpty($DnssecResult.Error)) { 'PASSED' } else { 'FAILED' })" -ForegroundColor $(if([string]::IsNullOrEmpty($DnssecResult.Error)) { 'Green' } else { 'Red' })
+if (-not [string]::IsNullOrEmpty($DnssecResult.Error)) {
+    Write-Host "Validation details: $($DnssecResult.Error)" -ForegroundColor Red
+}
 
 # CAA Records
 Write-Host "`nCAA Records:" -ForegroundColor Yellow

--- a/Website/README.md
+++ b/Website/README.md
@@ -1,0 +1,6 @@
+# DnsClientX website content
+
+This folder contains the curated PowerForge website material for DnsClientX.
+
+The public examples are deliberately small and use public test domains such as `example.com`. Raw example sources include transport experiments and maintainer-specific DNS targets, so the website should only publish examples that are safe, repeatable, and easy to understand.
+

--- a/Website/content/examples/_index.md
+++ b/Website/content/examples/_index.md
@@ -1,0 +1,13 @@
+---
+title: "DnsClientX Examples"
+description: "Curated public examples for DnsClientX."
+layout: docs
+---
+
+These examples cover the first useful checks: resolving a record from PowerShell and reading strongly typed records from .NET.
+
+## Examples
+
+- [Resolve DNS from PowerShell](./resolve-dns-powershell/)
+- [Use typed records in .NET](./typed-records-dotnet/)
+

--- a/Website/content/examples/resolve-dns-powershell.md
+++ b/Website/content/examples/resolve-dns-powershell.md
@@ -1,0 +1,32 @@
+---
+title: "Resolve DNS from PowerShell"
+description: "Resolve DNS records through selected providers and transports."
+layout: docs
+---
+
+This pattern is useful when you need a quick, repeatable resolver check.
+
+It is adapted from `DnsClientX.PowerShell/CmdletResolveDnsQuery.cs`.
+
+## Example
+
+```powershell
+Import-Module DnsClientX
+
+Resolve-Dns -Name 'example.com' -Type A -DnsProvider Cloudflare
+
+Resolve-Dns -Name 'example.com' -Type MX -DnsProvider Cloudflare, Google -ResolverStrategy FirstSuccess
+
+Resolve-Dns -Name 'example.com' -Type TXT -ResolverEndpoint '1.1.1.1:53', 'https://dns.google/dns-query' -ResolverStrategy FirstSuccess
+```
+
+## What this demonstrates
+
+- selecting a DNS provider explicitly
+- querying multiple providers with a resolver strategy
+- mixing endpoint styles without hardcoding internal resolver addresses
+
+## Source
+
+- [CmdletResolveDnsQuery.cs](https://github.com/EvotecIT/DnsClientX/blob/master/DnsClientX.PowerShell/CmdletResolveDnsQuery.cs)
+

--- a/Website/content/examples/typed-records-dotnet.md
+++ b/Website/content/examples/typed-records-dotnet.md
@@ -1,0 +1,34 @@
+---
+title: "Use typed records in .NET"
+description: "Read DNS query results as typed .NET record objects."
+layout: docs
+---
+
+This pattern is useful when application code needs structured DNS data instead of raw strings.
+
+It is adapted from `DnsClientX.Examples/DemoTypedRecords.cs`.
+
+## Example
+
+```csharp
+using DnsClientX;
+
+using var client = new ClientX(DnsEndpoint.Cloudflare);
+var response = await client.Resolve("example.com", DnsRecordType.A, typedRecords: true);
+
+foreach (var record in response.TypedAnswers ?? [])
+{
+    Console.WriteLine(record);
+}
+```
+
+## What this demonstrates
+
+- using the .NET client directly
+- enabling typed records for safer downstream processing
+- keeping the example independent of private zones
+
+## Source
+
+- [DemoTypedRecords.cs](https://github.com/EvotecIT/DnsClientX/blob/master/DnsClientX.Examples/DemoTypedRecords.cs)
+

--- a/Website/content/project-docs/docs/_index.md
+++ b/Website/content/project-docs/docs/_index.md
@@ -1,0 +1,19 @@
+---
+title: "DnsClientX Docs"
+description: "Curated documentation workspace for DnsClientX."
+layout: docs
+---
+
+DnsClientX is a DNS client for .NET and PowerShell. It supports classic DNS transports plus modern options such as DNS over HTTPS, DNS over TLS, DNS over HTTP/3, and DNS over QUIC.
+
+## Start here
+
+- [Project overview](./overview/)
+- [Install](./install/)
+- [Back to project overview](/projects/dnsclientx/)
+
+## Notes
+
+- Use public test domains for examples unless you are documenting a specific internal resolver workflow.
+- Curated examples stay under `/projects/dnsclientx/examples/`.
+

--- a/Website/content/project-docs/docs/install.md
+++ b/Website/content/project-docs/docs/install.md
@@ -1,0 +1,21 @@
+---
+title: "Install DnsClientX"
+description: "Install DnsClientX for PowerShell or .NET."
+layout: docs
+---
+
+Install the PowerShell module:
+
+```powershell
+Install-Module -Name DnsClientX -Scope CurrentUser
+Import-Module DnsClientX
+```
+
+Use the .NET library from NuGet:
+
+```powershell
+dotnet add package DnsClientX
+```
+
+The PowerShell module is the quickest way to test resolver behavior interactively. The .NET package is the better fit when DNS queries are part of an application or service.
+

--- a/Website/content/project-docs/docs/overview.md
+++ b/Website/content/project-docs/docs/overview.md
@@ -1,0 +1,19 @@
+---
+title: "DnsClientX Overview"
+description: "How DnsClientX fits DNS lookup and resolver testing workflows."
+layout: docs
+---
+
+DnsClientX is useful when you need DNS lookups that are explicit about provider, transport, caching, and result shape.
+
+## Common fit
+
+- compare results from different public DNS providers
+- test DNS over HTTPS, TLS, HTTP/3, or QUIC support
+- return typed DNS records in .NET code
+- run multi-record lookups from PowerShell without shelling out to platform-specific tools
+
+## Good operating pattern
+
+Start with `example.com` or another safe public test domain. Move to internal zones only after you know which resolver and transport settings you want to validate.
+


### PR DESCRIPTION
## Summary
- align the core `ClientX.Resolve(...)` path so `validateDnsSec` implies `requestDnsSec`
- add focused wire-level tests to verify validation requests send the expected DO+CD flags
- fix README examples that referenced stale `DnsResponse` members and document current DNSSEC result handling

## Why
The README had drifted from the current public API, and the core resolve path did not match the wrapper/request flows for DNSSEC validation behavior.

## Validation
- `dotnet test DnsClientX.Tests\\DnsClientX.Tests.csproj --filter "FullyQualifiedName~EdnsDoBitTests|FullyQualifiedName~CdBitTests"`

Closes #499
