### PR TITLE
Update NuGet dependencies

### DIFF
--- a/DnsClientX.Examples/DnsClientX.Examples.csproj
+++ b/DnsClientX.Examples/DnsClientX.Examples.csproj
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-        <PackageReference Include="Spectre.Console" Version="0.55.0" />
+        <PackageReference Include="Spectre.Console" Version="0.55.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DnsClientX.Tests/DnsClientX.Tests.csproj
+++ b/DnsClientX.Tests/DnsClientX.Tests.csproj
@@ -27,9 +27,9 @@
     <ItemGroup>
         <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net472'" />
         <PackageReference Include="SemanticComparison" Version="4.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -37,9 +37,9 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="10.0.5"
+        <PackageReference Include="System.Text.Json" Version="10.0.7"
             Condition="'$(TargetFramework)' == 'net472'" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5"
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7"
             Condition="'$(TargetFramework)' == 'net472'" />
     </ItemGroup>
 

--- a/DnsClientX/DnsClientX.csproj
+++ b/DnsClientX/DnsClientX.csproj
@@ -55,15 +55,15 @@
     </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-        <PackageReference Include="System.Text.Json" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+        <PackageReference Include="System.Text.Json" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
   </ItemGroup>
 
 
     <ItemGroup Condition="'$(TargetFramework)'=='net472' OR '$(TargetFramework)'=='net48'">
         <Reference Include="System.Net.Http" />
-        <PackageReference Include="System.Text.Json" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+        <PackageReference Include="System.Text.Json" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Update NuGet dependencies covered by the open Dependabot PRs.
- Move System.Text.Json and Microsoft.Bcl.AsyncInterfaces together to 10.0.7 to avoid NU1605 downgrade failures.
- Update Microsoft.NET.Test.Sdk to 18.5.0, coverlet.collector to 10.0.0, and Spectre.Console to 0.55.2.

## Root Cause
The individual Dependabot PRs split System.Text.Json and Microsoft.Bcl.AsyncInterfaces into separate updates. System.Text.Json 10.0.6+ requires Microsoft.Bcl.AsyncInterfaces >= 10.0.6, so restoring the single-package PRs could fail with NU1605 package downgrade warnings-as-errors.

## Validation
- dotnet restore DnsClientX.sln
- dotnet build DnsClientX.sln --configuration Release --no-restore
- dotnet build DnsClientX.sln --configuration Debug --no-restore

Note: local full test runs for net472/net10.0 stalled after initial skipped DNS tests in this workstation environment, so I stopped those processes and left the PR matrix to run the authoritative CI tests.