### PR TITLE
Prepare release hygiene and resolver workflows

### DIFF
--- a/DnsClientX.Cli/DnsClientX.Cli.csproj
+++ b/DnsClientX.Cli/DnsClientX.Cli.csproj
@@ -5,9 +5,9 @@
     <AssemblyTitle>DnsClientX CLI</AssemblyTitle>
     <Title>DnsClientX Command Line Interface</Title>
     <Description>Command-line interface for DnsClientX DNS library. Provides quick DNS queries, resolver benchmarking, and scripting capabilities including modern DoH3 and DoQ flows on .NET 8+.</Description>
-    <VersionPrefix>1.0.7</VersionPrefix>
-    <AssemblyVersion>1.0.7</AssemblyVersion>
-    <FileVersion>1.0.7</FileVersion>
+    <VersionPrefix>1.0.8</VersionPrefix>
+    <AssemblyVersion>1.0.8</AssemblyVersion>
+    <FileVersion>1.0.8</FileVersion>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>
     <Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>

--- a/DnsClientX.Cli/Program.cs
+++ b/DnsClientX.Cli/Program.cs
@@ -64,6 +64,8 @@ namespace DnsClientX.Cli {
             public bool Explain { get; set; }
             public bool Trace { get; set; }
             public bool ShowCapabilities { get; set; }
+            public string? StampInfo { get; set; }
+            public bool ResolverValidate { get; set; }
             public bool DoUpdate { get; set; }
             public string? Zone { get; set; }
             public string? UpdateName { get; set; }
@@ -122,6 +124,14 @@ namespace DnsClientX.Cli {
 
                 if (parsedOptions.ShowCapabilities) {
                     return WriteCapabilities(parsedOptions);
+                }
+
+                if (!string.IsNullOrWhiteSpace(parsedOptions.StampInfo)) {
+                    return WriteStampInfo(parsedOptions);
+                }
+
+                if (parsedOptions.ResolverValidate) {
+                    return await RunResolverValidationAsync(parsedOptions, cts.Token).ConfigureAwait(false);
                 }
 
                 if (parsedOptions.Probe) {
@@ -365,6 +375,9 @@ namespace DnsClientX.Cli {
                         }
                         AddOptionValues(options.ProbeEndpointUrls, resolverUrl);
                         break;
+                    case var opt when opt.Equals("--resolver-validate", StringComparison.OrdinalIgnoreCase):
+                        options.ResolverValidate = true;
+                        break;
                     case var opt when opt.Equals("--probe-summary-only", StringComparison.OrdinalIgnoreCase):
                         options.Probe = true;
                         options.ProbeSummaryOnly = true;
@@ -463,6 +476,14 @@ namespace DnsClientX.Cli {
                     case var opt when opt.Equals("--capabilities", StringComparison.OrdinalIgnoreCase):
                         options.ShowCapabilities = true;
                         break;
+                    case var opt when opt.Equals("--stamp-info", StringComparison.OrdinalIgnoreCase):
+                        if (!TryReadNext(args, ref i, "--stamp-info", out string? stampInfo, out errorMessage)) {
+                            invalidSwitches = null;
+                            options = null;
+                            return false;
+                        }
+                        options.StampInfo = stampInfo;
+                        break;
                     case var opt when opt.Equals("--update", StringComparison.OrdinalIgnoreCase):
                         if (!TryReadNext(args, ref i, "--update", out string? zone, out errorMessage) ||
                             !TryReadNext(args, ref i, "--update", out string? updateName, out errorMessage) ||
@@ -516,14 +537,34 @@ namespace DnsClientX.Cli {
                 return false;
             }
 
-            if (options.HasCustomEndpointInputs && !options.Benchmark) {
+            if (options.HasCustomEndpointInputs && !options.Benchmark && !options.ResolverValidate) {
                 options.Probe = true;
             }
 
             if (options.ShowCapabilities &&
                 (options.Probe || options.Benchmark || options.DoUpdate || options.ZoneTransfer ||
+                 !string.IsNullOrWhiteSpace(options.ResolverSelectPath) || !string.IsNullOrWhiteSpace(options.ResolverUsePath) ||
+                 !string.IsNullOrWhiteSpace(options.StampInfo) || options.ResolverValidate)) {
+                errorMessage = "--capabilities cannot be combined with query, probe, benchmark, update, axfr, resolver selection, or stamp modes.";
+                invalidSwitches = null;
+                options = null;
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.StampInfo) &&
+                (options.Probe || options.Benchmark || options.DoUpdate || options.ZoneTransfer ||
+                 !string.IsNullOrWhiteSpace(options.ResolverSelectPath) || !string.IsNullOrWhiteSpace(options.ResolverUsePath) ||
+                 options.ResolverValidate)) {
+                errorMessage = "--stamp-info cannot be combined with query, probe, benchmark, update, axfr, or resolver selection modes.";
+                invalidSwitches = null;
+                options = null;
+                return false;
+            }
+
+            if (options.ResolverValidate &&
+                (options.Probe || options.Benchmark || options.DoUpdate || options.ZoneTransfer ||
                  !string.IsNullOrWhiteSpace(options.ResolverSelectPath) || !string.IsNullOrWhiteSpace(options.ResolverUsePath))) {
-                errorMessage = "--capabilities cannot be combined with query, probe, benchmark, update, axfr, or resolver selection modes.";
+                errorMessage = "--resolver-validate cannot be combined with query, probe, benchmark, update, axfr, or resolver selection modes.";
                 invalidSwitches = null;
                 options = null;
                 return false;
@@ -615,6 +656,26 @@ namespace DnsClientX.Cli {
                 return false;
             }
 
+            if (!string.IsNullOrWhiteSpace(options.StampInfo) &&
+                (options.ShortOutput || options.TxtConcatOutput || options.HasExplicitSectionSelection || options.TransferSummary || options.OutputFormat == QueryOutputFormat.Raw ||
+                 options.ReverseLookup || options.RecordTypeSpecified || options.RequestDnsSec || options.ValidateDnsSec || options.WirePost ||
+                 !string.IsNullOrWhiteSpace(options.Domain))) {
+                errorMessage = "Stamp mode supports only --stamp-info and optional --format json.";
+                invalidSwitches = null;
+                options = null;
+                return false;
+            }
+
+            if (options.ResolverValidate &&
+                (options.ShortOutput || options.TxtConcatOutput || options.HasExplicitSectionSelection || options.TransferSummary || options.OutputFormat == QueryOutputFormat.Raw ||
+                 options.ReverseLookup || options.RecordTypeSpecified || options.RequestDnsSec || options.ValidateDnsSec || options.WirePost ||
+                 !string.IsNullOrWhiteSpace(options.Domain) || !options.HasCustomEndpointInputs)) {
+                errorMessage = "Resolver validation mode requires --resolver-validate with --probe-endpoint, --resolver-file, or --resolver-url, and supports optional --format json.";
+                invalidSwitches = null;
+                options = null;
+                return false;
+            }
+
             if ((options.Benchmark || options.Probe || options.DoUpdate) &&
                 (options.ShortOutput || options.TxtConcatOutput || options.OutputFormat != QueryOutputFormat.Pretty || options.HasExplicitSectionSelection || options.TransferSummary)) {
                 errorMessage = "Query output switches (--format, --short, --txt-concat, --question, --answer, --authority, --additional) apply only to standard query mode.";
@@ -678,6 +739,10 @@ namespace DnsClientX.Cli {
                 }
             } else if (options.ShowCapabilities) {
                 // Capability mode does not require a domain.
+            } else if (!string.IsNullOrWhiteSpace(options.StampInfo)) {
+                // Stamp mode requires only the stamp input.
+            } else if (options.ResolverValidate) {
+                // Resolver validation mode requires only resolver inputs.
             } else if (!string.IsNullOrWhiteSpace(options.ResolverSelectPath)) {
                 // Selection mode requires only the saved snapshot path.
             } else if (options.ZoneTransfer && string.IsNullOrWhiteSpace(options.Domain)) {
@@ -980,6 +1045,67 @@ namespace DnsClientX.Cli {
             }
 
             return 0;
+        }
+
+        private static int WriteStampInfo(CliOptions options) {
+            DnsStampInfo info = DnsStamp.Describe(options.StampInfo!);
+            if (options.OutputFormat == QueryOutputFormat.Json) {
+                Console.WriteLine(DnsClientXJsonSerializer.Serialize(info));
+                return 0;
+            }
+
+            Console.WriteLine("DNS Stamp:");
+            Console.WriteLine($"  Transport: {info.Transport}");
+            Console.WriteLine($"  Request format: {info.RequestFormat}");
+            Console.WriteLine($"  Host: {info.Host}");
+            Console.WriteLine($"  Port: {info.Port}");
+            if (info.DohUrl != null) {
+                Console.WriteLine($"  DoH URL: {info.DohUrl}");
+            }
+            Console.WriteLine($"  DNSSEC property: {(info.DnsSecOk ? "yes" : "no")}");
+            Console.WriteLine($"  Endpoint: {info.Endpoint}");
+            Console.WriteLine($"  Normalized stamp: {info.NormalizedStamp}");
+            return 0;
+        }
+
+        private static async Task<int> RunResolverValidationAsync(CliOptions options, CancellationToken cancellationToken) {
+            ResolverEndpointValidationResult[] results = await EndpointParser.ValidateManyAsync(
+                options.ProbeEndpoints,
+                options.ProbeEndpointFiles,
+                options.ProbeEndpointUrls,
+                cancellationToken).ConfigureAwait(false);
+
+            if (options.OutputFormat == QueryOutputFormat.Json) {
+                Console.WriteLine(DnsClientXJsonSerializer.Serialize(results));
+            } else {
+                WriteResolverValidationResults(results);
+            }
+
+            return results.Any(result => !result.IsValid) ? 1 : 0;
+        }
+
+        private static void WriteResolverValidationResults(ResolverEndpointValidationResult[] results) {
+            int valid = results.Count(result => result.IsValid);
+            int invalid = results.Length - valid;
+
+            Console.WriteLine("Resolver Validation:");
+            Console.WriteLine($"  Entries: {results.Length}");
+            Console.WriteLine($"  Valid: {valid}");
+            Console.WriteLine($"  Invalid: {invalid}");
+
+            foreach (ResolverEndpointValidationResult result in results) {
+                string location = string.IsNullOrWhiteSpace(result.Source)
+                    ? "unknown"
+                    : result.LineNumber.HasValue
+                        ? $"{result.Source}:{result.LineNumber.Value}"
+                        : result.Source;
+
+                if (result.IsValid) {
+                    Console.WriteLine($"  valid   {location}  {result.Entry} -> {result.Endpoint}");
+                } else {
+                    Console.WriteLine($"  invalid {location}  {result.Entry} ({result.Error})");
+                }
+            }
         }
 
         private static async Task<int> RunBenchmarkAsync(CliOptions options, CancellationToken cancellationToken) {
@@ -1547,6 +1673,7 @@ namespace DnsClientX.Cli {
             Console.WriteLine("      --probe-endpoint <endpoint>  Probe a custom endpoint such as tcp@1.1.1.1:53, doq@dns.quad9.net:853, or doh3@https://dns.quad9.net/dns-query");
             Console.WriteLine("      --resolver-file <path>  Load custom endpoints from a text file for probe or benchmark");
             Console.WriteLine("      --resolver-url <url>  Load custom endpoints from an HTTP or HTTPS URL for probe or benchmark");
+            Console.WriteLine("      --resolver-validate  Validate resolver endpoint inputs without querying DNS");
             Console.WriteLine("      --probe-summary-only  Suppress per-endpoint probe lines and print only the header and summary");
             Console.WriteLine("      --probe-summary-line  Append one stable PROBE_SUMMARY key=value line for automation");
             Console.WriteLine("      --probe-save <path>  Persist probe scoring and health data as JSON");
@@ -1557,6 +1684,7 @@ namespace DnsClientX.Cli {
             Console.WriteLine("      --probe-min-success <count>  Fail when fewer than the given number of probes succeed");
             Console.WriteLine("      --probe-min-success-percent <percent>  Fail when the probe success rate is below the given 1-100 percentage");
             Console.WriteLine("      --capabilities       Print the shared transport capability report");
+            Console.WriteLine("      --stamp-info <stamp> Print parsed DNS stamp details without querying DNS");
             Console.WriteLine("      --explain            Print resolver and response diagnostics");
             Console.WriteLine("      --trace              Print explain output plus audit details");
             Console.WriteLine("      --update <zone> <name> <type> <data>  Send dynamic update");

--- a/DnsClientX.PowerShell/CmdletConvertFromDnsStamp.cs
+++ b/DnsClientX.PowerShell/CmdletConvertFromDnsStamp.cs
@@ -1,0 +1,30 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using DnsClientX;
+
+namespace DnsClientX.PowerShell {
+    /// <summary>
+    /// <para type="synopsis">Parses a DNS stamp into a resolver endpoint description.</para>
+    /// <para type="description">Converts a supported sdns:// DNS stamp into the same endpoint model used by DnsClientX resolver workflows. This command does not perform a DNS query.</para>
+    /// <example>
+    ///   <para>Parse a DNS-over-HTTPS stamp</para>
+    ///   <code>ConvertFrom-DnsStamp -Stamp 'sdns://AgUAAAAAAAAABzEuMS4xLjEAGm1vemlsbGEuY2xvdWRmbGFyZS1kbnMuY29tCi9kbnMtcXVlcnk'</code>
+    /// </example>
+    /// </summary>
+    [Cmdlet(VerbsData.ConvertFrom, "DnsStamp")]
+    [OutputType(typeof(DnsStampInfo))]
+    public sealed class CmdletConvertFromDnsStamp : AsyncPSCmdlet {
+        /// <summary>
+        /// DNS stamp to parse.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        [ValidateNotNullOrEmpty]
+        public string Stamp { get; set; } = string.Empty;
+
+        /// <inheritdoc />
+        protected override Task ProcessRecordAsync() {
+            WriteObject(DnsStamp.Describe(Stamp));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DnsClientX.PowerShell/CmdletTestDnsResolverCatalog.cs
+++ b/DnsClientX.PowerShell/CmdletTestDnsResolverCatalog.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Management.Automation;
+using System.Threading.Tasks;
+using DnsClientX;
+
+namespace DnsClientX.PowerShell {
+    /// <summary>
+    /// <para type="synopsis">Validates resolver endpoint catalog inputs without querying DNS.</para>
+    /// <para type="description">Checks inline resolver endpoints, resolver endpoint files, and resolver endpoint URLs using the same parser used by probe and benchmark workflows.</para>
+    /// <example>
+    ///   <para>Validate inline resolver endpoint syntax</para>
+    ///   <code>Test-DnsResolverCatalog -ResolverEndpoint udp@1.1.1.1:53,doh@https://dns.google/dns-query</code>
+    /// </example>
+    /// <example>
+    ///   <para>Validate resolver endpoints from a file</para>
+    ///   <code>Test-DnsResolverCatalog -ResolverEndpointFile .\resolvers.txt</code>
+    /// </example>
+    /// </summary>
+    [Cmdlet(VerbsDiagnostic.Test, "DnsResolverCatalog")]
+    [OutputType(typeof(ResolverEndpointValidationResult))]
+    public sealed class CmdletTestDnsResolverCatalog : AsyncPSCmdlet {
+        /// <summary>
+        /// Inline resolver endpoint entries.
+        /// </summary>
+        [Parameter(Mandatory = false, ValueFromPipeline = true)]
+        public string[] ResolverEndpoint { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// Files containing resolver endpoint entries.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public string[] ResolverEndpointFile { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// HTTP or HTTPS URLs containing resolver endpoint entries.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public string[] ResolverEndpointUrl { get; set; } = Array.Empty<string>();
+
+        /// <inheritdoc />
+        protected override async Task ProcessRecordAsync() {
+            if ((ResolverEndpoint?.Length ?? 0) == 0 &&
+                (ResolverEndpointFile?.Length ?? 0) == 0 &&
+                (ResolverEndpointUrl?.Length ?? 0) == 0) {
+                throw new PSArgumentException(
+                    "At least one resolver endpoint, resolver endpoint file, or resolver endpoint URL must be specified.",
+                    nameof(ResolverEndpoint));
+            }
+
+            ResolverEndpointValidationResult[] results = await EndpointParser.ValidateManyAsync(
+                ResolverEndpoint,
+                ResolverEndpointFile,
+                ResolverEndpointUrl,
+                CancelToken).ConfigureAwait(false);
+
+            WriteObject(results, true);
+        }
+    }
+}

--- a/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
+++ b/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
@@ -13,9 +13,9 @@
             including modern DoH3 and DoQ flows on .NET 8+.</Description>
         <AssemblyName>DnsClientX.PowerShell</AssemblyName>
         <AssemblyTitle>DnsClientX PowerShell Module</AssemblyTitle>
-        <VersionPrefix>1.0.7</VersionPrefix>
-        <AssemblyVersion>1.0.7</AssemblyVersion>
-        <FileVersion>1.0.7</FileVersion>
+        <VersionPrefix>1.0.8</VersionPrefix>
+        <AssemblyVersion>1.0.8</AssemblyVersion>
+        <FileVersion>1.0.8</FileVersion>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>

--- a/DnsClientX.Tests/CliStampInfoTests.cs
+++ b/DnsClientX.Tests/CliStampInfoTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests CLI DNS stamp inspection mode.
+    /// </summary>
+    [Collection("NoParallel")]
+    public class CliStampInfoTests {
+        private const string CloudflareStamp = "sdns://AgUAAAAAAAAABzEuMS4xLjEAGm1vemlsbGEuY2xvdWRmbGFyZS1kbnMuY29tCi9kbnMtcXVlcnk";
+
+        private static async Task<int> InvokeCliAsync(params string[] args) {
+            var assembly = Assembly.Load("DnsClientX.Cli");
+            Type programType = assembly.GetType("DnsClientX.Cli.Program")!;
+            MethodInfo main = programType.GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
+            Task<int> task = (Task<int>)main.Invoke(null, new object[] { args })!;
+            return await task;
+        }
+
+        /// <summary>
+        /// Ensures stamp mode prints a readable no-network description.
+        /// </summary>
+        [Fact]
+        public async Task StampInfo_PrintsTextDescription() {
+            using var output = new StringWriter();
+            TextWriter originalOut = Console.Out;
+            try {
+                Console.SetOut(output);
+
+                int exitCode = await InvokeCliAsync("--stamp-info", CloudflareStamp);
+
+                Assert.Equal(0, exitCode);
+                string text = output.ToString();
+                Assert.Contains("DNS Stamp:", text, StringComparison.Ordinal);
+                Assert.Contains("Transport: Doh", text, StringComparison.Ordinal);
+                Assert.Contains("Host: mozilla.cloudflare-dns.com", text, StringComparison.Ordinal);
+                Assert.Contains("DoH URL: https://mozilla.cloudflare-dns.com/dns-query", text, StringComparison.Ordinal);
+            } finally {
+                Console.SetOut(originalOut);
+            }
+        }
+
+        /// <summary>
+        /// Ensures stamp mode can emit JSON for automation.
+        /// </summary>
+        [Fact]
+        public async Task StampInfo_Json_PrintsStructuredDescription() {
+            using var output = new StringWriter();
+            TextWriter originalOut = Console.Out;
+            try {
+                Console.SetOut(output);
+
+                int exitCode = await InvokeCliAsync("--stamp-info", CloudflareStamp, "--format", "json");
+
+                Assert.Equal(0, exitCode);
+                string text = output.ToString();
+                Assert.Contains("\"Transport\": \"Doh\"", text, StringComparison.Ordinal);
+                Assert.Contains("\"RequestFormat\": \"DnsOverHttps\"", text, StringComparison.Ordinal);
+                Assert.Contains("\"Host\": \"mozilla.cloudflare-dns.com\"", text, StringComparison.Ordinal);
+                Assert.Contains("\"DnsSecOk\": true", text, StringComparison.Ordinal);
+            } finally {
+                Console.SetOut(originalOut);
+            }
+        }
+
+        /// <summary>
+        /// Ensures stamp mode rejects query-only switches.
+        /// </summary>
+        [Fact]
+        public async Task StampInfo_RejectsQuerySwitches() {
+            using var error = new StringWriter();
+            TextWriter originalError = Console.Error;
+            try {
+                Console.SetError(error);
+
+                int exitCode = await InvokeCliAsync("--stamp-info", CloudflareStamp, "--short");
+
+                Assert.Equal(1, exitCode);
+                Assert.Contains("Stamp mode supports only --stamp-info", error.ToString(), StringComparison.Ordinal);
+            } finally {
+                Console.SetError(originalError);
+            }
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsMessageOptionsTests.cs
+++ b/DnsClientX.Tests/DnsMessageOptionsTests.cs
@@ -27,5 +27,41 @@ namespace DnsClientX.Tests {
             byte[] data = message.SerializeDnsWireFormat();
             AssertEcsOption(data, "example.com");
         }
+
+        /// <summary>
+        /// Ensures fully-qualified names are encoded with one terminating root label.
+        /// </summary>
+        [Fact]
+        public void SerializeDnsWireFormat_ShouldNotWriteExtraRootLabel_WhenNameHasTrailingDot() {
+            var message = new DnsMessage("example.com.", DnsRecordType.A, requestDnsSec: false);
+            byte[] data = message.SerializeDnsWireFormat();
+
+            Assert.Equal(0, data[24]);
+            ushort type = (ushort)((data[25] << 8) | data[26]);
+            ushort @class = (ushort)((data[27] << 8) | data[28]);
+            Assert.Equal((ushort)DnsRecordType.A, type);
+            Assert.Equal(1, @class);
+        }
+
+        /// <summary>
+        /// Ensures DoH GET serialization uses the same fully-qualified-name encoding.
+        /// </summary>
+        [Fact]
+        public void ToBase64Url_ShouldNotWriteExtraRootLabel_WhenNameHasTrailingDot() {
+            var message = new DnsMessage("example.com.", DnsRecordType.A, requestDnsSec: false);
+            byte[] data = DecodeBase64Url(message.ToBase64Url());
+
+            Assert.Equal(0, data[24]);
+            ushort type = (ushort)((data[25] << 8) | data[26]);
+            ushort @class = (ushort)((data[27] << 8) | data[28]);
+            Assert.Equal((ushort)DnsRecordType.A, type);
+            Assert.Equal(1, @class);
+        }
+
+        private static byte[] DecodeBase64Url(string value) {
+            string base64 = value.Replace('-', '+').Replace('_', '/');
+            base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
+            return System.Convert.FromBase64String(base64);
+        }
     }
 }

--- a/DnsClientX.Tests/DnsMultiResolverStrategiesTests.cs
+++ b/DnsClientX.Tests/DnsMultiResolverStrategiesTests.cs
@@ -111,7 +111,7 @@ namespace DnsClientX.Tests {
                 var calls = new ConcurrentDictionary<string,int>();
                 DnsMultiResolver.ResolveOverride = async (ep, name, type, ct) => {
                     calls.AddOrUpdate(ep.Host ?? string.Empty, 1, (_, v) => v + 1);
-                    if (ep.Host == "slow") await Task.Delay(80, ct); else await Task.Delay(10, ct);
+                    if (ep.Host == "slow") await Task.Delay(500, ct); else await Task.Delay(1, ct);
                     return Ok(name, type);
                 };
                 var mr = new DnsMultiResolver(eps, opts);

--- a/DnsClientX.Tests/DnsStampTests.cs
+++ b/DnsClientX.Tests/DnsStampTests.cs
@@ -157,6 +157,23 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
+        /// Ensures DoH3 endpoints are not serialized into ordinary DoH stamps.
+        /// </summary>
+        [Fact]
+        public void DohStamp_CreateRejectsHttp3Endpoint() {
+            var endpoint = new DnsResolverEndpoint {
+                Transport = Transport.Doh,
+                RequestFormat = DnsRequestFormat.DnsOverHttp3,
+                Host = "dns.example.test",
+                Port = 443,
+                DohUrl = new Uri("https://dns.example.test/dns-query")
+            };
+
+            NotSupportedException exception = Assert.Throws<NotSupportedException>(() => DnsStamp.Create(endpoint));
+            Assert.Contains("HTTP/3", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
         /// Ensures explicit empty bootstrap address sets are accepted when parsing external stamps.
         /// </summary>
         [Fact]

--- a/DnsClientX.Tests/DnsStampTests.cs
+++ b/DnsClientX.Tests/DnsStampTests.cs
@@ -115,23 +115,57 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
-        /// Ensures generated DoH stamps preserve resolver paths.
+        /// Ensures generated DoH stamps preserve resolver paths and query strings.
         /// </summary>
         [Fact]
-        public void DohStamp_RoundTripsPath() {
+        public void DohStamp_RoundTripsPathAndQuery() {
             var endpoint = new DnsResolverEndpoint {
                 Transport = Transport.Doh,
                 RequestFormat = DnsRequestFormat.DnsOverHttps,
                 Host = "dns.example.test",
                 Port = 8443,
-                DohUrl = new Uri("https://dns.example.test:8443/custom-query")
+                DohUrl = new Uri("https://dns.example.test:8443/custom-query?token=abc")
             };
 
             DnsResolverEndpoint parsed = DnsStamp.Parse(DnsStamp.Create(endpoint));
 
             Assert.Equal("dns.example.test", parsed.Host);
             Assert.Equal(8443, parsed.Port);
-            Assert.Equal(new Uri("https://dns.example.test:8443/custom-query"), parsed.DohUrl);
+            Assert.Equal(new Uri("https://dns.example.test:8443/custom-query?token=abc"), parsed.DohUrl);
+        }
+
+        /// <summary>
+        /// Ensures explicit empty bootstrap address sets are accepted when parsing external stamps.
+        /// </summary>
+        [Fact]
+        public void DohStamp_WithExplicitEmptyBootstrapSet_Parses() {
+            var endpoint = new DnsResolverEndpoint {
+                Transport = Transport.Doh,
+                RequestFormat = DnsRequestFormat.DnsOverHttps,
+                Host = "dns.example.test",
+                Port = 443,
+                DohUrl = new Uri("https://dns.example.test/dns-query")
+            };
+
+            string stamp = AppendPayloadByte(DnsStamp.Create(endpoint), 0);
+            DnsResolverEndpoint parsed = DnsStamp.Parse(stamp);
+
+            Assert.Equal(Transport.Doh, parsed.Transport);
+            Assert.Equal("dns.example.test", parsed.Host);
+            Assert.Equal(new Uri("https://dns.example.test/dns-query"), parsed.DohUrl);
+        }
+
+        private static string AppendPayloadByte(string stamp, byte value) {
+            const string scheme = "sdns://";
+            string encoded = stamp.Substring(scheme.Length);
+            string base64 = encoded.Replace('-', '+').Replace('_', '/');
+            base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
+            byte[] payload = Convert.FromBase64String(base64);
+            byte[] updated = payload.Concat(new[] { value }).ToArray();
+            return scheme + Convert.ToBase64String(updated)
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
         }
     }
 }

--- a/DnsClientX.Tests/DnsStampTests.cs
+++ b/DnsClientX.Tests/DnsStampTests.cs
@@ -174,6 +174,22 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
+        /// Ensures invalid endpoint ports are rejected before non-round-trippable stamps are emitted.
+        /// </summary>
+        [Fact]
+        public void StampCreate_InvalidPort_Throws() {
+            var endpoint = new DnsResolverEndpoint {
+                Transport = Transport.Dot,
+                RequestFormat = DnsRequestFormat.DnsOverTLS,
+                Host = "dns.example.test",
+                Port = 70000
+            };
+
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() => DnsStamp.Create(endpoint));
+            Assert.Contains("port", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
         /// Ensures explicit empty bootstrap address sets are accepted when parsing external stamps.
         /// </summary>
         [Fact]

--- a/DnsClientX.Tests/DnsStampTests.cs
+++ b/DnsClientX.Tests/DnsStampTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests DNS stamp parsing and generation.
+    /// </summary>
+    public class DnsStampTests {
+        /// <summary>
+        /// Ensures plain DNS stamps round-trip through the endpoint model.
+        /// </summary>
+        [Fact]
+        public void PlainDnsStamp_RoundTripsEndpoint() {
+            var endpoint = new DnsResolverEndpoint {
+                Host = "1.1.1.1",
+                Port = 53,
+                Transport = Transport.Udp,
+                RequestFormat = DnsRequestFormat.DnsOverUDP,
+                DnsSecOk = true
+            };
+
+            string stamp = DnsStamp.Create(endpoint);
+            DnsResolverEndpoint parsed = DnsStamp.Parse(stamp);
+
+            Assert.Equal(Transport.Udp, parsed.Transport);
+            Assert.Equal(DnsRequestFormat.DnsOverUDP, parsed.RequestFormat);
+            Assert.Equal("1.1.1.1", parsed.Host);
+            Assert.Equal(53, parsed.Port);
+            Assert.True(parsed.DnsSecOk);
+        }
+
+        /// <summary>
+        /// Ensures known DoH stamps parse into HTTPS resolver endpoints.
+        /// </summary>
+        [Fact]
+        public void DohStamp_ParsesKnownCloudflareExample() {
+            const string stamp = "sdns://AgUAAAAAAAAABzEuMS4xLjEAGm1vemlsbGEuY2xvdWRmbGFyZS1kbnMuY29tCi9kbnMtcXVlcnk";
+
+            DnsResolverEndpoint endpoint = DnsStamp.Parse(stamp);
+
+            Assert.Equal(Transport.Doh, endpoint.Transport);
+            Assert.Equal(DnsRequestFormat.DnsOverHttps, endpoint.RequestFormat);
+            Assert.Equal("mozilla.cloudflare-dns.com", endpoint.Host);
+            Assert.Equal(443, endpoint.Port);
+            Assert.Equal(new Uri("https://mozilla.cloudflare-dns.com/dns-query"), endpoint.DohUrl);
+            Assert.True(endpoint.DnsSecOk);
+        }
+
+        /// <summary>
+        /// Ensures DoT and DoQ stamps round-trip with non-default ports.
+        /// </summary>
+        [Theory]
+        [InlineData(Transport.Dot, DnsRequestFormat.DnsOverTLS, 853)]
+        [InlineData(Transport.Quic, DnsRequestFormat.DnsOverQuic, 8853)]
+        public void SecureTransportStamp_RoundTripsEndpoint(Transport transport, DnsRequestFormat requestFormat, int port) {
+            var endpoint = new DnsResolverEndpoint {
+                Host = "dns.example.test",
+                Port = port,
+                Transport = transport,
+                RequestFormat = requestFormat
+            };
+
+            DnsResolverEndpoint parsed = DnsStamp.Parse(DnsStamp.Create(endpoint));
+
+            Assert.Equal(transport, parsed.Transport);
+            Assert.Equal(requestFormat, parsed.RequestFormat);
+            Assert.Equal("dns.example.test", parsed.Host);
+            Assert.Equal(port, parsed.Port);
+        }
+
+        /// <summary>
+        /// Ensures endpoint parser accepts DNS stamps as resolver inputs.
+        /// </summary>
+        [Fact]
+        public void EndpointParser_AcceptsDnsStampInput() {
+            var endpoint = new DnsResolverEndpoint {
+                Host = "9.9.9.9",
+                Port = 53,
+                Transport = Transport.Udp,
+                RequestFormat = DnsRequestFormat.DnsOverUDP
+            };
+
+            DnsResolverEndpoint[] endpoints = EndpointParser.TryParseMany(new[] { DnsStamp.Create(endpoint) }, out var errors);
+
+            Assert.Empty(errors);
+            DnsResolverEndpoint parsed = Assert.Single(endpoints);
+            Assert.Equal("9.9.9.9", parsed.Host);
+            Assert.Equal(Transport.Udp, parsed.Transport);
+        }
+
+        /// <summary>
+        /// Ensures unsupported stamp protocols fail with a descriptive error.
+        /// </summary>
+        [Fact]
+        public void TryParse_UnsupportedDnsCryptStamp_ReturnsError() {
+            const string dnsCryptPayload = "AQAAAAAAAAAAAQAAAAEAAAA";
+            bool parsed = DnsStamp.TryParse("sdns://" + dnsCryptPayload, out DnsResolverEndpoint? endpoint, out string? error);
+
+            Assert.False(parsed);
+            Assert.Null(endpoint);
+            Assert.Contains("DNSCrypt", error, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Ensures invalid stamps are surfaced as endpoint parser errors.
+        /// </summary>
+        [Fact]
+        public void EndpointParser_InvalidDnsStampReportsError() {
+            DnsResolverEndpoint[] endpoints = EndpointParser.TryParseMany(new[] { "sdns://not-valid" }, out var errors);
+
+            Assert.Empty(endpoints);
+            string error = Assert.Single(errors);
+            Assert.Contains("Invalid DNS stamp", error, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Ensures generated DoH stamps preserve resolver paths.
+        /// </summary>
+        [Fact]
+        public void DohStamp_RoundTripsPath() {
+            var endpoint = new DnsResolverEndpoint {
+                Transport = Transport.Doh,
+                RequestFormat = DnsRequestFormat.DnsOverHttps,
+                Host = "dns.example.test",
+                Port = 8443,
+                DohUrl = new Uri("https://dns.example.test:8443/custom-query")
+            };
+
+            DnsResolverEndpoint parsed = DnsStamp.Parse(DnsStamp.Create(endpoint));
+
+            Assert.Equal("dns.example.test", parsed.Host);
+            Assert.Equal(8443, parsed.Port);
+            Assert.Equal(new Uri("https://dns.example.test:8443/custom-query"), parsed.DohUrl);
+        }
+    }
+}

--- a/DnsClientX.Tests/DnsStampTests.cs
+++ b/DnsClientX.Tests/DnsStampTests.cs
@@ -137,6 +137,26 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
+        /// Ensures generated DoH stamps keep IPv6 host brackets when a custom port is present.
+        /// </summary>
+        [Fact]
+        public void DohStamp_RoundTripsIpv6AddressAndCustomPort() {
+            var endpoint = new DnsResolverEndpoint {
+                Transport = Transport.Doh,
+                RequestFormat = DnsRequestFormat.DnsOverHttps,
+                Host = "2606:4700:4700::1111",
+                Port = 8443,
+                DohUrl = new Uri("https://[2606:4700:4700::1111]:8443/dns-query")
+            };
+
+            DnsResolverEndpoint parsed = DnsStamp.Parse(DnsStamp.Create(endpoint));
+
+            Assert.Equal("2606:4700:4700::1111", parsed.Host);
+            Assert.Equal(8443, parsed.Port);
+            Assert.Equal(new Uri("https://[2606:4700:4700::1111]:8443/dns-query"), parsed.DohUrl);
+        }
+
+        /// <summary>
         /// Ensures explicit empty bootstrap address sets are accepted when parsing external stamps.
         /// </summary>
         [Fact]

--- a/DnsClientX.Tests/DnsStampTests.cs
+++ b/DnsClientX.Tests/DnsStampTests.cs
@@ -176,13 +176,15 @@ namespace DnsClientX.Tests {
         /// <summary>
         /// Ensures invalid endpoint ports are rejected before non-round-trippable stamps are emitted.
         /// </summary>
-        [Fact]
-        public void StampCreate_InvalidPort_Throws() {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(70000)]
+        public void StampCreate_InvalidPort_Throws(int port) {
             var endpoint = new DnsResolverEndpoint {
                 Transport = Transport.Dot,
                 RequestFormat = DnsRequestFormat.DnsOverTLS,
                 Host = "dns.example.test",
-                Port = 70000
+                Port = port
             };
 
             ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() => DnsStamp.Create(endpoint));
@@ -208,6 +210,29 @@ namespace DnsClientX.Tests {
             Assert.Equal(Transport.Doh, parsed.Transport);
             Assert.Equal("dns.example.test", parsed.Host);
             Assert.Equal(new Uri("https://dns.example.test/dns-query"), parsed.DohUrl);
+        }
+
+        /// <summary>
+        /// Ensures bootstrap-address stamps are rejected instead of silently dropping routing data.
+        /// </summary>
+        [Fact]
+        public void DohStamp_WithBootstrapAddress_IsUnsupported() {
+            var endpoint = new DnsResolverEndpoint {
+                Transport = Transport.Doh,
+                RequestFormat = DnsRequestFormat.DnsOverHttps,
+                Host = "dns.example.test",
+                Port = 443,
+                DohUrl = new Uri("https://dns.example.test/dns-query")
+            };
+
+            string stamp = AppendPayloadValue(DnsStamp.Create(endpoint), "9.9.9.9");
+
+            bool parsed = DnsStamp.TryParse(stamp, out DnsResolverEndpoint? parsedEndpoint, out string? error);
+
+            Assert.False(parsed);
+            Assert.Null(parsedEndpoint);
+            Assert.Contains("Bootstrap addresses", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("not supported", error, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -269,6 +294,17 @@ namespace DnsClientX.Tests {
                 .TrimEnd('=')
                 .Replace('+', '-')
                 .Replace('/', '_');
+        }
+
+        private static string AppendPayloadValue(string stamp, string value) {
+            const string scheme = "sdns://";
+            string encoded = stamp.Substring(scheme.Length);
+            string base64 = encoded.Replace('-', '+').Replace('_', '/');
+            base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
+            byte[] payload = Convert.FromBase64String(base64);
+            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+            byte[] updated = payload.Concat(new[] { (byte)valueBytes.Length }).Concat(valueBytes).ToArray();
+            return EncodePayload(updated);
         }
 
         private static string CreateDohStamp(string address, string host, string path, byte[]? certificateHash = null) {

--- a/DnsClientX.Tests/DnsStampTests.cs
+++ b/DnsClientX.Tests/DnsStampTests.cs
@@ -195,6 +195,22 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
+        /// Ensures certificate-pinned stamps are rejected instead of silently dropping the pins.
+        /// </summary>
+        [Fact]
+        public void DohStamp_WithCertificateHash_IsUnsupported() {
+            byte[] certificateHash = Enumerable.Repeat((byte)0xAB, 32).ToArray();
+            string stamp = CreateDohStamp("1.1.1.1", "dns.example.test", "/dns-query", certificateHash);
+
+            bool parsed = DnsStamp.TryParse(stamp, out DnsResolverEndpoint? endpoint, out string? error);
+
+            Assert.False(parsed);
+            Assert.Null(endpoint);
+            Assert.Contains("Certificate hashes", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("not supported", error, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
         /// Ensures DoH stamps preserve a non-default address port when hostname carries certificate name only.
         /// </summary>
         [Fact]
@@ -239,12 +255,17 @@ namespace DnsClientX.Tests {
                 .Replace('/', '_');
         }
 
-        private static string CreateDohStamp(string address, string host, string path) {
+        private static string CreateDohStamp(string address, string host, string path, byte[]? certificateHash = null) {
             using var stream = new MemoryStream();
             stream.WriteByte(0x02);
             WriteProperties(stream);
             WriteLengthPrefixed(stream, address);
-            WriteEmptyVariableLengthSet(stream);
+            if (certificateHash == null) {
+                WriteEmptyVariableLengthSet(stream);
+            } else {
+                WriteSingleVariableLengthSet(stream, certificateHash);
+            }
+
             WriteLengthPrefixed(stream, host);
             WriteLengthPrefixed(stream, path);
             return EncodePayload(stream.ToArray());
@@ -272,6 +293,15 @@ namespace DnsClientX.Tests {
 
         private static void WriteEmptyVariableLengthSet(Stream stream) {
             stream.WriteByte(0);
+        }
+
+        private static void WriteSingleVariableLengthSet(Stream stream, byte[] value) {
+            if (value.Length > 127) {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            stream.WriteByte((byte)value.Length);
+            stream.Write(value, 0, value.Length);
         }
 
         private static string EncodePayload(byte[] payload) {

--- a/DnsClientX.Tests/DnsStampTests.cs
+++ b/DnsClientX.Tests/DnsStampTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace DnsClientX.Tests {
@@ -155,6 +157,38 @@ namespace DnsClientX.Tests {
             Assert.Equal(new Uri("https://dns.example.test/dns-query"), parsed.DohUrl);
         }
 
+        /// <summary>
+        /// Ensures DoH stamps preserve a non-default address port when hostname carries certificate name only.
+        /// </summary>
+        [Fact]
+        public void DohStamp_UsesAddressPortWhenHostnameHasNoPort() {
+            string stamp = CreateDohStamp("1.1.1.1:8443", "dns.example.test", "/dns-query");
+
+            DnsResolverEndpoint parsed = DnsStamp.Parse(stamp);
+
+            Assert.Equal(Transport.Doh, parsed.Transport);
+            Assert.Equal("dns.example.test", parsed.Host);
+            Assert.Equal(8443, parsed.Port);
+            Assert.Equal(new Uri("https://dns.example.test:8443/dns-query"), parsed.DohUrl);
+        }
+
+        /// <summary>
+        /// Ensures DoT and DoQ stamps preserve a non-default address port when hostname carries certificate name only.
+        /// </summary>
+        [Theory]
+        [InlineData(0x03, Transport.Dot, DnsRequestFormat.DnsOverTLS)]
+        [InlineData(0x04, Transport.Quic, DnsRequestFormat.DnsOverQuic)]
+        public void TlsLikeStamp_UsesAddressPortWhenHostnameHasNoPort(byte protocol, Transport transport, DnsRequestFormat requestFormat) {
+            string stamp = CreateTlsLikeStamp(protocol, "9.9.9.9:8853", "dns.example.test");
+
+            DnsResolverEndpoint parsed = DnsStamp.Parse(stamp);
+
+            Assert.Equal(transport, parsed.Transport);
+            Assert.Equal(requestFormat, parsed.RequestFormat);
+            Assert.Equal("dns.example.test", parsed.Host);
+            Assert.Equal(8853, parsed.Port);
+        }
+
         private static string AppendPayloadByte(string stamp, byte value) {
             const string scheme = "sdns://";
             string encoded = stamp.Substring(scheme.Length);
@@ -163,6 +197,49 @@ namespace DnsClientX.Tests {
             byte[] payload = Convert.FromBase64String(base64);
             byte[] updated = payload.Concat(new[] { value }).ToArray();
             return scheme + Convert.ToBase64String(updated)
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
+        }
+
+        private static string CreateDohStamp(string address, string host, string path) {
+            using var stream = new MemoryStream();
+            stream.WriteByte(0x02);
+            WriteProperties(stream);
+            WriteLengthPrefixed(stream, address);
+            WriteEmptyVariableLengthSet(stream);
+            WriteLengthPrefixed(stream, host);
+            WriteLengthPrefixed(stream, path);
+            return EncodePayload(stream.ToArray());
+        }
+
+        private static string CreateTlsLikeStamp(byte protocol, string address, string host) {
+            using var stream = new MemoryStream();
+            stream.WriteByte(protocol);
+            WriteProperties(stream);
+            WriteLengthPrefixed(stream, address);
+            WriteEmptyVariableLengthSet(stream);
+            WriteLengthPrefixed(stream, host);
+            return EncodePayload(stream.ToArray());
+        }
+
+        private static void WriteProperties(Stream stream) {
+            stream.Write(new byte[8], 0, 8);
+        }
+
+        private static void WriteLengthPrefixed(Stream stream, string value) {
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            stream.WriteByte((byte)bytes.Length);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static void WriteEmptyVariableLengthSet(Stream stream) {
+            stream.WriteByte(0);
+        }
+
+        private static string EncodePayload(byte[] payload) {
+            const string scheme = "sdns://";
+            return scheme + Convert.ToBase64String(payload)
                 .TrimEnd('=')
                 .Replace('+', '-')
                 .Replace('/', '_');

--- a/DnsClientX.Tests/NextDnsTests.cs
+++ b/DnsClientX.Tests/NextDnsTests.cs
@@ -1,6 +1,4 @@
 using System.Threading.Tasks;
-using Xunit;
-
 namespace DnsClientX.Tests {
     /// <summary>
     /// Integration tests targeting the NextDNS public resolver.
@@ -9,7 +7,7 @@ namespace DnsClientX.Tests {
         /// <summary>
         /// Verifies that records can be resolved against NextDNS.
         /// </summary>
-        [Fact]
+        [RealDnsFact]
         public async Task ResolveUsingNextDns() {
             using var client = new ClientX(DnsEndpoint.NextDNS) { Debug = false };
             var response = await client.Resolve("github.com", DnsRecordType.A);

--- a/DnsClientX.Tests/ReleaseSanityTests.cs
+++ b/DnsClientX.Tests/ReleaseSanityTests.cs
@@ -40,17 +40,17 @@ namespace DnsClientX.Tests {
         [Fact]
         public void ReleaseVersions_ShouldStayAligned() {
             string root = FindRepositoryRoot();
-            string coreVersion = ReadProjectProperty(Path.Combine(root, "DnsClientX", "DnsClientX.csproj"), "VersionPrefix");
+            string coreVersion = ReadProjectProperty(CombineRelative(root, "DnsClientX", "DnsClientX.csproj"), "VersionPrefix");
 
-            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "VersionPrefix"));
-            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "AssemblyVersion"));
-            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "FileVersion"));
+            Assert.Equal(coreVersion, ReadProjectProperty(CombineRelative(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "VersionPrefix"));
+            Assert.Equal(coreVersion, ReadProjectProperty(CombineRelative(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "AssemblyVersion"));
+            Assert.Equal(coreVersion, ReadProjectProperty(CombineRelative(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "FileVersion"));
 
-            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "VersionPrefix"));
-            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "AssemblyVersion"));
-            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "FileVersion"));
+            Assert.Equal(coreVersion, ReadProjectProperty(CombineRelative(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "VersionPrefix"));
+            Assert.Equal(coreVersion, ReadProjectProperty(CombineRelative(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "AssemblyVersion"));
+            Assert.Equal(coreVersion, ReadProjectProperty(CombineRelative(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "FileVersion"));
 
-            Assert.Equal(coreVersion, ReadPowerShellManifestVersion(Path.Combine(root, "Module", "DnsClientX.psd1")));
+            Assert.Equal(coreVersion, ReadPowerShellManifestVersion(CombineRelative(root, "Module", "DnsClientX.psd1")));
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace DnsClientX.Tests {
         [Fact]
         public async Task CliHelpAndReadme_ShouldDocumentKeyOperatorSwitches() {
             string root = FindRepositoryRoot();
-            string readme = File.ReadAllText(Path.Combine(root, "README.md"));
+            string readme = File.ReadAllText(CombineRelative(root, "README.md"));
             string help = await GetCliHelpAsync();
 
             foreach (string cliSwitch in CliOperatorSwitches) {
@@ -74,8 +74,8 @@ namespace DnsClientX.Tests {
         [Fact]
         public void PowerShellManifest_ShouldExportBinaryCmdlets() {
             string root = FindRepositoryRoot();
-            string manifest = File.ReadAllText(Path.Combine(root, "Module", "DnsClientX.psd1"));
-            string[] sourceFiles = Directory.GetFiles(Path.Combine(root, "DnsClientX.PowerShell"), "*.cs");
+            string manifest = File.ReadAllText(CombineRelative(root, "Module", "DnsClientX.psd1"));
+            string[] sourceFiles = Directory.GetFiles(CombineRelative(root, "DnsClientX.PowerShell"), "*.cs");
 
             foreach (string sourceFile in sourceFiles) {
                 string source = File.ReadAllText(sourceFile);
@@ -106,6 +106,23 @@ namespace DnsClientX.Tests {
             } finally {
                 Console.SetOut(originalOut);
             }
+        }
+
+        private static string CombineRelative(string basePath, params string[] segments) {
+            string current = basePath;
+            foreach (string segment in segments) {
+                if (string.IsNullOrWhiteSpace(segment)) {
+                    throw new ArgumentException("Path segment cannot be empty.", nameof(segments));
+                }
+
+                if (Path.IsPathRooted(segment)) {
+                    throw new ArgumentException($"Path segment must be relative: {segment}", nameof(segments));
+                }
+
+                current = Path.Combine(current, segment);
+            }
+
+            return current;
         }
 
         private static string ReadProjectProperty(string path, string propertyName) {

--- a/DnsClientX.Tests/ReleaseSanityTests.cs
+++ b/DnsClientX.Tests/ReleaseSanityTests.cs
@@ -77,8 +77,7 @@ namespace DnsClientX.Tests {
             string manifest = File.ReadAllText(CombineRelative(root, "Module", "DnsClientX.psd1"));
             string[] sourceFiles = Directory.GetFiles(CombineRelative(root, "DnsClientX.PowerShell"), "*.cs");
 
-            foreach (string sourceFile in sourceFiles) {
-                string source = File.ReadAllText(sourceFile);
+            foreach (string source in sourceFiles.Select(File.ReadAllText)) {
                 Match match = Regex.Match(source, @"\[Cmdlet\([^,]+,\s*""(?<noun>[^""]+)""", RegexOptions.CultureInvariant);
                 if (!match.Success) {
                     continue;
@@ -119,10 +118,17 @@ namespace DnsClientX.Tests {
                     throw new ArgumentException($"Path segment must be relative: {segment}", nameof(segments));
                 }
 
-                current = Path.Combine(current, segment);
+                current = JoinPath(current, segment);
             }
 
             return current;
+        }
+
+        private static string JoinPath(string left, string right) {
+            return left.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
+                   left.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+                ? left + right
+                : left + Path.DirectorySeparatorChar + right;
         }
 
         private static string ReadProjectProperty(string path, string propertyName) {
@@ -159,7 +165,7 @@ namespace DnsClientX.Tests {
         private static string FindRepositoryRoot() {
             DirectoryInfo? directory = new DirectoryInfo(AppContext.BaseDirectory);
             while (directory != null) {
-                if (File.Exists(Path.Combine(directory.FullName, "DnsClientX.sln"))) {
+                if (File.Exists(CombineRelative(directory.FullName, "DnsClientX.sln"))) {
                     return directory.FullName;
                 }
 

--- a/DnsClientX.Tests/ReleaseSanityTests.cs
+++ b/DnsClientX.Tests/ReleaseSanityTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests release-facing metadata and documentation drift.
+    /// </summary>
+    [Collection("NoParallel")]
+    public class ReleaseSanityTests {
+        private static readonly string[] CliOperatorSwitches = {
+            "--format",
+            "--short",
+            "--txt-concat",
+            "--question",
+            "--answer",
+            "--authority",
+            "--additional",
+            "--reverse",
+            "--axfr",
+            "--transfer-summary",
+            "--resolver-file",
+            "--resolver-url",
+            "--resolver-validate",
+            "--probe-save",
+            "--benchmark-save",
+            "--resolver-select",
+            "--resolver-use",
+            "--stamp-info"
+        };
+
+        /// <summary>
+        /// Ensures release-facing project versions stay aligned.
+        /// </summary>
+        [Fact]
+        public void ReleaseVersions_ShouldStayAligned() {
+            string root = FindRepositoryRoot();
+            string coreVersion = ReadProjectProperty(Path.Combine(root, "DnsClientX", "DnsClientX.csproj"), "VersionPrefix");
+
+            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "VersionPrefix"));
+            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "AssemblyVersion"));
+            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.Cli", "DnsClientX.Cli.csproj"), "FileVersion"));
+
+            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "VersionPrefix"));
+            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "AssemblyVersion"));
+            Assert.Equal(coreVersion, ReadProjectProperty(Path.Combine(root, "DnsClientX.PowerShell", "DnsClientX.PowerShell.csproj"), "FileVersion"));
+
+            Assert.Equal(coreVersion, ReadPowerShellManifestVersion(Path.Combine(root, "Module", "DnsClientX.psd1")));
+        }
+
+        /// <summary>
+        /// Ensures README and CLI help cover key operator switches together.
+        /// </summary>
+        [Fact]
+        public async Task CliHelpAndReadme_ShouldDocumentKeyOperatorSwitches() {
+            string root = FindRepositoryRoot();
+            string readme = File.ReadAllText(Path.Combine(root, "README.md"));
+            string help = await GetCliHelpAsync();
+
+            foreach (string cliSwitch in CliOperatorSwitches) {
+                Assert.Contains(cliSwitch, help, StringComparison.Ordinal);
+                Assert.Contains(cliSwitch, readme, StringComparison.Ordinal);
+            }
+        }
+
+        /// <summary>
+        /// Ensures exported binary cmdlets stay listed in the PowerShell module manifest.
+        /// </summary>
+        [Fact]
+        public void PowerShellManifest_ShouldExportBinaryCmdlets() {
+            string root = FindRepositoryRoot();
+            string manifest = File.ReadAllText(Path.Combine(root, "Module", "DnsClientX.psd1"));
+            string[] sourceFiles = Directory.GetFiles(Path.Combine(root, "DnsClientX.PowerShell"), "*.cs");
+
+            foreach (string sourceFile in sourceFiles) {
+                string source = File.ReadAllText(sourceFile);
+                Match match = Regex.Match(source, @"\[Cmdlet\([^,]+,\s*""(?<noun>[^""]+)""", RegexOptions.CultureInvariant);
+                if (!match.Success) {
+                    continue;
+                }
+
+                string verb = ReadCmdletVerb(source);
+                string noun = match.Groups["noun"].Value;
+                Assert.Contains($"{verb}-{noun}", manifest, StringComparison.Ordinal);
+            }
+        }
+
+        private static async Task<string> GetCliHelpAsync() {
+            var assembly = Assembly.Load("DnsClientX.Cli");
+            Type programType = assembly.GetType("DnsClientX.Cli.Program")!;
+            MethodInfo main = programType.GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            using var output = new StringWriter();
+            TextWriter originalOut = Console.Out;
+            try {
+                Console.SetOut(output);
+                Task<int> task = (Task<int>)main.Invoke(null, new object[] { new[] { "--help" } })!;
+                int exitCode = await task;
+                Assert.Equal(0, exitCode);
+                return output.ToString();
+            } finally {
+                Console.SetOut(originalOut);
+            }
+        }
+
+        private static string ReadProjectProperty(string path, string propertyName) {
+            XDocument document = XDocument.Load(path);
+            string? value = document.Root?
+                .Elements("PropertyGroup")
+                .Elements(propertyName)
+                .Select(element => element.Value.Trim())
+                .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+
+            Assert.False(string.IsNullOrWhiteSpace(value), $"Missing {propertyName} in {path}.");
+            return value!;
+        }
+
+        private static string ReadPowerShellManifestVersion(string path) {
+            string content = File.ReadAllText(path);
+            Match match = Regex.Match(content, @"ModuleVersion\s*=\s*'(?<version>[^']+)'", RegexOptions.CultureInvariant);
+            Assert.True(match.Success, $"Missing ModuleVersion in {path}.");
+            return match.Groups["version"].Value;
+        }
+
+        private static string ReadCmdletVerb(string source) {
+            if (source.Contains("VerbsCommon.Get", StringComparison.Ordinal)) return "Get";
+            if (source.Contains("VerbsCommon.Clear", StringComparison.Ordinal)) return "Clear";
+            if (source.Contains("VerbsCommon.Find", StringComparison.Ordinal)) return "Find";
+            if (source.Contains("VerbsData.ConvertFrom", StringComparison.Ordinal)) return "ConvertFrom";
+            if (source.Contains("VerbsDiagnostic.Resolve", StringComparison.Ordinal)) return "Resolve";
+            if (source.Contains("VerbsDiagnostic.Test", StringComparison.Ordinal)) return "Test";
+            if (source.Contains("VerbsLifecycle.Invoke", StringComparison.Ordinal)) return "Invoke";
+
+            throw new InvalidOperationException("Unsupported cmdlet verb in PowerShell source.");
+        }
+
+        private static string FindRepositoryRoot() {
+            DirectoryInfo? directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null) {
+                if (File.Exists(Path.Combine(directory.FullName, "DnsClientX.sln"))) {
+                    return directory.FullName;
+                }
+
+                directory = directory.Parent;
+            }
+
+            throw new DirectoryNotFoundException("Could not find repository root containing DnsClientX.sln.");
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolverCatalogValidationTests.cs
+++ b/DnsClientX.Tests/ResolverCatalogValidationTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Reflection;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -19,6 +23,43 @@ namespace DnsClientX.Tests {
             MethodInfo main = programType.GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
             Task<int> task = (Task<int>)main.Invoke(null, new object[] { args })!;
             return await task;
+        }
+
+        private static async Task RunStallingHttpServerAsync(int port, ManualResetEventSlim ready, CancellationToken token) {
+            var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            ready.Set();
+
+            try {
+                TcpClient client;
+#if NET8_0_OR_GREATER
+                client = await listener.AcceptTcpClientAsync(token);
+#else
+                Task<TcpClient> acceptTask = listener.AcceptTcpClientAsync();
+                Task completed = await Task.WhenAny(acceptTask, Task.Delay(Timeout.Infinite, token));
+                if (completed != acceptTask) {
+                    throw new OperationCanceledException(token);
+                }
+
+                client = acceptTask.Result;
+#endif
+
+                using (client)
+                using (NetworkStream stream = client.GetStream())
+                using (var reader = new StreamReader(stream, Encoding.ASCII, false, 1024, true)) {
+                    while (!token.IsCancellationRequested) {
+                        string? line = await reader.ReadLineAsync();
+                        if (line is null || line.Length == 0) {
+                            break;
+                        }
+                    }
+
+                    await Task.Delay(Timeout.Infinite, token);
+                }
+            } catch (OperationCanceledException) when (token.IsCancellationRequested) {
+            } finally {
+                listener.Stop();
+            }
         }
 
         /// <summary>
@@ -44,6 +85,29 @@ namespace DnsClientX.Tests {
                 Assert.Equal(Transport.Doh, results[2].Endpoint!.Transport);
             } finally {
                 File.Delete(resolverFile);
+            }
+        }
+
+        /// <summary>
+        /// Ensures caller cancellation is not reported as a URL validation error.
+        /// </summary>
+        [Fact]
+        public async Task ValidateManyAsync_UrlImport_PropagatesCancellation() {
+            int port = TestUtilities.GetFreeTcpPort();
+            using var ready = new ManualResetEventSlim(false);
+            using var serverCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            Task serverTask = RunStallingHttpServerAsync(port, ready, serverCts.Token);
+            Assert.True(ready.Wait(TimeSpan.FromSeconds(2)));
+
+            using var clientCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+            try {
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => EndpointParser.ValidateManyAsync(
+                    urls: new[] { $"http://127.0.0.1:{port}/resolvers.txt" },
+                    cancellationToken: clientCts.Token));
+            } finally {
+                serverCts.Cancel();
+                await serverTask;
             }
         }
 

--- a/DnsClientX.Tests/ResolverCatalogValidationTests.cs
+++ b/DnsClientX.Tests/ResolverCatalogValidationTests.cs
@@ -94,6 +94,29 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
+        /// Ensures unreadable resolver files are reported as invalid sources.
+        /// </summary>
+        [Fact]
+        public async Task ValidateManyAsync_UnreadableFile_ReturnsInvalidResult() {
+            string resolverFile = Path.GetTempFileName();
+            File.WriteAllText(resolverFile, "udp@1.1.1.1:53\r\n");
+
+            try {
+                using var locked = new FileStream(resolverFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+                ResolverEndpointValidationResult[] results = await EndpointParser.ValidateManyAsync(files: new[] { resolverFile });
+
+                ResolverEndpointValidationResult result = Assert.Single(results);
+                Assert.False(result.IsValid);
+                Assert.Equal(resolverFile, result.Source);
+                Assert.Equal(resolverFile, result.Entry);
+                Assert.False(string.IsNullOrWhiteSpace(result.Error));
+            } finally {
+                File.Delete(resolverFile);
+            }
+        }
+
+        /// <summary>
         /// Ensures caller cancellation is not reported as a URL validation error.
         /// </summary>
         [Fact]

--- a/DnsClientX.Tests/ResolverCatalogValidationTests.cs
+++ b/DnsClientX.Tests/ResolverCatalogValidationTests.cs
@@ -117,6 +117,30 @@ namespace DnsClientX.Tests {
         }
 
         /// <summary>
+        /// Ensures malformed resolver file paths are reported per source and do not abort validation.
+        /// </summary>
+        [Fact]
+        public async Task ValidateManyAsync_InvalidFilePath_ReturnsInvalidResultAndContinues() {
+            const string invalidPath = "bad\0path";
+            string resolverFile = Path.GetTempFileName();
+            File.WriteAllText(resolverFile, "udp@1.1.1.1:53\r\n");
+
+            try {
+                ResolverEndpointValidationResult[] results = await EndpointParser.ValidateManyAsync(files: new[] { invalidPath, resolverFile });
+
+                Assert.Equal(2, results.Length);
+                Assert.False(results[0].IsValid);
+                Assert.Equal(invalidPath, results[0].Source);
+                Assert.Equal(invalidPath, results[0].Entry);
+                Assert.False(string.IsNullOrWhiteSpace(results[0].Error));
+                Assert.True(results[1].IsValid);
+                Assert.Equal(resolverFile, results[1].Source);
+            } finally {
+                File.Delete(resolverFile);
+            }
+        }
+
+        /// <summary>
         /// Ensures caller cancellation is not reported as a URL validation error.
         /// </summary>
         [Fact]

--- a/DnsClientX.Tests/ResolverCatalogValidationTests.cs
+++ b/DnsClientX.Tests/ResolverCatalogValidationTests.cs
@@ -26,7 +26,11 @@ namespace DnsClientX.Tests {
         }
 
         private static async Task RunStallingHttpServerAsync(int port, ManualResetEventSlim ready, CancellationToken token) {
+#if NET8_0_OR_GREATER
+            using var listener = new TcpListener(IPAddress.Loopback, port);
+#else
             var listener = new TcpListener(IPAddress.Loopback, port);
+#endif
             listener.Start();
             ready.Set();
 
@@ -57,6 +61,7 @@ namespace DnsClientX.Tests {
                     await Task.Delay(Timeout.Infinite, token);
                 }
             } catch (OperationCanceledException) when (token.IsCancellationRequested) {
+                // Expected during test cleanup after the client-side cancellation path is verified.
             } finally {
                 listener.Stop();
             }

--- a/DnsClientX.Tests/ResolverCatalogValidationTests.cs
+++ b/DnsClientX.Tests/ResolverCatalogValidationTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DnsClientX.Tests {
+    /// <summary>
+    /// Tests resolver catalog validation workflows.
+    /// </summary>
+    [Collection("NoParallel")]
+    public class ResolverCatalogValidationTests {
+        private const string CloudflareStamp = "sdns://AgUAAAAAAAAABzEuMS4xLjEAGm1vemlsbGEuY2xvdWRmbGFyZS1kbnMuY29tCi9kbnMtcXVlcnk";
+
+        private static async Task<int> InvokeCliAsync(params string[] args) {
+            var assembly = Assembly.Load("DnsClientX.Cli");
+            Type programType = assembly.GetType("DnsClientX.Cli.Program")!;
+            MethodInfo main = programType.GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
+            Task<int> task = (Task<int>)main.Invoke(null, new object[] { args })!;
+            return await task;
+        }
+
+        /// <summary>
+        /// Ensures validation preserves file line context for valid and invalid entries.
+        /// </summary>
+        [Fact]
+        public async Task ValidateManyAsync_FileEntries_ReturnsLineContext() {
+            string resolverFile = Path.GetTempFileName();
+            File.WriteAllText(
+                resolverFile,
+                "# comment\r\nudp@1.1.1.1:53,broken endpoint\r\n" + CloudflareStamp + "\r\n");
+
+            try {
+                ResolverEndpointValidationResult[] results = await EndpointParser.ValidateManyAsync(files: new[] { resolverFile });
+
+                Assert.Equal(3, results.Length);
+                Assert.Equal(2, results.Count(result => result.IsValid));
+                Assert.Single(results, result => !result.IsValid);
+                Assert.All(results, result => Assert.Equal(resolverFile, result.Source));
+                Assert.Equal(2, results[0].LineNumber);
+                Assert.Equal(2, results[1].LineNumber);
+                Assert.Equal(3, results[2].LineNumber);
+                Assert.Equal(Transport.Doh, results[2].Endpoint!.Transport);
+            } finally {
+                File.Delete(resolverFile);
+            }
+        }
+
+        /// <summary>
+        /// Ensures CLI validation prints a readable report and exits non-zero when entries are invalid.
+        /// </summary>
+        [Fact]
+        public async Task CliResolverValidate_PrintsTextReport() {
+            string resolverFile = Path.GetTempFileName();
+            File.WriteAllText(resolverFile, "udp@1.1.1.1:53\r\nbroken endpoint\r\n");
+
+            using var output = new StringWriter();
+            TextWriter originalOut = Console.Out;
+            try {
+                Console.SetOut(output);
+
+                int exitCode = await InvokeCliAsync("--resolver-validate", "--resolver-file", resolverFile);
+
+                Assert.Equal(1, exitCode);
+                string text = output.ToString();
+                Assert.Contains("Resolver Validation:", text, StringComparison.Ordinal);
+                Assert.Contains("Valid: 1", text, StringComparison.Ordinal);
+                Assert.Contains("Invalid: 1", text, StringComparison.Ordinal);
+                Assert.Contains("valid", text, StringComparison.Ordinal);
+                Assert.Contains("invalid", text, StringComparison.Ordinal);
+                Assert.Contains(resolverFile + ":2", text, StringComparison.Ordinal);
+            } finally {
+                Console.SetOut(originalOut);
+                File.Delete(resolverFile);
+            }
+        }
+
+        /// <summary>
+        /// Ensures CLI validation emits structured JSON for automation.
+        /// </summary>
+        [Fact]
+        public async Task CliResolverValidate_Json_PrintsStructuredResults() {
+            using var output = new StringWriter();
+            TextWriter originalOut = Console.Out;
+            try {
+                Console.SetOut(output);
+
+                int exitCode = await InvokeCliAsync("--resolver-validate", "--probe-endpoint", CloudflareStamp, "--format", "json");
+
+                Assert.Equal(0, exitCode);
+                string text = output.ToString();
+                Assert.Contains("\"Source\": \"inline\"", text, StringComparison.Ordinal);
+                Assert.Contains("\"IsValid\": true", text, StringComparison.Ordinal);
+                Assert.Contains("\"Transport\": \"Doh\"", text, StringComparison.Ordinal);
+                Assert.Contains("\"Host\": \"mozilla.cloudflare-dns.com\"", text, StringComparison.Ordinal);
+            } finally {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+}

--- a/DnsClientX.Tests/ResolverScoreStoreTests.cs
+++ b/DnsClientX.Tests/ResolverScoreStoreTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Xunit;
 
 namespace DnsClientX.Tests {
@@ -51,6 +53,7 @@ namespace DnsClientX.Tests {
                 ResolverScoreStore.Save(path, snapshot);
                 ResolverScoreSnapshot loaded = ResolverScoreStore.Load(path);
 
+                Assert.Equal(ResolverScoreSnapshot.CurrentSchemaVersion, loaded.SchemaVersion);
                 Assert.Equal(ResolverScoreMode.Benchmark, loaded.Summary.Mode);
                 Assert.True(loaded.Summary.RecommendationAvailable);
                 Assert.Equal("Cloudflare", loaded.Summary.RecommendedTarget);
@@ -62,6 +65,60 @@ namespace DnsClientX.Tests {
             } finally {
                 File.Delete(path);
             }
+        }
+
+        /// <summary>
+        /// Ensures snapshots from future schema versions are rejected with a clear compatibility error.
+        /// </summary>
+        [Fact]
+        public void ResolverScoreStore_LoadFutureSchemaVersion_FailsClearly() {
+            string path = Path.GetTempFileName();
+
+            try {
+                var snapshot = new ResolverScoreSnapshot {
+                    SchemaVersion = ResolverScoreSnapshot.CurrentSchemaVersion + 1,
+                    Summary = new ResolverScoreSummary {
+                        Mode = ResolverScoreMode.Probe,
+                        RecommendationAvailable = true,
+                        RecommendedTarget = "Cloudflare"
+                    }
+                };
+                var serializerOptions = new JsonSerializerOptions {
+                    WriteIndented = true,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                };
+                serializerOptions.Converters.Add(new JsonStringEnumConverter());
+                File.WriteAllText(path, JsonSerializer.Serialize(snapshot, serializerOptions));
+
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => ResolverScoreStore.Load(path));
+
+                Assert.Contains("newer DnsClientX release", exception.Message, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains((ResolverScoreSnapshot.CurrentSchemaVersion + 1).ToString(), exception.Message, StringComparison.Ordinal);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        /// <summary>
+        /// Ensures resolver selection checks snapshot compatibility before attempting recommendation reuse.
+        /// </summary>
+        [Fact]
+        public void ResolverScoreSelector_FutureSchemaVersion_FailsBeforeSelection() {
+            bool selected = ResolverScoreSelector.TrySelectRecommended(
+                new ResolverScoreSnapshot {
+                    SchemaVersion = ResolverScoreSnapshot.CurrentSchemaVersion + 1,
+                    Summary = new ResolverScoreSummary {
+                        Mode = ResolverScoreMode.Benchmark,
+                        RecommendationAvailable = true,
+                        RecommendedTarget = "Cloudflare"
+                    }
+                },
+                out ResolverSelectionResult? selection,
+                out string? error);
+
+            Assert.False(selected);
+            Assert.Null(selection);
+            Assert.Contains("newer DnsClientX release", error, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/DnsClientX.Tests/TcpCleanupRegressionTests.cs
+++ b/DnsClientX.Tests/TcpCleanupRegressionTests.cs
@@ -39,16 +39,17 @@ namespace DnsClientX.Tests {
         }
 
         private static async Task<bool> HasOpenTcpConnectionAsync(int port) {
-            if (IsWindows()) {
-                try {
-                    var connTask = Task.Run(() => IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections());
-                    if (await Task.WhenAny(connTask, Task.Delay(2000)) == connTask) {
-                        var connections = connTask.Result;
-                        return connections.Any(c => (c.LocalEndPoint.Port == port || c.RemoteEndPoint.Port == port) && c.State != TcpState.TimeWait && c.State != TcpState.Closed);
-                    }
-                } catch {
-                    // fall back to netstat
+            try {
+                var connTask = Task.Run(() => IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections());
+                if (await Task.WhenAny(connTask, Task.Delay(2000)) == connTask) {
+                    var connections = connTask.Result;
+                    return connections.Any(c =>
+                        (c.LocalEndPoint.Port == port || c.RemoteEndPoint.Port == port) &&
+                        c.State != TcpState.TimeWait &&
+                        c.State != TcpState.Closed);
                 }
+            } catch {
+                // fall back to netstat
             }
 
             try {
@@ -67,7 +68,12 @@ namespace DnsClientX.Tests {
                     if (!proc.HasExited) {
                         try { proc.Kill(); } catch { }
                     }
-                    return output.Contains($":{port}");
+
+                    return output
+                        .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                        .Any(line =>
+                            line.Contains($":{port}") &&
+                            !line.Contains("TIME_WAIT", StringComparison.OrdinalIgnoreCase));
                 } else {
                     try { proc.Kill(); } catch { }
                 }

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -127,6 +127,10 @@ namespace DnsClientX {
                     WriteLengthPrefixed(stream, BuildAddress(endpoint, 53));
                     break;
                 case Transport.Doh:
+                    if (endpoint.RequestFormat == DnsRequestFormat.DnsOverHttp3) {
+                        throw new NotSupportedException("DNS stamps do not support DNS-over-HTTP/3 endpoints.");
+                    }
+
                     stream.WriteByte(0x02);
                     WriteProperties(stream, endpoint);
                     WriteLengthPrefixed(stream, string.Empty);

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -62,14 +62,15 @@ namespace DnsClientX {
                 return false;
             }
 
-            if (!stamp.StartsWith(Scheme, StringComparison.OrdinalIgnoreCase)) {
+            string value = stamp!;
+            if (!value.StartsWith(Scheme, StringComparison.OrdinalIgnoreCase)) {
                 error = "DNS stamp must start with sdns://.";
                 return false;
             }
 
             byte[] payload;
             try {
-                payload = DecodeBase64Url(stamp.Substring(Scheme.Length));
+                payload = DecodeBase64Url(value.Substring(Scheme.Length));
             } catch (FormatException ex) {
                 error = $"DNS stamp payload is not valid base64url: {ex.Message}";
                 return false;
@@ -189,14 +190,14 @@ namespace DnsClientX {
             }
 
             (string hostName, int port, AddressFamily? family) = SplitHostPort(host, 443);
-            var builder = new UriBuilder(Uri.UriSchemeHttps, hostName, port, path);
+            Uri dohUrl = BuildDohUri(hostName, port, path);
             return new DnsResolverEndpoint {
                 Transport = Transport.Doh,
                 RequestFormat = DnsRequestFormat.DnsOverHttps,
                 Host = hostName,
                 Port = port,
                 Family = family,
-                DohUrl = builder.Uri,
+                DohUrl = dohUrl,
                 DnsSecOk = HasDnsSec(properties) ? true : null
             };
         }
@@ -250,10 +251,9 @@ namespace DnsClientX {
                 }
 
                 host = trimmed.Substring(1, end - 1);
-                if (trimmed.Length > end + 1) {
-                    if (trimmed[end + 1] != ':' || !int.TryParse(trimmed.Substring(end + 2), out port)) {
-                        throw new FormatException($"Invalid port in endpoint: {value}");
-                    }
+                if (trimmed.Length > end + 1 &&
+                    (trimmed[end + 1] != ':' || !int.TryParse(trimmed.Substring(end + 2), out port))) {
+                    throw new FormatException($"Invalid port in endpoint: {value}");
                 }
             } else {
                 int separator = trimmed.LastIndexOf(':');
@@ -277,6 +277,18 @@ namespace DnsClientX {
             }
 
             return (host, port, family);
+        }
+
+        private static Uri BuildDohUri(string host, int port, string pathAndQuery) {
+            int queryIndex = pathAndQuery.IndexOf('?');
+            string path = queryIndex >= 0 ? pathAndQuery.Substring(0, queryIndex) : pathAndQuery;
+            string? query = queryIndex >= 0 ? pathAndQuery.Substring(queryIndex + 1) : null;
+            var builder = new UriBuilder(Uri.UriSchemeHttps, host, port, path);
+            if (query != null) {
+                builder.Query = query;
+            }
+
+            return builder.Uri;
         }
 
         private static string BuildAddress(DnsResolverEndpoint endpoint, int defaultPort) {
@@ -402,6 +414,10 @@ namespace DnsClientX {
 
             internal void ReadBootstrapAddresses() {
                 foreach (byte[] value in ReadVariableLengthSet("bootstrap address")) {
+                    if (value.Length == 0) {
+                        continue;
+                    }
+
                     string address = Encoding.UTF8.GetString(value, 0, value.Length);
                     EnsureAddress(address, allowEmpty: false);
                 }

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -368,9 +368,10 @@ namespace DnsClientX {
 
         private static void WriteDohHostAndPath(Stream stream, DnsResolverEndpoint endpoint) {
             Uri uri = EndpointParser.BuildDohUri(endpoint);
+            string formattedHost = FormatHost(uri.Host);
             string host = uri.IsDefaultPort || uri.Port == 443
-                ? uri.Host
-                : $"{uri.Host}:{uri.Port}";
+                ? formattedHost
+                : $"{formattedHost}:{uri.Port}";
             string path = string.IsNullOrEmpty(uri.PathAndQuery) ? "/dns-query" : uri.PathAndQuery;
             WriteLengthPrefixed(stream, host);
             WriteLengthPrefixed(stream, path);

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -191,6 +191,10 @@ namespace DnsClientX {
             }
 
             (string hostName, int port, AddressFamily? family) = SplitHostPort(host, 443);
+            if (!HasExplicitPort(host) && TryGetExplicitPort(address, out int addressPort)) {
+                port = addressPort;
+            }
+
             Uri dohUrl = BuildDohUri(hostName, port, path);
             return new DnsResolverEndpoint {
                 Transport = Transport.Doh,
@@ -221,16 +225,21 @@ namespace DnsClientX {
                 throw new FormatException("DNS stamp hostname or address is required.");
             }
 
-            return EndpointFromAddress(endpointValue, transport, requestFormat, defaultPort, properties);
+            int? portOverride = !string.IsNullOrWhiteSpace(host) &&
+                                !HasExplicitPort(host) &&
+                                TryGetExplicitPort(address, out int addressPort)
+                ? addressPort
+                : null;
+            return EndpointFromAddress(endpointValue, transport, requestFormat, defaultPort, properties, portOverride);
         }
 
-        private static DnsResolverEndpoint EndpointFromAddress(string value, Transport transport, DnsRequestFormat requestFormat, int defaultPort, ulong properties) {
+        private static DnsResolverEndpoint EndpointFromAddress(string value, Transport transport, DnsRequestFormat requestFormat, int defaultPort, ulong properties, int? portOverride = null) {
             (string host, int port, AddressFamily? family) = SplitHostPort(value, defaultPort);
             return new DnsResolverEndpoint {
                 Transport = transport,
                 RequestFormat = requestFormat,
                 Host = host,
-                Port = port,
+                Port = portOverride ?? port,
                 Family = family,
                 DnsSecOk = HasDnsSec(properties) ? true : null
             };
@@ -278,6 +287,33 @@ namespace DnsClientX {
             }
 
             return (host, port, family);
+        }
+
+        private static bool HasExplicitPort(string value) => TryGetExplicitPort(value, out _);
+
+        private static bool TryGetExplicitPort(string value, out int port) {
+            port = 0;
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+
+            string trimmed = value.Trim();
+            if (trimmed.StartsWith("[", StringComparison.Ordinal)) {
+                int end = trimmed.IndexOf(']');
+                return end > 1 &&
+                       trimmed.Length > end + 1 &&
+                       trimmed[end + 1] == ':' &&
+                       int.TryParse(trimmed.Substring(end + 2), out port) &&
+                       port >= 1 &&
+                       port <= 65535;
+            }
+
+            int separator = trimmed.LastIndexOf(':');
+            return separator > 0 &&
+                   trimmed.IndexOf(':') == separator &&
+                   int.TryParse(trimmed.Substring(separator + 1), out port) &&
+                   port >= 1 &&
+                   port <= 65535;
         }
 
         private static Uri BuildDohUri(string host, int port, string pathAndQuery) {
@@ -406,7 +442,7 @@ namespace DnsClientX {
             }
 
             internal void ReadHashes() {
-                foreach (byte[] hash in ReadVariableLengthSet("certificate hash").Where(static hash => hash.Length != 0 && hash.Length != 32)) {
+                if (ReadVariableLengthSet("certificate hash").Any(static hash => hash.Length != 0 && hash.Length != 32)) {
                     throw new FormatException("Certificate hashes in DNS stamps must be 32 bytes.");
                 }
             }

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Generic;
+using System.Buffers.Binary;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Parses and creates DNS stamps for endpoint formats supported by DnsClientX.
+    /// </summary>
+    public static class DnsStamp {
+        private const string Scheme = "sdns://";
+
+        /// <summary>
+        /// Parses a DNS stamp into a resolver endpoint.
+        /// </summary>
+        /// <param name="stamp">The DNS stamp string.</param>
+        /// <returns>The parsed resolver endpoint.</returns>
+        public static DnsResolverEndpoint Parse(string stamp) {
+            if (!TryParse(stamp, out DnsResolverEndpoint? endpoint, out string? error)) {
+                throw new FormatException(error ?? "Invalid DNS stamp.");
+            }
+
+            return endpoint!;
+        }
+
+        /// <summary>
+        /// Parses a DNS stamp into a user-facing description.
+        /// </summary>
+        /// <param name="stamp">The DNS stamp string.</param>
+        /// <returns>Parsed stamp information.</returns>
+        public static DnsStampInfo Describe(string stamp) {
+            DnsResolverEndpoint endpoint = Parse(stamp);
+            return new DnsStampInfo {
+                Stamp = stamp,
+                NormalizedStamp = Create(endpoint),
+                Endpoint = endpoint,
+                Transport = endpoint.Transport,
+                RequestFormat = endpoint.RequestFormat,
+                Host = endpoint.Host,
+                Port = endpoint.Port,
+                DohUrl = endpoint.DohUrl,
+                DnsSecOk = endpoint.DnsSecOk == true
+            };
+        }
+
+        /// <summary>
+        /// Attempts to parse a DNS stamp into a resolver endpoint.
+        /// </summary>
+        /// <param name="stamp">The DNS stamp string.</param>
+        /// <param name="endpoint">The parsed endpoint when successful.</param>
+        /// <param name="error">A descriptive error when parsing fails.</param>
+        /// <returns><c>true</c> when the stamp is supported and valid.</returns>
+        public static bool TryParse(string? stamp, out DnsResolverEndpoint? endpoint, out string? error) {
+            endpoint = null;
+            error = null;
+
+            if (string.IsNullOrWhiteSpace(stamp)) {
+                error = "DNS stamp is empty.";
+                return false;
+            }
+
+            if (!stamp.StartsWith(Scheme, StringComparison.OrdinalIgnoreCase)) {
+                error = "DNS stamp must start with sdns://.";
+                return false;
+            }
+
+            byte[] payload;
+            try {
+                payload = DecodeBase64Url(stamp.Substring(Scheme.Length));
+            } catch (FormatException ex) {
+                error = $"DNS stamp payload is not valid base64url: {ex.Message}";
+                return false;
+            }
+
+            if (payload.Length == 0) {
+                error = "DNS stamp payload is empty.";
+                return false;
+            }
+
+            var reader = new StampReader(payload);
+            byte protocol = reader.ReadByte();
+            try {
+                endpoint = protocol switch {
+                    0x00 => ParsePlainDns(reader),
+                    0x02 => ParseDoh(reader),
+                    0x03 => ParseTlsLike(reader, Transport.Dot, DnsRequestFormat.DnsOverTLS, 853),
+                    0x04 => ParseTlsLike(reader, Transport.Quic, DnsRequestFormat.DnsOverQuic, 853),
+                    0x01 => throw new NotSupportedException("DNSCrypt stamps are not supported by the core resolver endpoint model."),
+                    0x05 => throw new NotSupportedException("Oblivious DoH target stamps are not supported by the core resolver endpoint model."),
+                    0x81 => throw new NotSupportedException("Anonymized DNSCrypt relay stamps are not supported by the core resolver endpoint model."),
+                    0x85 => throw new NotSupportedException("Oblivious DoH relay stamps are not supported by the core resolver endpoint model."),
+                    _ => throw new FormatException($"Unsupported DNS stamp protocol identifier 0x{protocol:X2}.")
+                };
+
+                if (!reader.EndOfPayload) {
+                    throw new FormatException("DNS stamp contains trailing data.");
+                }
+
+                return true;
+            } catch (Exception ex) when (ex is FormatException || ex is NotSupportedException || ex is ArgumentException) {
+                endpoint = null;
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Creates a DNS stamp for a supported resolver endpoint.
+        /// </summary>
+        /// <param name="endpoint">The endpoint to encode.</param>
+        /// <returns>A DNS stamp string.</returns>
+        public static string Create(DnsResolverEndpoint endpoint) {
+            if (endpoint == null) {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
+            using var stream = new MemoryStream();
+            switch (endpoint.Transport) {
+                case Transport.Udp:
+                    stream.WriteByte(0x00);
+                    WriteProperties(stream, endpoint);
+                    WriteLengthPrefixed(stream, BuildAddress(endpoint, 53));
+                    break;
+                case Transport.Doh:
+                    stream.WriteByte(0x02);
+                    WriteProperties(stream, endpoint);
+                    WriteLengthPrefixed(stream, string.Empty);
+                    WriteEmptyVariableLengthSet(stream);
+                    WriteDohHostAndPath(stream, endpoint);
+                    break;
+                case Transport.Dot:
+                    stream.WriteByte(0x03);
+                    WriteProperties(stream, endpoint);
+                    WriteLengthPrefixed(stream, string.Empty);
+                    WriteEmptyVariableLengthSet(stream);
+                    WriteLengthPrefixed(stream, BuildHostWithPort(endpoint, 853));
+                    break;
+                case Transport.Quic:
+                    stream.WriteByte(0x04);
+                    WriteProperties(stream, endpoint);
+                    WriteLengthPrefixed(stream, string.Empty);
+                    WriteEmptyVariableLengthSet(stream);
+                    WriteLengthPrefixed(stream, BuildHostWithPort(endpoint, 853));
+                    break;
+                default:
+                    throw new NotSupportedException($"DNS stamps cannot be generated for transport {endpoint.Transport}.");
+            }
+
+            return Scheme + EncodeBase64Url(stream.ToArray());
+        }
+
+        /// <summary>
+        /// Returns whether a string looks like a DNS stamp.
+        /// </summary>
+        /// <param name="value">Input value.</param>
+        /// <returns><c>true</c> when the value starts with the DNS stamp scheme.</returns>
+        public static bool IsStamp(string? value) => value?.StartsWith(Scheme, StringComparison.OrdinalIgnoreCase) == true;
+
+        private static DnsResolverEndpoint ParsePlainDns(StampReader reader) {
+            ulong properties = reader.ReadProperties();
+            string address = reader.ReadLengthPrefixedString("address");
+            reader.EnsureAddress(address, allowEmpty: false);
+            return EndpointFromAddress(address, Transport.Udp, DnsRequestFormat.DnsOverUDP, 53, properties);
+        }
+
+        private static DnsResolverEndpoint ParseDoh(StampReader reader) {
+            ulong properties = reader.ReadProperties();
+            string address = reader.ReadLengthPrefixedString("address");
+            if (!string.IsNullOrEmpty(address)) {
+                reader.EnsureAddress(address, allowEmpty: false);
+            }
+
+            reader.ReadHashes();
+            string host = reader.ReadLengthPrefixedString("hostname");
+            string path = reader.ReadLengthPrefixedString("path");
+            if (reader.HasRemaining) {
+                reader.ReadBootstrapAddresses();
+            }
+
+            if (string.IsNullOrWhiteSpace(host)) {
+                throw new FormatException("DoH stamp hostname is required.");
+            }
+
+            if (string.IsNullOrEmpty(path) || !path.StartsWith("/", StringComparison.Ordinal)) {
+                throw new FormatException("DoH stamp path must start with '/'.");
+            }
+
+            (string hostName, int port, AddressFamily? family) = SplitHostPort(host, 443);
+            var builder = new UriBuilder(Uri.UriSchemeHttps, hostName, port, path);
+            return new DnsResolverEndpoint {
+                Transport = Transport.Doh,
+                RequestFormat = DnsRequestFormat.DnsOverHttps,
+                Host = hostName,
+                Port = port,
+                Family = family,
+                DohUrl = builder.Uri,
+                DnsSecOk = HasDnsSec(properties) ? true : null
+            };
+        }
+
+        private static DnsResolverEndpoint ParseTlsLike(StampReader reader, Transport transport, DnsRequestFormat requestFormat, int defaultPort) {
+            ulong properties = reader.ReadProperties();
+            string address = reader.ReadLengthPrefixedString("address");
+            if (!string.IsNullOrEmpty(address)) {
+                reader.EnsureAddress(address, allowEmpty: false);
+            }
+
+            reader.ReadHashes();
+            string host = reader.ReadLengthPrefixedString("hostname");
+            if (reader.HasRemaining) {
+                reader.ReadBootstrapAddresses();
+            }
+
+            string endpointValue = string.IsNullOrWhiteSpace(host) ? address : host;
+            if (string.IsNullOrWhiteSpace(endpointValue)) {
+                throw new FormatException("DNS stamp hostname or address is required.");
+            }
+
+            return EndpointFromAddress(endpointValue, transport, requestFormat, defaultPort, properties);
+        }
+
+        private static DnsResolverEndpoint EndpointFromAddress(string value, Transport transport, DnsRequestFormat requestFormat, int defaultPort, ulong properties) {
+            (string host, int port, AddressFamily? family) = SplitHostPort(value, defaultPort);
+            return new DnsResolverEndpoint {
+                Transport = transport,
+                RequestFormat = requestFormat,
+                Host = host,
+                Port = port,
+                Family = family,
+                DnsSecOk = HasDnsSec(properties) ? true : null
+            };
+        }
+
+        private static (string Host, int Port, AddressFamily? Family) SplitHostPort(string value, int defaultPort) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                throw new FormatException("Endpoint host is required.");
+            }
+
+            string host;
+            int port = defaultPort;
+            string trimmed = value.Trim();
+
+            if (trimmed.StartsWith("[", StringComparison.Ordinal)) {
+                int end = trimmed.IndexOf(']');
+                if (end <= 1) {
+                    throw new FormatException($"Invalid IPv6 endpoint: {value}");
+                }
+
+                host = trimmed.Substring(1, end - 1);
+                if (trimmed.Length > end + 1) {
+                    if (trimmed[end + 1] != ':' || !int.TryParse(trimmed.Substring(end + 2), out port)) {
+                        throw new FormatException($"Invalid port in endpoint: {value}");
+                    }
+                }
+            } else {
+                int separator = trimmed.LastIndexOf(':');
+                if (separator > 0 && trimmed.IndexOf(':') == separator) {
+                    host = trimmed.Substring(0, separator);
+                    if (!int.TryParse(trimmed.Substring(separator + 1), out port)) {
+                        throw new FormatException($"Invalid port in endpoint: {value}");
+                    }
+                } else {
+                    host = trimmed;
+                }
+            }
+
+            if (port < 1 || port > 65535) {
+                throw new FormatException($"Invalid port in endpoint: {value}");
+            }
+
+            AddressFamily? family = null;
+            if (IPAddress.TryParse(host, out IPAddress? address)) {
+                family = address.AddressFamily;
+            }
+
+            return (host, port, family);
+        }
+
+        private static string BuildAddress(DnsResolverEndpoint endpoint, int defaultPort) {
+            if (string.IsNullOrWhiteSpace(endpoint.Host)) {
+                throw new ArgumentException("DNS stamp endpoint requires Host.", nameof(endpoint));
+            }
+
+            string host = FormatHost(endpoint.Host!);
+            string hostForValidation = host.Trim('[', ']');
+            if (!IPAddress.TryParse(hostForValidation, out _)) {
+                throw new ArgumentException("Plain DNS stamp endpoints require an IP address host.", nameof(endpoint));
+            }
+
+            return endpoint.Port > 0 && endpoint.Port != defaultPort
+                ? $"{host}:{endpoint.Port}"
+                : host;
+        }
+
+        private static string BuildHostWithPort(DnsResolverEndpoint endpoint, int defaultPort) {
+            if (string.IsNullOrWhiteSpace(endpoint.Host)) {
+                throw new ArgumentException("DNS stamp endpoint requires Host.", nameof(endpoint));
+            }
+
+            string host = FormatHost(endpoint.Host!);
+            return endpoint.Port > 0 && endpoint.Port != defaultPort
+                ? $"{host}:{endpoint.Port}"
+                : host;
+        }
+
+        private static string FormatHost(string host) {
+            if (IPAddress.TryParse(host, out IPAddress? address) &&
+                address.AddressFamily == AddressFamily.InterNetworkV6 &&
+                !host.StartsWith("[", StringComparison.Ordinal) &&
+                !host.EndsWith("]", StringComparison.Ordinal)) {
+                return $"[{host}]";
+            }
+
+            return host;
+        }
+
+        private static void WriteDohHostAndPath(Stream stream, DnsResolverEndpoint endpoint) {
+            Uri uri = EndpointParser.BuildDohUri(endpoint);
+            string host = uri.IsDefaultPort || uri.Port == 443
+                ? uri.Host
+                : $"{uri.Host}:{uri.Port}";
+            string path = string.IsNullOrEmpty(uri.PathAndQuery) ? "/dns-query" : uri.PathAndQuery;
+            WriteLengthPrefixed(stream, host);
+            WriteLengthPrefixed(stream, path);
+        }
+
+        private static void WriteProperties(Stream stream, DnsResolverEndpoint endpoint) {
+            ulong properties = endpoint.DnsSecOk == true ? 1UL : 0UL;
+            Span<byte> buffer = stackalloc byte[8];
+            BinaryPrimitives.WriteUInt64LittleEndian(buffer, properties);
+            stream.Write(buffer.ToArray(), 0, buffer.Length);
+        }
+
+        private static void WriteLengthPrefixed(Stream stream, string value) {
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            if (bytes.Length > byte.MaxValue) {
+                throw new ArgumentException("DNS stamp fields cannot exceed 255 bytes.");
+            }
+
+            stream.WriteByte((byte)bytes.Length);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static void WriteEmptyVariableLengthSet(Stream stream) {
+            stream.WriteByte(0);
+        }
+
+        private static bool HasDnsSec(ulong properties) => (properties & 1UL) != 0;
+
+        private static byte[] DecodeBase64Url(string value) {
+            string base64 = value.Replace('-', '+').Replace('_', '/');
+            base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
+            return Convert.FromBase64String(base64);
+        }
+
+        private static string EncodeBase64Url(byte[] value) {
+            return Convert.ToBase64String(value)
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
+        }
+
+        private sealed class StampReader {
+            private readonly byte[] _payload;
+            private int _offset;
+
+            internal StampReader(byte[] payload) {
+                _payload = payload;
+            }
+
+            internal bool EndOfPayload => _offset == _payload.Length;
+
+            internal bool HasRemaining => _offset < _payload.Length;
+
+            internal byte ReadByte() {
+                EnsureRemaining(1, "byte");
+                return _payload[_offset++];
+            }
+
+            internal ulong ReadProperties() {
+                EnsureRemaining(8, "properties");
+                ulong value = BinaryPrimitives.ReadUInt64LittleEndian(_payload.AsSpan(_offset, 8));
+                _offset += 8;
+                return value;
+            }
+
+            internal string ReadLengthPrefixedString(string fieldName) {
+                byte[] bytes = ReadLengthPrefixed(fieldName);
+                return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+            }
+
+            internal void ReadHashes() {
+                foreach (byte[] hash in ReadVariableLengthSet("certificate hash")) {
+                    if (hash.Length != 0 && hash.Length != 32) {
+                        throw new FormatException("Certificate hashes in DNS stamps must be 32 bytes.");
+                    }
+                }
+            }
+
+            internal void ReadBootstrapAddresses() {
+                foreach (byte[] value in ReadVariableLengthSet("bootstrap address")) {
+                    string address = Encoding.UTF8.GetString(value, 0, value.Length);
+                    EnsureAddress(address, allowEmpty: false);
+                }
+            }
+
+            internal void EnsureAddress(string value, bool allowEmpty) {
+                if (string.IsNullOrEmpty(value)) {
+                    if (allowEmpty) {
+                        return;
+                    }
+
+                    throw new FormatException("DNS stamp address is required.");
+                }
+
+                (string host, _, _) = SplitHostPort(value, 53);
+                if (!IPAddress.TryParse(host, out _)) {
+                    throw new FormatException($"Invalid DNS stamp address: {value}");
+                }
+            }
+
+            private IEnumerable<byte[]> ReadVariableLengthSet(string fieldName) {
+                while (true) {
+                    byte lengthByte = ReadByte();
+                    bool hasMore = (lengthByte & 0x80) != 0;
+                    int length = lengthByte & 0x7F;
+                    EnsureRemaining(length, fieldName);
+
+                    byte[] value = new byte[length];
+                    Array.Copy(_payload, _offset, value, 0, length);
+                    _offset += length;
+                    yield return value;
+
+                    if (!hasMore) {
+                        break;
+                    }
+                }
+            }
+
+            private byte[] ReadLengthPrefixed(string fieldName) {
+                int length = ReadByte();
+                EnsureRemaining(length, fieldName);
+
+                byte[] value = new byte[length];
+                Array.Copy(_payload, _offset, value, 0, length);
+                _offset += length;
+                return value;
+            }
+
+            private void EnsureRemaining(int length, string fieldName) {
+                if (_offset + length > _payload.Length) {
+                    throw new FormatException($"DNS stamp has a truncated {fieldName} field.");
+                }
+            }
+        }
+    }
+}

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Buffers.Binary;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -405,10 +406,8 @@ namespace DnsClientX {
             }
 
             internal void ReadHashes() {
-                foreach (byte[] hash in ReadVariableLengthSet("certificate hash")) {
-                    if (hash.Length != 0 && hash.Length != 32) {
-                        throw new FormatException("Certificate hashes in DNS stamps must be 32 bytes.");
-                    }
+                foreach (byte[] hash in ReadVariableLengthSet("certificate hash").Where(static hash => hash.Length != 0 && hash.Length != 32)) {
+                    throw new FormatException("Certificate hashes in DNS stamps must be 32 bytes.");
                 }
             }
 

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -351,8 +351,8 @@ namespace DnsClientX {
         }
 
         private static void ValidateEndpointPort(DnsResolverEndpoint endpoint) {
-            if (endpoint.Port < 0 || endpoint.Port > 65535) {
-                throw new ArgumentOutOfRangeException(nameof(endpoint), endpoint.Port, "DNS stamp endpoint port must be between 0 and 65535.");
+            if (endpoint.Port < 1 || endpoint.Port > 65535) {
+                throw new ArgumentOutOfRangeException(nameof(endpoint), endpoint.Port, "DNS stamp endpoint port must be between 1 and 65535.");
             }
         }
 
@@ -461,13 +461,8 @@ namespace DnsClientX {
             }
 
             internal void ReadBootstrapAddresses() {
-                foreach (byte[] value in ReadVariableLengthSet("bootstrap address")) {
-                    if (value.Length == 0) {
-                        continue;
-                    }
-
-                    string address = Encoding.UTF8.GetString(value, 0, value.Length);
-                    EnsureAddress(address, allowEmpty: false);
+                if (ReadVariableLengthSet("bootstrap address").Any(static value => value.Length != 0)) {
+                    throw new NotSupportedException("Bootstrap addresses in DNS stamps are not supported by the core resolver endpoint model.");
                 }
             }
 

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -119,6 +119,8 @@ namespace DnsClientX {
                 throw new ArgumentNullException(nameof(endpoint));
             }
 
+            ValidateEndpointPort(endpoint);
+
             using var stream = new MemoryStream();
             switch (endpoint.Transport) {
                 case Transport.Udp:
@@ -346,6 +348,12 @@ namespace DnsClientX {
             return endpoint.Port > 0 && endpoint.Port != defaultPort
                 ? $"{host}:{endpoint.Port}"
                 : host;
+        }
+
+        private static void ValidateEndpointPort(DnsResolverEndpoint endpoint) {
+            if (endpoint.Port < 0 || endpoint.Port > 65535) {
+                throw new ArgumentOutOfRangeException(nameof(endpoint), endpoint.Port, "DNS stamp endpoint port must be between 0 and 65535.");
+            }
         }
 
         private static string BuildHostWithPort(DnsResolverEndpoint endpoint, int defaultPort) {

--- a/DnsClientX/DnsStamp.cs
+++ b/DnsClientX/DnsStamp.cs
@@ -447,8 +447,8 @@ namespace DnsClientX {
             }
 
             internal void ReadHashes() {
-                if (ReadVariableLengthSet("certificate hash").Any(static hash => hash.Length != 0 && hash.Length != 32)) {
-                    throw new FormatException("Certificate hashes in DNS stamps must be 32 bytes.");
+                if (ReadVariableLengthSet("certificate hash").Any(static hash => hash.Length != 0)) {
+                    throw new NotSupportedException("Certificate hashes in DNS stamps are not supported by the core resolver endpoint model.");
                 }
             }
 

--- a/DnsClientX/DnsStampInfo.cs
+++ b/DnsClientX/DnsStampInfo.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace DnsClientX {
+    /// <summary>
+    /// Describes a parsed DNS stamp in a user-facing shape.
+    /// </summary>
+    public sealed class DnsStampInfo {
+        /// <summary>
+        /// Original DNS stamp input.
+        /// </summary>
+        public string Stamp { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Normalized DNS stamp generated from the parsed endpoint.
+        /// </summary>
+        public string NormalizedStamp { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Parsed resolver endpoint.
+        /// </summary>
+        public DnsResolverEndpoint Endpoint { get; init; } = new DnsResolverEndpoint();
+
+        /// <summary>
+        /// Transport represented by the stamp.
+        /// </summary>
+        public Transport Transport { get; init; }
+
+        /// <summary>
+        /// Request format represented by the stamp.
+        /// </summary>
+        public DnsRequestFormat? RequestFormat { get; init; }
+
+        /// <summary>
+        /// Hostname or IP address represented by the stamp.
+        /// </summary>
+        public string? Host { get; init; }
+
+        /// <summary>
+        /// Port represented by the stamp.
+        /// </summary>
+        public int Port { get; init; }
+
+        /// <summary>
+        /// DNS-over-HTTPS URI when the stamp represents DoH.
+        /// </summary>
+        public Uri? DohUrl { get; init; }
+
+        /// <summary>
+        /// Indicates whether the DNSSEC property is set in the stamp.
+        /// </summary>
+        public bool DnsSecOk { get; init; }
+    }
+}

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -162,18 +162,18 @@ namespace DnsClientX {
                     continue;
                 }
 
-                FileInfo fileInfo = new FileInfo(fullPath);
-                if (fileInfo.Length > MaxImportedContentBytes) {
-                    results.Add(new ResolverEndpointValidationResult {
-                        Source = fullPath,
-                        Entry = fileEntry ?? string.Empty,
-                        IsValid = false,
-                        Error = $"Resolver file exceeds the {MaxImportedContentBytes} byte import limit: {fileEntry}"
-                    });
-                    continue;
-                }
-
                 try {
+                    FileInfo fileInfo = new FileInfo(fullPath);
+                    if (fileInfo.Length > MaxImportedContentBytes) {
+                        results.Add(new ResolverEndpointValidationResult {
+                            Source = fullPath,
+                            Entry = fileEntry ?? string.Empty,
+                            IsValid = false,
+                            Error = $"Resolver file exceeds the {MaxImportedContentBytes} byte import limit: {fileEntry}"
+                        });
+                        continue;
+                    }
+
                     using var reader = File.OpenText(fullPath);
                     string content = await reader.ReadToEndAsync().ConfigureAwait(false);
                     results.AddRange(ValidateImportedContent(content, fullPath));

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -112,6 +112,114 @@ namespace DnsClientX {
         }
 
         /// <summary>
+        /// Validates resolver endpoint inputs from inline entries, files, and URLs while preserving source context.
+        /// </summary>
+        /// <param name="inputs">Inline resolver endpoint values.</param>
+        /// <param name="files">Text files containing resolver endpoint entries.</param>
+        /// <param name="urls">HTTP or HTTPS URLs containing resolver endpoint entries.</param>
+        /// <param name="cancellationToken">Cancellation token used for file and network loading.</param>
+        /// <returns>Validation results for every discovered entry.</returns>
+        public static async Task<ResolverEndpointValidationResult[]> ValidateManyAsync(
+            IEnumerable<string>? inputs = null,
+            IEnumerable<string>? files = null,
+            IEnumerable<string>? urls = null,
+            CancellationToken cancellationToken = default) {
+            var results = new List<ResolverEndpointValidationResult>();
+
+            foreach (string? input in inputs ?? Array.Empty<string>()) {
+                string trimmed = input?.Trim() ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(trimmed)) {
+                    results.Add(ValidateEntry(trimmed, "inline", null));
+                }
+            }
+
+            foreach (string? fileEntry in files ?? Array.Empty<string>()) {
+                cancellationToken.ThrowIfCancellationRequested();
+                string filePath = fileEntry?.Trim() ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(filePath)) {
+                    continue;
+                }
+
+                string fullPath = Path.GetFullPath(filePath);
+                if (!File.Exists(fullPath)) {
+                    results.Add(new ResolverEndpointValidationResult {
+                        Source = fileEntry ?? string.Empty,
+                        Entry = fileEntry ?? string.Empty,
+                        IsValid = false,
+                        Error = $"Resolver file not found: {fileEntry}"
+                    });
+                    continue;
+                }
+
+                FileInfo fileInfo = new FileInfo(fullPath);
+                if (fileInfo.Length > MaxImportedContentBytes) {
+                    results.Add(new ResolverEndpointValidationResult {
+                        Source = fullPath,
+                        Entry = fileEntry ?? string.Empty,
+                        IsValid = false,
+                        Error = $"Resolver file exceeds the {MaxImportedContentBytes} byte import limit: {fileEntry}"
+                    });
+                    continue;
+                }
+
+                using var reader = File.OpenText(fullPath);
+                string content = await reader.ReadToEndAsync().ConfigureAwait(false);
+                results.AddRange(ValidateImportedContent(content, fullPath));
+            }
+
+            string[] urlEntries = (urls ?? Array.Empty<string>())
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Select(value => value.Trim())
+                .ToArray();
+
+            if (urlEntries.Length > 0) {
+                using var httpClient = new HttpClient {
+                    Timeout = ImportHttpTimeout
+                };
+
+                foreach (string urlEntry in urlEntries) {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (!Uri.TryCreate(urlEntry, UriKind.Absolute, out Uri? uri) ||
+                        (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)) {
+                        results.Add(new ResolverEndpointValidationResult {
+                            Source = urlEntry,
+                            Entry = urlEntry,
+                            IsValid = false,
+                            Error = $"Invalid resolver URL: {urlEntry}"
+                        });
+                        continue;
+                    }
+
+                    try {
+                        using HttpResponseMessage response = await httpClient.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+                        if (!response.IsSuccessStatusCode) {
+                            results.Add(new ResolverEndpointValidationResult {
+                                Source = urlEntry,
+                                Entry = urlEntry,
+                                IsValid = false,
+                                Error = $"Resolver URL returned HTTP {(int)response.StatusCode}: {urlEntry}"
+                            });
+                            continue;
+                        }
+
+                        string content = await ReadContentWithLimitAsync(response, cancellationToken).ConfigureAwait(false);
+                        results.AddRange(ValidateImportedContent(content, urlEntry));
+                    } catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException || ex is InvalidOperationException) {
+                        results.Add(new ResolverEndpointValidationResult {
+                            Source = urlEntry,
+                            Entry = urlEntry,
+                            IsValid = false,
+                            Error = ex.Message
+                        });
+                    }
+                }
+            }
+
+            return results.ToArray();
+        }
+
+        /// <summary>
         /// Parses imported resolver endpoint content, skipping blank lines and full-line comments.
         /// </summary>
         /// <param name="content">Imported text content.</param>
@@ -140,6 +248,53 @@ namespace DnsClientX {
             }
         }
 
+        private static IEnumerable<ResolverEndpointValidationResult> ValidateImportedContent(string? content, string source) {
+            if (string.IsNullOrWhiteSpace(content)) {
+                yield break;
+            }
+
+            using var reader = new StringReader(content);
+            int lineNumber = 0;
+            while (reader.ReadLine() is string line) {
+                lineNumber++;
+                string trimmed = line.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed) ||
+                    trimmed.StartsWith("#", StringComparison.Ordinal) ||
+                    trimmed.StartsWith(";", StringComparison.Ordinal) ||
+                    trimmed.StartsWith("//", StringComparison.Ordinal)) {
+                    continue;
+                }
+
+                foreach (string entry in trimmed.Split(',')) {
+                    string value = entry.Trim();
+                    if (!string.IsNullOrWhiteSpace(value)) {
+                        yield return ValidateEntry(value, source, lineNumber);
+                    }
+                }
+            }
+        }
+
+        private static ResolverEndpointValidationResult ValidateEntry(string value, string source, int? lineNumber) {
+            DnsResolverEndpoint[] endpoints = TryParseMany(new[] { value }, out IReadOnlyList<string> errors);
+            if (endpoints.Length == 1 && errors.Count == 0) {
+                return new ResolverEndpointValidationResult {
+                    Source = source,
+                    LineNumber = lineNumber,
+                    Entry = value,
+                    IsValid = true,
+                    Endpoint = endpoints[0]
+                };
+            }
+
+            return new ResolverEndpointValidationResult {
+                Source = source,
+                LineNumber = lineNumber,
+                Entry = value,
+                IsValid = false,
+                Error = errors.Count == 0 ? "Endpoint could not be parsed." : string.Join("; ", errors)
+            };
+        }
+
         /// <summary>
         /// Tries to parse multiple endpoint input strings.
         /// Accepted formats:
@@ -165,6 +320,16 @@ namespace DnsClientX {
                 }
                 if (raw.Any(char.IsWhiteSpace)) {
                     errs.Add($"Endpoint contains whitespace: {rawIn}");
+                    continue;
+                }
+
+                if (DnsStamp.IsStamp(raw)) {
+                    if (DnsStamp.TryParse(raw, out DnsResolverEndpoint? stampEndpoint, out string? stampError)) {
+                        list.Add(stampEndpoint!);
+                    } else {
+                        errs.Add($"Invalid DNS stamp: {stampError}");
+                    }
+
                     continue;
                 }
 

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -126,10 +126,10 @@ namespace DnsClientX {
             CancellationToken cancellationToken = default) {
             var results = new List<ResolverEndpointValidationResult>();
 
-            foreach (string trimmed in (inputs ?? Array.Empty<string>()).Select(static input => input?.Trim() ?? string.Empty)) {
-                if (!string.IsNullOrWhiteSpace(trimmed)) {
-                    results.Add(ValidateEntry(trimmed, "inline", null));
-                }
+            foreach (string trimmed in (inputs ?? Array.Empty<string>())
+                .Select(static input => input?.Trim() ?? string.Empty)
+                .Where(static trimmed => !string.IsNullOrWhiteSpace(trimmed))) {
+                results.Add(ValidateEntry(trimmed, "inline", null));
             }
 
             foreach (string? fileEntry in files ?? Array.Empty<string>()) {
@@ -264,10 +264,10 @@ namespace DnsClientX {
                     continue;
                 }
 
-                foreach (string value in trimmed.Split(',').Select(static entry => entry.Trim())) {
-                    if (!string.IsNullOrWhiteSpace(value)) {
-                        yield return ValidateEntry(value, source, lineNumber);
-                    }
+                foreach (string value in trimmed.Split(',')
+                    .Select(static entry => entry.Trim())
+                    .Where(static value => !string.IsNullOrWhiteSpace(value))) {
+                    yield return ValidateEntry(value, source, lineNumber);
                 }
             }
         }

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -126,8 +126,7 @@ namespace DnsClientX {
             CancellationToken cancellationToken = default) {
             var results = new List<ResolverEndpointValidationResult>();
 
-            foreach (string? input in inputs ?? Array.Empty<string>()) {
-                string trimmed = input?.Trim() ?? string.Empty;
+            foreach (string trimmed in (inputs ?? Array.Empty<string>()).Select(static input => input?.Trim() ?? string.Empty)) {
                 if (!string.IsNullOrWhiteSpace(trimmed)) {
                     results.Add(ValidateEntry(trimmed, "inline", null));
                 }
@@ -265,8 +264,7 @@ namespace DnsClientX {
                     continue;
                 }
 
-                foreach (string entry in trimmed.Split(',')) {
-                    string value = entry.Trim();
+                foreach (string value in trimmed.Split(',').Select(static entry => entry.Trim())) {
                     if (!string.IsNullOrWhiteSpace(value)) {
                         yield return ValidateEntry(value, source, lineNumber);
                     }

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -161,9 +161,18 @@ namespace DnsClientX {
                     continue;
                 }
 
-                using var reader = File.OpenText(fullPath);
-                string content = await reader.ReadToEndAsync().ConfigureAwait(false);
-                results.AddRange(ValidateImportedContent(content, fullPath));
+                try {
+                    using var reader = File.OpenText(fullPath);
+                    string content = await reader.ReadToEndAsync().ConfigureAwait(false);
+                    results.AddRange(ValidateImportedContent(content, fullPath));
+                } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException) {
+                    results.Add(new ResolverEndpointValidationResult {
+                        Source = fullPath,
+                        Entry = fileEntry ?? string.Empty,
+                        IsValid = false,
+                        Error = ex.Message
+                    });
+                }
             }
 
             string[] urlEntries = (urls ?? Array.Empty<string>())

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -204,6 +204,8 @@ namespace DnsClientX {
 
                         string content = await ReadContentWithLimitAsync(response, cancellationToken).ConfigureAwait(false);
                         results.AddRange(ValidateImportedContent(content, urlEntry));
+                    } catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested) {
+                        throw;
                     } catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException || ex is InvalidOperationException) {
                         results.Add(new ResolverEndpointValidationResult {
                             Source = urlEntry,

--- a/DnsClientX/EndpointParser.cs
+++ b/DnsClientX/EndpointParser.cs
@@ -139,7 +139,19 @@ namespace DnsClientX {
                     continue;
                 }
 
-                string fullPath = Path.GetFullPath(filePath);
+                string fullPath;
+                try {
+                    fullPath = Path.GetFullPath(filePath);
+                } catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException || ex is PathTooLongException || ex is IOException) {
+                    results.Add(new ResolverEndpointValidationResult {
+                        Source = fileEntry ?? string.Empty,
+                        Entry = fileEntry ?? string.Empty,
+                        IsValid = false,
+                        Error = ex.Message
+                    });
+                    continue;
+                }
+
                 if (!File.Exists(fullPath)) {
                     results.Add(new ResolverEndpointValidationResult {
                         Source = fileEntry ?? string.Empty,

--- a/DnsClientX/ProtocolDnsWire/DnsMessage.cs
+++ b/DnsClientX/ProtocolDnsWire/DnsMessage.cs
@@ -123,7 +123,7 @@ namespace DnsClientX {
             stream.Write(buffer.ToArray(), 0, buffer.Length);
 
             // Write the question name
-            foreach (var label in _name.Split('.')) {
+            foreach (var label in GetWireLabels(_name)) {
                 var labelBytes = Encoding.ASCII.GetBytes(label);
                 stream.WriteByte((byte)labelBytes.Length); // Write the length of the label
                 stream.Write(labelBytes, 0, labelBytes.Length);
@@ -247,7 +247,7 @@ namespace DnsClientX {
                 ms.Write(bytes, 0, bytes.Length);
 
                 // Queries
-                foreach (var part in _name.Split('.')) {
+                foreach (var part in GetWireLabels(_name)) {
                     ms.WriteByte((byte)part.Length);
                     var partBytes = Encoding.ASCII.GetBytes(part);
                     ms.Write(partBytes, 0, partBytes.Length);
@@ -332,6 +332,13 @@ namespace DnsClientX {
             }
 
             return ms.ToArray();
+        }
+
+        private static string[] GetWireLabels(string name) {
+            string normalizedName = name.TrimEnd('.');
+            return normalizedName.Length == 0
+                ? Array.Empty<string>()
+                : normalizedName.Split('.');
         }
     }
 }

--- a/DnsClientX/ResolverEndpointValidationResult.cs
+++ b/DnsClientX/ResolverEndpointValidationResult.cs
@@ -1,0 +1,36 @@
+namespace DnsClientX {
+    /// <summary>
+    /// Describes validation outcome for one resolver endpoint catalog entry.
+    /// </summary>
+    public sealed class ResolverEndpointValidationResult {
+        /// <summary>
+        /// Source of the entry, such as inline input, file path, or URL.
+        /// </summary>
+        public string Source { get; init; } = string.Empty;
+
+        /// <summary>
+        /// One-based line number when the entry came from line-oriented content.
+        /// </summary>
+        public int? LineNumber { get; init; }
+
+        /// <summary>
+        /// Original endpoint entry.
+        /// </summary>
+        public string Entry { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Indicates whether the entry parsed successfully.
+        /// </summary>
+        public bool IsValid { get; init; }
+
+        /// <summary>
+        /// Parsed endpoint when validation succeeded.
+        /// </summary>
+        public DnsResolverEndpoint? Endpoint { get; init; }
+
+        /// <summary>
+        /// Validation error when parsing failed.
+        /// </summary>
+        public string? Error { get; init; }
+    }
+}

--- a/DnsClientX/ResolverScoreSelector.cs
+++ b/DnsClientX/ResolverScoreSelector.cs
@@ -18,6 +18,10 @@ namespace DnsClientX {
                 return false;
             }
 
+            if (!ResolverScoreSnapshot.TryValidateCompatibility(snapshot, out error)) {
+                return false;
+            }
+
             ResolverScoreSummary? summary = snapshot.Summary;
             if (summary == null) {
                 error = "Resolver score snapshot summary is required.";

--- a/DnsClientX/ResolverScoreSnapshot.cs
+++ b/DnsClientX/ResolverScoreSnapshot.cs
@@ -6,9 +6,19 @@ namespace DnsClientX {
     /// </summary>
     public sealed class ResolverScoreSnapshot {
         /// <summary>
+        /// The oldest resolver score snapshot schema version supported by this library.
+        /// </summary>
+        public const int MinimumSupportedSchemaVersion = 1;
+
+        /// <summary>
+        /// The resolver score snapshot schema version written by this library.
+        /// </summary>
+        public const int CurrentSchemaVersion = 2;
+
+        /// <summary>
         /// Gets or sets the snapshot schema version.
         /// </summary>
-        public int SchemaVersion { get; set; } = 2;
+        public int SchemaVersion { get; set; } = CurrentSchemaVersion;
 
         /// <summary>
         /// Gets or sets the UTC time when the snapshot was generated.
@@ -24,5 +34,32 @@ namespace DnsClientX {
         /// Gets or sets the scored candidate entries for the snapshot.
         /// </summary>
         public ResolverScoreEntry[] Results { get; set; } = Array.Empty<ResolverScoreEntry>();
+
+        /// <summary>
+        /// Validates whether a resolver score snapshot can be read by this library.
+        /// </summary>
+        /// <param name="snapshot">The snapshot to validate.</param>
+        /// <param name="error">The compatibility error when validation fails.</param>
+        /// <returns><c>true</c> when the snapshot schema is supported; otherwise <c>false</c>.</returns>
+        public static bool TryValidateCompatibility(ResolverScoreSnapshot? snapshot, out string? error) {
+            error = null;
+
+            if (snapshot == null) {
+                error = "Resolver score snapshot is required.";
+                return false;
+            }
+
+            if (snapshot.SchemaVersion < MinimumSupportedSchemaVersion) {
+                error = $"Resolver score snapshot schema version {snapshot.SchemaVersion} is not supported. Supported schema versions are {MinimumSupportedSchemaVersion} through {CurrentSchemaVersion}.";
+                return false;
+            }
+
+            if (snapshot.SchemaVersion > CurrentSchemaVersion) {
+                error = $"Resolver score snapshot schema version {snapshot.SchemaVersion} was produced by a newer DnsClientX release. This release supports schema versions {MinimumSupportedSchemaVersion} through {CurrentSchemaVersion}.";
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/DnsClientX/ResolverScoreStore.cs
+++ b/DnsClientX/ResolverScoreStore.cs
@@ -25,6 +25,10 @@ namespace DnsClientX {
                 throw new InvalidOperationException($"Resolver score snapshot could not be read: {path}");
             }
 
+            if (!ResolverScoreSnapshot.TryValidateCompatibility(snapshot, out string? compatibilityError)) {
+                throw new InvalidOperationException(compatibilityError);
+            }
+
             return snapshot;
         }
 
@@ -38,6 +42,10 @@ namespace DnsClientX {
 
             if (snapshot == null) {
                 throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            if (!ResolverScoreSnapshot.TryValidateCompatibility(snapshot, out string? compatibilityError)) {
+                throw new InvalidOperationException(compatibilityError);
             }
 
             string fullPath = Path.GetFullPath(path);

--- a/Module/DnsClientX.psd1
+++ b/Module/DnsClientX.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @('Get-DnsZoneTransfer', 'Resolve-DnsQuery')
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Clear-DnsMultiResolverCache', 'Get-DnsService', 'Invoke-DnsUpdate', 'Get-DnsZone', 'Find-DnsService', 'Resolve-Dns', 'Test-DnsBenchmark')
+    CmdletsToExport      = @('Clear-DnsMultiResolverCache', 'ConvertFrom-DnsStamp', 'Find-DnsService', 'Get-DnsResolverSelection', 'Get-DnsService', 'Get-DnsTransportCapability', 'Get-DnsZone', 'Invoke-DnsUpdate', 'Resolve-Dns', 'Test-DnsBenchmark', 'Test-DnsProbe', 'Test-DnsResolverCatalog')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
@@ -9,7 +9,7 @@
     FunctionsToExport    = @()
     GUID                 = '77fa806c-70b7-48d9-8b88-942ed73f24ed'
     HelpInfoURI          = 'https://github.com/EvotecIT/DnsClientX/blob/master/README.md'
-    ModuleVersion        = '1.0.5'
+    ModuleVersion        = '1.0.8'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,175 +2,175 @@
 
 ## Purpose
 
-This plan turns the current assessment into a library-aligned roadmap.
+This roadmap tracks the next library-aligned work for DnsClientX after the recent cleanup wave.
 
-It is written to support the current identity of the project:
+The project identity remains:
 
 - library first
 - cross-platform core
-- minimal dependencies in the main package
-- strong CLI and PowerShell surfaces built on the same engine
-- advanced DNS features without drifting into unrelated network product areas
+- dependency-light main package
+- CLI and PowerShell surfaces built on the same engine
+- advanced DNS protocol features without drifting into unrelated network product areas
 
 ## Principles
 
-### Keep the core focused
+### Keep The Core Focused
 
-The main package should remain centered on DNS resolution, DNS transport handling, DNS diagnostics, DNSSEC, updates, and related protocol features.
+The main package should stay centered on DNS resolution, DNS transport handling, diagnostics, DNSSEC, updates, zone transfer workflows, resolver selection, and protocol parsing.
 
-### Prefer additive features over product sprawl
+### Prefer Additive Depth Over Product Sprawl
 
-The best next features are the ones that deepen the resolver, parser, diagnostics, CLI, and automation story without turning the project into a proxy, desktop security suite, or operating system management tool.
+The best next features deepen the resolver, parser, diagnostics, CLI, and automation story. Avoid turning the main package into a proxy, desktop security suite, operating system manager, or broad network-control product.
 
-### Protect the no-dependency baseline
+### Protect The No-Dependency Baseline
 
-For modern targets, the main package should stay dependency-free where practical. If a feature is valuable but pushes the core too far, it should move into an optional package instead of reshaping the main library.
+Modern targets should remain dependency-free where practical. If a feature needs specialized dependencies, unusual crypto, a different support contract, or a much larger maintenance surface, it should move into an optional package.
 
-### Keep runtime-native modern transports in core
+### Keep Runtime-Native Modern Transports In Core
 
-If a transport can be implemented with no additional NuGet dependency on the modern target line, it belongs in the main package even if older targets cannot support it fully.
+DoH3 and DoQ belong in the core package when the runtime provides the transport support without extra package weight. Older targets should report clear unsupported behavior instead of pulling in compatibility stacks.
 
-That means:
+### Build Through Existing Surfaces
 
-- modern runtime-native transports should live in the core package for `net8+`
-- older targets may degrade gracefully instead of matching feature parity
-- optional packages should be reserved for features that genuinely add dependency graph weight or separate maintenance burden
+New capabilities should use the current architecture:
 
-### Build through existing surfaces
-
-New capabilities should be aligned with the current architecture:
-
-- core library for protocol and parsing features
-- CLI for diagnostics, scripting, and operator workflows
+- core library for protocol, parsing, resolver, and diagnostics behavior
+- CLI for operator workflows and scripting
 - PowerShell for automation and administration
 
-## Proposed Structure
+## Completed Cleanup Wave
 
-The roadmap is organized into four layers:
+The previous roadmap items below are now implemented and should be treated as maintained surfaces rather than future work:
 
-1. Core Enhancements
-2. CLI and PowerShell Experience
-3. Advanced Policy and Resolver Workflows
-4. Optional Package Candidates
-
-This structure keeps the project aligned with what it already does well and makes it easier to phase work without creating architectural debt.
+- CLI query output modes: `pretty`, `json`, `raw`, and `short`
+- CLI section toggles for question, answer, authority, and additional output
+- reverse lookup shortcut support in the CLI
+- TXT concatenation output support
+- EDNS padding and cookie option support
+- recursive AXFR convenience flow in the CLI
+- explicit resolver endpoint syntax shared by library, CLI, and PowerShell workflows
+- resolver import from files and URLs for probe and benchmark workflows
+- persisted probe and benchmark score snapshots
+- resolver selection and resolver reuse from saved score snapshots
+- runtime transport capability reporting
+- DNS stamp parsing and generation for plain DNS, DoH, DoT, and DoQ endpoint models
+- no-network DNS stamp inspection in the CLI and PowerShell
+- no-network resolver catalog validation in the CLI and PowerShell
+- resolver score snapshot schema versioning and future-version compatibility checks
+- release sanity coverage for version alignment and CLI help/README parity
 
 ## Current Direction
 
-The project already has a strong foundation:
+The project already has strong foundations:
 
-- broad transport support
-- DNSSEC support
+- broad DNS transport support
+- DNSSEC and root validation work
 - typed records
-- AXFR and updates
+- AXFR and dynamic updates
 - multi-resolver strategies
-- benchmark and probe workflows
-- cross-platform support
+- probe, benchmark, scoring, and resolver reuse workflows
+- cross-platform targeting
 
-Because of that, the next phase should not be about reinventing the resolver. It should be about making the existing engine more complete, more diagnosable, and easier to use in automation.
-
-## What To Add First
-
-The best first additions are the ones that are:
-
-- high value
-- low to medium implementation risk
-- aligned with the current library architecture
-- realistic without adding dependencies
-
-### First Wave
-
-- richer CLI output modes: `json`, `raw`, `short`, and section toggles
-- reverse lookup shortcut support in the CLI
-- TXT concatenation as an output or parsing option
-- EDNS padding support
-- EDNS cookie support
-- NSID-focused convenience modes
-- recursive AXFR helpers in CLI and PowerShell
-- resolver import from files and URLs for benchmark and probe workflows
-
-These are the most natural next steps because they improve usability, scripting, and protocol completeness without requiring a major redesign.
+The next phase should focus on protocol completeness, sharper resolver operations, and a small DNS-only policy model.
 
 ## Roadmap
 
-## Phase 1: Strengthen Existing Surfaces
+## Phase 1: Protocol Completeness
 
-Goal: improve the value of the existing library, CLI, and PowerShell surfaces without changing the project's architectural identity.
+Goal: improve protocol coverage in the core package without adding dependency pressure.
 
-### Core
+### Scope
 
-- add EDNS padding support
-- add EDNS cookie support
-- expose a cleaner NSID request path for reusable request models
-- add stamp parsing for standard endpoint formats that map naturally onto existing transports
+- cleaner NSID request and response convenience paths
+- stronger validation for EDNS option combinations and public request models
+- more focused tests around fully-qualified names, root labels, and wire serialization edge cases
 
-### CLI
+### Primary File Areas
 
-- add `json` output
-- add `raw` output
-- add `short` output
-- add question, authority, and additional section toggles
-- add human-friendly TTL formatting
-- add reverse lookup shortcut support
-- add TXT concatenation support
-- add recursive AXFR convenience commands
+- `DnsClientX/Edns/*`
+- `DnsClientX/EdnsOptions.cs`
+- `DnsClientX/DnsMessageOptions.cs`
+- `DnsClientX/ResolveDnsRequest.cs`
+- `DnsClientX/EndpointParser.cs`
+- `DnsClientX/ProtocolDnsWire/DnsMessage.cs`
+- `DnsClientX.Tests/*Edns*`
+- `DnsClientX.Tests/*EndpointParser*`
 
-### PowerShell
+### Acceptance Criteria
 
-- expose the same recursive AXFR convenience surface
-- support resolver import for benchmark and probe scenarios
-- keep parameter names aligned with existing request models
+- supported DNS stamps remain round-trippable through the same `DnsResolverEndpoint` model as explicit endpoint syntax
+- NSID can be requested through reusable request models without hand-building EDNS options
+- wire-format tests cover trailing-dot and root-label edge cases
 
-### Why This Comes First
+## Phase 2: Resolver Operations
 
-- strong user value
-- low architectural risk
-- no need to widen the dependency surface
-- direct alignment with the current strengths of the library
+Goal: make resolver selection workflows more repeatable and operator-friendly.
 
-## Phase 2: Improve Resolver Operations
+### Scope
 
-Goal: build better operator workflows on top of the existing resolver and benchmark engine.
+- bootstrap resolver control for hostname-based DoH, DoT, DoH3, DoQ, and gRPC endpoints
+- resolver catalog import as a first-class library API, not only CLI plumbing
+- score snapshot migration guardrails for any future schema changes
+- optional resolver health profile files for repeated probe and benchmark runs
+- richer explain output for why a resolver was selected or rejected
 
-### Additions
+### Primary File Areas
 
-- bootstrap resolver control for hostname-based transports
-- import resolver catalogs from local files
-- import resolver catalogs from remote URLs
-- persist resolver scoring and health summaries from benchmark and probe runs
-- add a simple working-resolver selection workflow built on existing benchmark and probe logic
+- `DnsClientX/EndpointParser.cs`
+- `DnsClientX/ResolverExecutionTargetResolver.cs`
+- `DnsClientX/ResolverScoreStore.cs`
+- `DnsClientX/ResolverProbe*`
+- `DnsClientX/ResolverBenchmark*`
+- `DnsClientX.Cli/Program.cs`
+- `DnsClientX.PowerShell/*Benchmark*`
+- `DnsClientX.PowerShell/*Probe*`
 
-### Why This Matters
+### Acceptance Criteria
 
-The project already knows how to resolve, benchmark, and probe. The next useful step is to make those results reusable, so the CLI and automation layers can evolve from one-off checks into repeatable resolver selection workflows.
+- hostname-based transports can use an explicit bootstrap path when needed
+- resolver catalog loading and validation are reusable from library, CLI, and PowerShell
+- future score snapshot schema changes have migration or compatibility guardrails
+- explain output names policy, score, health, and capability factors
 
-## Phase 3: Add a DNS-Only Policy Layer
+## Phase 3: DNS-Only Policy Layer
 
-Goal: introduce domain-aware policy without drifting into unrelated product areas.
+Goal: add domain-aware behavior while staying inside the DNS domain.
 
 ### Initial Scope
 
 - block by domain
-- static override by domain
+- static answer override by domain
 - custom resolver selection by domain
-- rule explain and diagnostics output
+- rule explain output
+- testable policy decisions independent from network calls
 
 ### Scope Guardrails
 
-This layer should remain DNS-focused. It should not include:
+This layer should not include:
 
 - proxy orchestration
 - packet fragmentation
 - SNI rewriting
 - browser or system traffic manipulation
+- OS startup management
 
-### Why This Phase Is Valuable
+### Primary File Areas
 
-A DNS-only policy layer would be one of the strongest differentiators for the library, but it is large enough that it should arrive only after the transport, parser, CLI, and resolver workflow improvements are stable.
+- new policy-focused files under `DnsClientX/`
+- `DnsClientX.QueryDnsRequest.cs`
+- `DnsClientX.Cli/Program.cs`
+- `DnsClientX.PowerShell/*`
+- dedicated policy tests under `DnsClientX.Tests/`
+
+### Acceptance Criteria
+
+- policy decisions are deterministic and explainable
+- rules can be evaluated without performing network I/O
+- public APIs stay DNS-focused and do not imply system-wide traffic control
 
 ## Phase 4: Optional Packages
 
-Goal: keep the main library lean while still leaving room for higher-complexity protocol features.
+Goal: leave room for valuable higher-complexity protocols without weighing down the main package.
 
 ### Best Candidates
 
@@ -179,320 +179,90 @@ Goal: keep the main library lean while still leaving room for higher-complexity 
 - `DnsClientX.Rules`
 - `DnsClientX.Server`
 
-### Rationale
-
-These features may be valuable, but they should not force the main package to absorb significant complexity, new dependencies, or a broader maintenance burden than the core library needs.
-
 ### Packaging Policy
 
-- keep `DoH3` in the core package when it remains dependency-free on modern targets
-- keep `DoQ` in the core package when it remains dependency-free on modern targets
-- do not add compatibility dependencies just to backport `DoH3` or `DoQ` to older targets
-- return clear non-support behavior on older frameworks when the runtime cannot provide the transport
-- create optional packages only when a protocol requires external dependencies, specialized crypto, or a materially different support contract
-
-## Difficulty And Fit
-
-### High-fit, low-to-medium complexity
-
-- CLI output improvements
-- reverse lookup CLI support
-- TXT concatenation support
-- EDNS padding
-- EDNS cookie
-- NSID convenience support
-- recursive AXFR helper workflows
-- resolver import from file or URL
-
-These should be prioritized first.
-
-### High-fit, medium-to-high complexity
-
-- stamp parsing and generation
-- bootstrap resolver control
-- persisted resolver scoring
-- DNS-only policy rules
-
-These are worth doing, but they should follow the first wave.
-
-### Valuable, but better outside the main package
-
-- full DNSCrypt implementation
-- full ODoH implementation
-- local DNS or DoH server stacks if they grow large
-- any feature that requires broad protocol-specific dependencies or native helpers
-
-## Explicit Non-Goals For The Main Package
-
-The main library should avoid absorbing features that move it into a different product category.
-
-That includes:
-
-- DPI bypass workflows
-- packet fragmentation features
-- fake SNI workflows
-- proxy server product features
-- operating system startup management
-- large Windows-only orchestration features
-
-These may be useful in other tools, but they are not the right center of gravity for this library.
-
-## Recommended Execution Order
-
-1. CLI output modes and section controls
-2. EDNS padding and cookie support
-3. reverse lookup and TXT convenience features
-4. recursive AXFR convenience flows
-5. resolver import from file and URL
-6. bootstrap resolver control
-7. persisted resolver scoring
-8. DNS-only policy layer
-9. optional packages for higher-complexity protocols
-
-## Success Criteria
-
-The plan is succeeding if:
-
-- the main package remains dependency-light
-- new features build on existing abstractions instead of bypassing them
-- CLI and PowerShell become more useful for diagnostics and automation
-- the library becomes more complete at the DNS protocol layer
-- policy features remain DNS-focused
-- higher-complexity protocol work is isolated into optional packages when needed
+- keep dependency-free DoH3 and DoQ support in the core package on modern targets
+- do not add compatibility dependencies just to backport modern transports to older targets
+- create optional packages when a feature needs specialized dependencies, crypto, server hosting, or a materially different maintenance contract
 
 ## Concrete Backlog
 
-### Core backlog
+### Core
 
-- add EDNS padding option type and wire serialization support
-- add EDNS cookie option type and wire serialization support
-- extend reusable request models to express padding, cookie, and richer EDNS intent
-- add endpoint stamp parsing for supported built-in transport types
-- add bootstrap resolver configuration for hostname-based transports
-- add resolver import primitives from file and URL sources
-- add persisted resolver score model for benchmark and probe outputs
-- design a DNS-only rule model for block, override, and custom resolver selection
+- expose NSID convenience options through `ResolveDnsRequest`
+- add bootstrap resolver configuration to request and endpoint models
+- add migration guardrails when score snapshot schemas change
+- design a DNS-only rule model for block, override, and resolver selection
 
-### CLI backlog
+### CLI
 
-- add `--format json`
-- add `--format raw`
-- add `--short`
-- add section switches for question, answer, authority, and additional
-- add pretty TTL formatting options
-- add reverse lookup shortcut
-- add TXT concatenation option
-- add recursive AXFR mode
-- add resolver import input options
-- add stable machine-readable summary output for imported-resolver workflows
+- expose bootstrap resolver controls for explicit endpoints
+- add explain output for resolver score and policy decisions
+- keep help text and README feature lists aligned
 
-### PowerShell backlog
+### PowerShell
 
-- add recursive AXFR convenience cmdlet surface or parameter set
-- add resolver import support for benchmark and probe commands
-- add parameter coverage for richer EDNS controls
-- add rule explain support once a policy layer exists
+- expose bootstrap resolver controls
+- add parameter coverage for NSID and stamp workflows
+- add rule explain support once the policy model exists
 
-### Diagnostics and testing backlog
+### Diagnostics And Testing
 
-- add unit tests for EDNS padding and cookie serialization
-- add parser tests for stamp parsing
-- add CLI tests for new output modes and flags
-- add probe and benchmark tests for imported resolver sources
-- add tests for persisted resolver score read and write behavior
-- add rule engine tests before any public policy API is finalized
+- maintain release sanity tests for version alignment
+- maintain CLI help and README parity checks for documented switches
+- add parser tests for supported and unsupported stamps
+- maintain snapshot schema compatibility tests
+- add policy engine tests before public policy APIs are finalized
 
-## Milestones
+## Recommended Next 3 PRs
 
-### Milestone 1: Protocol Completeness
-
-Outcome:
-
-- richer EDNS support
-- cleaner NSID path
-- stamp parsing for supported transport types
-
-Scope:
-
-- EDNS padding
-- EDNS cookie
-- request-model support for richer EDNS options
-- tests for wire generation and parser behavior
-
-Primary file areas:
-
-- `DnsClientX/Edns/*`
-- `DnsClientX/EdnsOptions.cs`
-- `DnsClientX/DnsMessageOptions.cs`
-- `DnsClientX/ResolveDnsRequest.cs`
-- `DnsClientX/ProtocolDnsWire/DnsMessage.cs`
-- `DnsClientX.Tests/*Edns*`
-
-### Milestone 2: CLI Diagnostics Upgrade
-
-Outcome:
-
-- much stronger operator and scripting UX
-
-Scope:
-
-- `json`, `raw`, and `short` output modes
-- section toggles
-- reverse lookup shortcut
-- TXT concatenation
-
-Primary file areas:
-
-- `DnsClientX.Cli/Program.cs`
-- `DnsClientX.Tests/Cli*`
-- `DnsClientX.Tests/*Query*`
-
-### Milestone 3: AXFR and Resolver Workflow Improvements
-
-Outcome:
-
-- better operational workflows for large-scale resolver handling
-
-Scope:
-
-- recursive AXFR convenience
-- resolver import from file and URL
-- benchmark and probe integration for imported resolvers
-
-Primary file areas:
-
-- `DnsClientX.Cli/Program.cs`
-- `DnsClientX.PowerShell/*`
-- `DnsClientX/EndpointParser.cs`
-- `DnsClientX/Definitions/*`
-- `DnsClientX.Tests/*Benchmark*`
-- `DnsClientX.Tests/*Probe*`
-
-### Milestone 4: Resolver State and Selection
-
-Outcome:
-
-- reusable resolver quality data and better repeatable operator workflows
-
-Scope:
-
-- persisted resolver scoring
-- score reuse in benchmark and probe-driven selection flows
-- optional cache or profile model for resolver health snapshots
-
-Primary file areas:
-
-- `DnsClientX.Cli/Program.cs`
-- `DnsClientX.PowerShell/CmdletTestDnsBenchmark.cs`
-- `DnsClientX/Definitions/*`
-- `DnsClientX.Tests/*Benchmark*`
-
-### Milestone 5: DNS-Only Policy Layer
-
-Outcome:
-
-- domain-aware behavior without leaving the DNS domain
-
-Scope:
-
-- domain block rules
-- static answer override rules
-- per-domain custom resolver rules
-- explain output for rule decisions
-
-Primary file areas:
-
-- new policy-focused files under `DnsClientX/`
-- `DnsClientX.QueryDnsRequest.cs`
-- `DnsClientX.Cli/Program.cs`
-- `DnsClientX.PowerShell/*`
-- dedicated policy tests under `DnsClientX.Tests/`
-
-## Next 3 PRs
-
-### PR 1: Richer EDNS Support
+### PR 1: Bootstrap Resolver Control
 
 Goal:
 
-- add EDNS padding and cookie support in the core library, including reusable request-model support and tests
+- let hostname-based transports use explicit bootstrap resolver behavior where needed
 
-Why first:
+Acceptance criteria:
 
-- strong protocol value
-- contained scope
-- no dependency pressure
-- unlocks later CLI and automation work
+- bootstrap settings are available from reusable request models
+- CLI and PowerShell expose consistent parameter names
+- explain output shows when bootstrap behavior was used
 
-Suggested file targets:
-
-- `DnsClientX/Edns/`
-- `DnsClientX/EdnsOptions.cs`
-- `DnsClientX/DnsMessageOptions.cs`
-- `DnsClientX/ResolveDnsRequest.cs`
-- `DnsClientX/ProtocolDnsWire/DnsMessage.cs`
-- `DnsClientX.Tests/EdnsOptionsTests.cs`
-- new focused EDNS tests if needed
-
-Suggested acceptance criteria:
-
-- padding and cookie options can be expressed through public request paths
-- wire serialization includes the new EDNS options correctly
-- existing EDNS behavior remains unchanged when the new options are unused
-
-### PR 2: CLI Output Expansion
+### PR 2: NSID Request Convenience
 
 Goal:
 
-- add `json`, `raw`, and `short` output modes plus section toggles
+- expose NSID as a first-class request option instead of requiring hand-built EDNS options
 
-Why second:
+Acceptance criteria:
 
-- immediate user-visible value
-- builds on existing response structures
-- keeps work centered in the CLI layer
+- reusable request models can ask for NSID
+- CLI and PowerShell expose matching NSID switches or parameters
+- response parsing and output surfaces include returned NSID data when present
 
-Suggested file targets:
-
-- `DnsClientX.Cli/Program.cs`
-- `DnsClientX.Tests/CliIntegrationTests.cs`
-- `DnsClientX.Tests/CliExplainTraceTests.cs`
-- new CLI output tests if needed
-
-Suggested acceptance criteria:
-
-- CLI can render structured JSON output
-- CLI can render raw DNS-style output
-- CLI can emit short answer-only output
-- section flags correctly show or hide question, authority, and additional data
-
-### PR 3: Resolver Import Workflow
+### PR 3: Resolver Health Profiles
 
 Goal:
 
-- support importing resolver inputs from files and URLs for benchmark and probe flows
+- make repeated probe and benchmark runs easier to configure and compare
 
-Why third:
+Acceptance criteria:
 
-- high operational value
-- aligns with existing benchmark and probe investment
-- opens the door to persisted resolver scoring later
+- profile files can define resolver catalogs, domains, record types, and policy thresholds
+- CLI and PowerShell can load a profile and still override selected fields
+- reports include enough profile metadata to compare runs over time
 
-Suggested file targets:
+## Success Criteria
 
-- `DnsClientX.Cli/Program.cs`
-- `DnsClientX.PowerShell/*`
-- `DnsClientX/EndpointParser.cs`
-- `DnsClientX.Tests/*Benchmark*`
-- `DnsClientX.Tests/*Probe*`
+The roadmap is succeeding if:
 
-Suggested acceptance criteria:
-
-- benchmark and probe commands can consume resolver lists from file inputs
-- remote resolver list import is supported with validation
-- imported resolvers reuse the same parsing and endpoint validation path as direct inputs
+- the main package remains dependency-light
+- new features build on existing abstractions
+- CLI and PowerShell stay useful for diagnostics and automation
+- protocol coverage improves without product sprawl
+- policy features remain DNS-focused
+- optional packages absorb higher-complexity protocols when needed
 
 ## Summary
 
-The project should deepen along its current axis rather than widen into unrelated areas.
-
-The right next step is to improve protocol completeness, diagnostics, CLI output, resolver workflows, and eventually DNS-only policy support. The wrong next step is to grow the main package into a broader network-control product.
+DnsClientX should deepen along its current axis: protocol completeness, diagnostics, resolver workflows, and eventually DNS-only policy. The main package should avoid becoming a broader network-control product.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ DnsClientX.Cli --capabilities --format json
 ```
 
 Saved probe and benchmark snapshots also persist runtime capability hints, so recommendation files can distinguish unsupported modern transports from ordinary resolver failures.
+Snapshots include a schema version, and resolver selection rejects snapshots from newer unsupported schemas before attempting reuse.
 
 ## Explicit Endpoint Syntax
 
@@ -206,6 +207,7 @@ Custom resolver inputs share one endpoint parser across the library, CLI, and Po
 - DoH: `doh@https://dns.google/dns-query`
 - DoH3: `doh3@https://dns.quad9.net/dns-query`
 - DoQ: `doq@dns.quad9.net:853`
+- DNS stamp: `sdns://AgUAAAAAAAAABzEuMS4xLjEAGm1vemlsbGEuY2xvdWRmbGFyZS1kbnMuY29tCi9kbnMtcXVlcnk`
 
 The same syntax works in:
 
@@ -213,6 +215,49 @@ The same syntax works in:
 - `Test-DnsProbe -ResolverEndpoint ...`
 - `Test-DnsBenchmark -ResolverEndpoint ...`
 - CLI probe and benchmark endpoint inputs
+
+DNS stamps currently map into the core endpoint model for plain DNS, DoH, DoT, and DoQ. DNSCrypt and ODoH stamp protocols are detected and rejected with clear unsupported-protocol errors.
+
+## CLI Diagnostics and Resolver Workflows
+
+The CLI is intended for quick diagnostics and automation-friendly resolver checks.
+
+Standard query output:
+
+```powershell
+DnsClientX.Cli --format json example.com
+DnsClientX.Cli --format raw --question --answer --authority --additional example.com
+DnsClientX.Cli --short example.com
+DnsClientX.Cli --txt-concat --type TXT example.com
+DnsClientX.Cli --reverse 1.1.1.1
+```
+
+Zone transfer convenience:
+
+```powershell
+DnsClientX.Cli --axfr --transfer-summary example.com
+DnsClientX.Cli --axfr --format json example.com
+```
+
+Resolver import, probe, benchmark, and score reuse:
+
+```powershell
+DnsClientX.Cli --resolver-validate --resolver-file .\resolvers.txt
+DnsClientX.Cli --resolver-validate --resolver-file .\resolvers.txt --format json
+Test-DnsResolverCatalog -ResolverEndpointFile .\resolvers.txt
+DnsClientX.Cli --probe --resolver-file .\resolvers.txt --probe-save .\probe.json
+DnsClientX.Cli --benchmark --resolver-url https://example.com/resolvers.txt --benchmark-save .\benchmark.json
+DnsClientX.Cli --resolver-select .\probe.json
+DnsClientX.Cli --resolver-use .\probe.json --short example.com
+```
+
+DNS stamp inspection without querying DNS:
+
+```powershell
+DnsClientX.Cli --stamp-info 'sdns://AgUAAAAAAAAABzEuMS4xLjEAGm1vemlsbGEuY2xvdWRmbGFyZS1kbnMuY29tCi9kbnMtcXVlcnk'
+DnsClientX.Cli --stamp-info 'sdns://AgUAAAAAAAAABzEuMS4xLjEAGm1vemlsbGEuY2xvdWRmbGFyZS1kbnMuY29tCi9kbnMtcXVlcnk' --format json
+ConvertFrom-DnsStamp -Stamp 'sdns://AgUAAAAAAAAABzEuMS4xLjEAGm1vemlsbGEuY2xvdWRmbGFyZS1kbnMuY29tCi9kbnMtcXVlcnk'
+```
 
 ## Opt-In Real Modern Transport Checks
 


### PR DESCRIPTION
## Summary
- align CLI, PowerShell, and module versions with the core package for the 1.0.8 release
- refresh the roadmap so completed resolver and CLI work is tracked as maintained surface area rather than future scope
- add DNS stamp parsing/inspection, resolver catalog validation, and resolver score snapshot compatibility checks
- fix trailing-dot DNS wire serialization and add release/resolver regression coverage

## Validation
- dotnet build DnsClientX.sln -c Release -f net8.0
- dotnet test DnsClientX.Tests\DnsClientX.Tests.csproj -c Release -f net8.0 --no-build --filter "FullyQualifiedName~ResolverScoreStoreTests|FullyQualifiedName~ResolverExecutionTargetResolverTests|FullyQualifiedName~CliResolverSelectionTests|FullyQualifiedName~ResolverCatalogValidationTests|FullyQualifiedName~ReleaseSanityTests"
- dotnet test DnsClientX.Tests\DnsClientX.Tests.csproj -c Release -f net8.0 --no-build -- RunConfiguration.DisableParallelization=true
- git diff --check