### PR TITLE
Update NuGet signing certificate

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -25,7 +25,7 @@
   "PublishNuget": false,
   "PublishGitHub": false,
   "CreateReleaseZip": true,
-  "CertificateThumbprint": "483292C9E317AA13B07BB7A96AE9D1A5ED9E7703",
+  "CertificateThumbprint": "92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A",
   "CertificateStore": "CurrentUser",
   "TimeStampServer": "http://timestamp.digicert.com",
   "PublishSource": "https://api.nuget.org/v3/index.json",


### PR DESCRIPTION
## Summary

- replaces the expired NuGet code-signing certificate with the current Evotec Services certificate
- restores the existing PowerForge release path for signed DnsClientX packages

## Validation

- PowerForge resolved the release as DnsClientX 2.0.0
- a publish-disabled project release build completed successfully
- the resulting package passed NuGet author-signature verification and contained the expected net472, net8.0, net10.0, and netstandard2.0 assets

## Release context

DnsClientX 2.0.0 remains unpublished until this configuration fix merges. DomainDetective PR #1249 remains behind that public-package boundary.