### PR TITLE
build: 🧹 Use PowerForge native cmdlet documentation

### DIFF
--- a/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
+++ b/DnsClientX.PowerShell/DnsClientX.PowerShell.csproj
@@ -25,28 +25,14 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
+        <!-- PowerForge enriches module help from the compiler XML documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
 
     <!-- We need to remove PowerShell conflicting libraries as it will break output -->
     <Target Name="RemoveFilesAfterBuild" AfterTargets="Build">
         <Delete Files="$(OutDir)System.Management.Automation.dll" />
         <Delete Files="$(OutDir)System.Management.dll" />
-    </Target>
-
-    <!-- Copy help documentation to publish output after publish -->
-    <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
-        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml"
-            DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml"
-            Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
     </Target>
 
     <ItemGroup>

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -60,13 +60,13 @@ Build-Module -ModuleName 'DnsClientX' {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
+        SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $true } else { [bool]::Parse($Env:SignModule) }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = '92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A'
@@ -80,7 +80,7 @@ Build-Module -ModuleName 'DnsClientX' {
         DotSourceLibraries                = $true
         NETSearchClass                    = 'DnsClientX.PowerShell.CmdletResolveDnsQuery'
         NETBinaryModuleDocumentation      = $true
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $false } else { [bool]::Parse($Env:RefreshPSD1Only) }
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Docs/Clear-DnsMultiResolverCache.md
+++ b/Module/Docs/Clear-DnsMultiResolverCache.md
@@ -1,0 +1,138 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Clear-DnsMultiResolverCache
+## SYNOPSIS
+Clears the multi-resolver fastest-endpoint cache used by the FastestWins strategy.
+
+Clears the in-memory cache used to remember the fastest endpoint for a given set of endpoints. Use this when you change network conditions or want to force re-probing. Does not affect TTL-based response caching, which expires automatically.
+
+## SYNTAX
+### All (Default)
+```powershell
+Clear-DnsMultiResolverCache [-All] [<CommonParameters>]
+```
+
+### ResolverEndpoint
+```powershell
+Clear-DnsMultiResolverCache -ResolverEndpoint <string[]> [<CommonParameters>]
+```
+
+### ResolverDnsProvider
+```powershell
+Clear-DnsMultiResolverCache -ResolverDnsProvider <DnsEndpoint[]> [<CommonParameters>]
+```
+
+### DnsProvider
+```powershell
+Clear-DnsMultiResolverCache -DnsProvider <DnsEndpoint[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Clears the multi-resolver fastest-endpoint cache used by the FastestWins strategy.
+
+Clears the in-memory cache used to remember the fastest endpoint for a given set of endpoints. Use this when you change network conditions or want to force re-probing. Does not affect TTL-based response caching, which expires automatically.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Clear-DnsMultiResolverCache -All
+```
+
+
+### EXAMPLE 2
+```powershell
+Clear-DnsMultiResolverCache -DnsProvider @('Value')
+```
+
+
+### EXAMPLE 3
+```powershell
+Clear-DnsMultiResolverCache -ResolverDnsProvider @('Value')
+```
+
+
+## PARAMETERS
+
+### -All
+Clear all cached fastest-endpoint choices.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: All
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsProvider
+Alternate parameter: providers to clear when using the classic -DnsProvider parameter style.
+
+```yaml
+Type: DnsEndpoint[]
+Parameter Sets: DnsProvider
+Aliases: None
+Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverDnsProvider
+Clear cache entries for the specified predefined providers (DnsEndpoint enum).
+
+```yaml
+Type: DnsEndpoint[]
+Parameter Sets: ResolverDnsProvider
+Aliases: None
+Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpoint
+Specific endpoints to clear, e.g. "1.1.1.1:53", "[2606:4700:4700::1111]:53", or DoH URLs.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/ConvertFrom-DnsStamp.md
+++ b/Module/Docs/ConvertFrom-DnsStamp.md
@@ -1,0 +1,63 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# ConvertFrom-DnsStamp
+## SYNOPSIS
+Parses a DNS stamp into a resolver endpoint description.
+
+Converts a supported sdns:// DNS stamp into the same endpoint model used by DnsClientX resolver workflows. This command does not perform a DNS query.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+ConvertFrom-DnsStamp [-Stamp] <string> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Parses a DNS stamp into a resolver endpoint description.
+
+Converts a supported sdns:// DNS stamp into the same endpoint model used by DnsClientX resolver workflows. This command does not perform a DNS query.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+ConvertFrom-DnsStamp -Stamp 'Value'
+```
+
+
+## PARAMETERS
+
+### -Stamp
+DNS stamp to parse.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `DnsClientX.DnsStampInfo`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Find-DnsService.md
+++ b/Module/Docs/Find-DnsService.md
@@ -1,0 +1,63 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Find-DnsService
+## SYNOPSIS
+Discovers services advertised via DNS Service Discovery.
+
+Wraps DiscoverServices to return services under a domain.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Find-DnsService [-Domain] <string> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Discovers services advertised via DNS Service Discovery.
+
+Wraps DiscoverServices to return services under a domain.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Find-DnsService -Domain 'Value'
+```
+
+
+## PARAMETERS
+
+### -Domain
+Domain name to search for advertised services.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DnsResolverSelection.md
+++ b/Module/Docs/Get-DnsResolverSelection.md
@@ -1,0 +1,80 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-DnsResolverSelection
+## SYNOPSIS
+Loads a saved resolver score snapshot and returns the recommended resolver selection.
+
+Reads a persisted resolver score snapshot, applies the shared recommendation logic, and returns either the structured selection object or the raw target string for automation use.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DnsResolverSelection [-Path] <string> [-AsString] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Loads a saved resolver score snapshot and returns the recommended resolver selection.
+
+Reads a persisted resolver score snapshot, applies the shared recommendation logic, and returns either the structured selection object or the raw target string for automation use.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-DnsResolverSelection -Path 'C:\Path'
+```
+
+
+## PARAMETERS
+
+### -AsString
+Emits only the raw selected target string instead of the structured selection object.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Path to the saved resolver score snapshot.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `DnsClientX.ResolverSelectionResult`
+- `System.String`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DnsService.md
+++ b/Module/Docs/Get-DnsService.md
@@ -1,0 +1,63 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-DnsService
+## SYNOPSIS
+Retrieves services advertised via DNS Service Discovery.
+
+Queries the _services._dns-sd._udp tree for the specified domain and returns SRV/TXT data describing each advertised service.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DnsService [-Domain] <string> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves services advertised via DNS Service Discovery.
+
+Queries the _services._dns-sd._udp tree for the specified domain and returns SRV/TXT data describing each advertised service.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-DnsService -Domain 'Value'
+```
+
+
+## PARAMETERS
+
+### -Domain
+Domain name to search for advertised services.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DnsTransportCapability.md
+++ b/Module/Docs/Get-DnsTransportCapability.md
@@ -1,0 +1,63 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-DnsTransportCapability
+## SYNOPSIS
+Returns runtime transport support information for the DnsClientX core transport surface.
+
+Reports which core transports are available on the current runtime, including modern DoH3 and DoQ support on .NET 8+.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DnsTransportCapability [-ModernOnly] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Returns runtime transport support information for the DnsClientX core transport surface.
+
+Reports which core transports are available on the current runtime, including modern DoH3 and DoQ support on .NET 8+.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-DnsTransportCapability -ModernOnly
+```
+
+
+## PARAMETERS
+
+### -ModernOnly
+Emits only modern runtime-gated transports such as DoH3 and DoQ.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `DnsClientX.DnsTransportCapabilityInfo`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DnsZone.md
+++ b/Module/Docs/Get-DnsZone.md
@@ -1,0 +1,154 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Get-DnsZone
+## SYNOPSIS
+Performs a DNS zone transfer (AXFR) for a given zone.
+
+Retrieves all records for the specified zone using TCP based zone transfer.
+
+## SYNTAX
+### ExplicitServer (Default)
+```powershell
+Get-DnsZone [-Zone] <string> [-Server] <string> [-Port <int>] [<CommonParameters>]
+```
+
+### Recursive
+```powershell
+Get-DnsZone [-Zone] <string> [[-Server] <string>] -Recursive [-Port <int>] [-DnsProvider <DnsEndpoint>] [-IncludeTransferSummary] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Performs a DNS zone transfer (AXFR) for a given zone.
+
+Retrieves all records for the specified zone using TCP based zone transfer.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-DnsZone -DnsProvider 'Value'
+```
+
+
+### EXAMPLE 2
+```powershell
+Get-DnsZone -Recursive
+```
+
+
+## PARAMETERS
+
+### -DnsProvider
+Resolver profile used to discover authoritative servers when Recursive is specified and no explicit discovery server is provided.
+
+```yaml
+Type: DnsEndpoint
+Parameter Sets: Recursive
+Aliases: None
+Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeTransferSummary
+Emit the recursive transfer summary object before the transferred RRsets.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Recursive
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Port
+Port number to use. Defaults to 53.
+
+```yaml
+Type: Int32
+Parameter Sets: ExplicitServer, Recursive
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Recursive
+Discover authoritative servers first and attempt AXFR against them in order.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Recursive
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+DNS server to query.
+
+```yaml
+Type: String
+Parameter Sets: ExplicitServer, Recursive
+Aliases: ServerName
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Zone
+The zone to transfer.
+
+```yaml
+Type: String
+Parameter Sets: ExplicitServer, Recursive
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DnsUpdate.md
+++ b/Module/Docs/Invoke-DnsUpdate.md
@@ -1,0 +1,207 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Invoke-DnsUpdate
+## SYNOPSIS
+Sends DNS UPDATE messages to a server.
+
+Adds or removes records in a zone using RFC 2136 over TCP.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DnsUpdate [-Zone] <string> [-Server] <string> [-Name] <string> [-Type] <DnsRecordType> [[-Data] <string>] [-Port <int>] [-Ttl <int>] [-TsigKey <TsigKey>] [-Delete] [-DeleteValue] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sends DNS UPDATE messages to a server.
+
+Adds or removes records in a zone using RFC 2136 over TCP.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-DnsUpdate -Name 'Name'
+```
+
+
+## PARAMETERS
+
+### -Data
+Record data used when adding a record.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Delete
+If specified, the record is removed instead of added.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeleteValue
+If specified, only the exact value supplied through Data is removed.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Record name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Port
+Port number to use. Defaults to 53.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+DNS server to send the update to.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: ServerName
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TsigKey
+Optional typed TSIG key used to authenticate the update and its response.
+
+```yaml
+Type: TsigKey
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Ttl
+TTL for the new record. Zero is valid under RFC 2136; the default is 300 seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Type of record.
+
+```yaml
+Type: DnsRecordType
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Reserved, A, NS, MD, MF, CNAME, SOA, MB, MG, MR, NULL, WKS, PTR, HINFO, MINFO, MX, TXT, RP, AFSDB, X25, ISDN, RT, NSAP, NSAP_PTR, SIG, PX, AAAA, LOC, NXT, SRV, ATMA, NAPTR, KX, CERT, A6, DNAME, SINK, OPT, APL, DS, SSHFP, IPSECKEY, RRSIG, NSEC, DNSKEY, DHCID, NSEC3, NSEC3PARAM, TLSA, SMIMEA, HIP, NINFO, RKEY, TALINK, CDS, CDNSKEY, OPENPGPKEY, CSYNC, ZONEMD, SVCB, HTTPS, SPF, LP, TKEY, TSIG, IXFR, AXFR, MAILB, MAILA, ANY, URI, CAA, AVC, DOA, AMTRELAY, RESINFO, TA, DLV
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Zone
+Zone to update.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -1,0 +1,71 @@
+---
+Module Name: DnsClientX
+Module Guid: 77fa806c-70b7-48d9-8b88-942ed73f24ed
+Download Help Link: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+Help Version: 2.1.0
+Locale: en-US
+---
+# DnsClientX Module
+## Description
+DnsClientX is PowerShell module that allows you to query DNS servers for information. It supports DNS over UDP, TCP and DNS over HTTPS (DoH) and DNS over TLS (DoT). It supports multiple types of DNS queries and can be used to query public DNS servers, private DNS servers and has built-in DNS Providers.
+
+## DnsClientX Cmdlets
+### [Clear-DnsMultiResolverCache](Clear-DnsMultiResolverCache.md)
+Clears the multi-resolver fastest-endpoint cache used by the FastestWins strategy.
+
+Clears the in-memory cache used to remember the fastest endpoint for a given set of endpoints. Use this when you change network conditions or want to force re-probing. Does not affect TTL-based response caching, which expires automatically.
+
+### [ConvertFrom-DnsStamp](ConvertFrom-DnsStamp.md)
+Parses a DNS stamp into a resolver endpoint description.
+
+Converts a supported sdns:// DNS stamp into the same endpoint model used by DnsClientX resolver workflows. This command does not perform a DNS query.
+
+### [Find-DnsService](Find-DnsService.md)
+Discovers services advertised via DNS Service Discovery.
+
+Wraps DiscoverServices to return services under a domain.
+
+### [Get-DnsResolverSelection](Get-DnsResolverSelection.md)
+Loads a saved resolver score snapshot and returns the recommended resolver selection.
+
+Reads a persisted resolver score snapshot, applies the shared recommendation logic, and returns either the structured selection object or the raw target string for automation use.
+
+### [Get-DnsService](Get-DnsService.md)
+Retrieves services advertised via DNS Service Discovery.
+
+Queries the _services._dns-sd._udp tree for the specified domain and returns SRV/TXT data describing each advertised service.
+
+### [Get-DnsTransportCapability](Get-DnsTransportCapability.md)
+Returns runtime transport support information for the DnsClientX core transport surface.
+
+Reports which core transports are available on the current runtime, including modern DoH3 and DoQ support on .NET 8+.
+
+### [Get-DnsZone](Get-DnsZone.md)
+Performs a DNS zone transfer (AXFR) for a given zone.
+
+Retrieves all records for the specified zone using TCP based zone transfer.
+
+### [Invoke-DnsUpdate](Invoke-DnsUpdate.md)
+Sends DNS UPDATE messages to a server.
+
+Adds or removes records in a zone using RFC 2136 over TCP.
+
+### [Resolve-Dns](Resolve-Dns.md)
+Resolves DNS records (A, AAAA, MX, TXT, …) over UDP, TCP, DoT, DoH, QUIC, or multicast with optional multi-resolver strategies.
+
+Supports single-provider queries, explicit servers with transport selection, multiple providers with FirstSuccess/FastestWins/SequentialFallback/RoundRobin, direct resolver endpoints, DNSSEC, EDNS/ECS, concurrency control, and TTL-based response caching.
+
+### [Test-DnsBenchmark](Test-DnsBenchmark.md)
+Benchmarks one or more DNS providers or explicit resolver endpoints across repeated queries.
+
+Returns one object per candidate with latency, success rate, answer consistency, rank, and recommendation metadata. PowerShell consumers can sort, filter, format, or export the results themselves.
+
+### [Test-DnsProbe](Test-DnsProbe.md)
+Probes one built-in resolver profile or a custom resolver set and reports health, consensus, and recommendation data.
+
+Runs a single DNS query against each candidate, highlights answer mismatches, applies optional success and consensus policy gates, and can persist the scored result set for later resolver selection and reuse.
+
+### [Test-DnsResolverCatalog](Test-DnsResolverCatalog.md)
+Validates resolver endpoint catalog inputs without querying DNS.
+
+Checks inline resolver endpoints, resolver endpoint files, and resolver endpoint URLs using the same parser used by probe and benchmark workflows.

--- a/Module/Docs/Resolve-Dns.md
+++ b/Module/Docs/Resolve-Dns.md
@@ -1,0 +1,802 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Resolve-Dns
+## SYNOPSIS
+Resolves DNS records (A, AAAA, MX, TXT, …) over UDP, TCP, DoT, DoH, QUIC, or multicast with optional multi-resolver strategies.
+
+Supports single-provider queries, explicit servers with transport selection, multiple providers with FirstSuccess/FastestWins/SequentialFallback/RoundRobin, direct resolver endpoints, DNSSEC, EDNS/ECS, concurrency control, and TTL-based response caching.
+
+## SYNTAX
+### ServerName (Default)
+```powershell
+Resolve-Dns [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-DnsSelectionStrategy <DnsSelectionStrategy>] [-Server <List[string]>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-RequestFormat <DnsRequestFormat>] [-Port <int>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-AllServers] [-Fallback] [-RandomServer] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### DnsProvider
+```powershell
+Resolve-Dns [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-DnsProvider <DnsEndpoint[]>] [-DnsSelectionStrategy <DnsSelectionStrategy>] [-ResolverStrategy <MultiResolverStrategy>] [-MaxParallelism <int>] [-RespectEndpointTimeout] [-FastestCacheMinutes <int>] [-PerEndpointMaxInFlight <int>] [-ResponseCache] [-MaxCacheTtlSeconds <int>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### ResolverEndpoint
+```powershell
+Resolve-Dns [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-DnsSelectionStrategy <DnsSelectionStrategy>] [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [-ResolverStrategy <MultiResolverStrategy>] [-MaxParallelism <int>] [-RespectEndpointTimeout] [-FastestCacheMinutes <int>] [-PerEndpointMaxInFlight <int>] [-ResponseCache] [-MaxCacheTtlSeconds <int>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### ResolverDnsProvider
+```powershell
+Resolve-Dns [-Name] <string[]> [[-Type] <DnsRecordType[]>] -ResolverDnsProvider <DnsEndpoint[]> [-DnsSelectionStrategy <DnsSelectionStrategy>] [-ResolverStrategy <MultiResolverStrategy>] [-MaxParallelism <int>] [-RespectEndpointTimeout] [-FastestCacheMinutes <int>] [-PerEndpointMaxInFlight <int>] [-ResponseCache] [-MaxCacheTtlSeconds <int>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### ResolverSelection
+```powershell
+Resolve-Dns [-Name] <string[]> [[-Type] <DnsRecordType[]>] -ResolverSelectionPath <string> [-DnsSelectionStrategy <DnsSelectionStrategy>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### PatternDnsProvider
+```powershell
+Resolve-Dns [-Pattern] <string> [[-Type] <DnsRecordType[]>] [-DnsProvider <DnsEndpoint[]>] [-DnsSelectionStrategy <DnsSelectionStrategy>] [-ResolverStrategy <MultiResolverStrategy>] [-MaxParallelism <int>] [-RespectEndpointTimeout] [-FastestCacheMinutes <int>] [-PerEndpointMaxInFlight <int>] [-ResponseCache] [-MaxCacheTtlSeconds <int>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### PatternServerName
+```powershell
+Resolve-Dns [-Pattern] <string> [[-Type] <DnsRecordType[]>] [-DnsSelectionStrategy <DnsSelectionStrategy>] [-Server <List[string]>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-RequestFormat <DnsRequestFormat>] [-Port <int>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-AllServers] [-Fallback] [-RandomServer] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### PatternResolverEndpoint
+```powershell
+Resolve-Dns [-Pattern] <string> [[-Type] <DnsRecordType[]>] [-DnsSelectionStrategy <DnsSelectionStrategy>] [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [-ResolverStrategy <MultiResolverStrategy>] [-MaxParallelism <int>] [-RespectEndpointTimeout] [-FastestCacheMinutes <int>] [-PerEndpointMaxInFlight <int>] [-ResponseCache] [-MaxCacheTtlSeconds <int>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### PatternResolverDnsProvider
+```powershell
+Resolve-Dns [-Pattern] <string> [[-Type] <DnsRecordType[]>] -ResolverDnsProvider <DnsEndpoint[]> [-DnsSelectionStrategy <DnsSelectionStrategy>] [-ResolverStrategy <MultiResolverStrategy>] [-MaxParallelism <int>] [-RespectEndpointTimeout] [-FastestCacheMinutes <int>] [-PerEndpointMaxInFlight <int>] [-ResponseCache] [-MaxCacheTtlSeconds <int>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+### PatternResolverSelection
+```powershell
+Resolve-Dns [-Pattern] <string> [[-Type] <DnsRecordType[]>] -ResolverSelectionPath <string> [-DnsSelectionStrategy <DnsSelectionStrategy>] [-EdnsBufferSize <int>] [-ClientSubnet <string>] [-UserAgent <string>] [-HttpVersion <version>] [-IgnoreCertificateErrors] [-UseTcpFallback <bool>] [-ProxyUri <uri>] [-MaxConnectionsPerServer <int>] [-MaxConcurrency <int>] [-FullResponse] [-TypedRecords] [-ParseTypedTxtRecords] [-TimeOut <int>] [-RetryCount <int>] [-RetryDelayMs <int>] [-RequestDnsSec] [-ValidateDnsSec] [-EnableEdns] [-CheckingDisabled] [-RequestNsid] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Resolves DNS records (A, AAAA, MX, TXT, …) over UDP, TCP, DoT, DoH, QUIC, or multicast with optional multi-resolver strategies.
+
+Supports single-provider queries, explicit servers with transport selection, multiple providers with FirstSuccess/FastestWins/SequentialFallback/RoundRobin, direct resolver endpoints, DNSSEC, EDNS/ECS, concurrency control, and TTL-based response caching.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Resolve-Dns -ResolverSelectionPath 'C:\Path'
+```
+
+
+### EXAMPLE 2
+```powershell
+Resolve-Dns -ResolverDnsProvider @('Value')
+```
+
+
+## PARAMETERS
+
+### -AllServers
+If specified, all servers listed in Server are queried sequentially and the responses are aggregated in server order.
+
+When not specified, only the first server is queried for faster results.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, PatternServerName
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckingDisabled
+Sets the CD (checking disabled) bit on outgoing queries.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientSubnet
+Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.
+
+```yaml
+Type: String
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsProvider
+Predefined provider(s) (DnsEndpoint) for the query.
+
+When a single provider is specified, the classic single-resolver path is used. When multiple providers are specified, the multi-resolver path is used.
+
+If not specified, the default provider System (UDP) is used.
+
+```yaml
+Type: DnsEndpoint[]
+Parameter Sets: DnsProvider, PatternDnsProvider
+Aliases: None
+Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsSelectionStrategy
+How to choose among built-in provider hostnames when a single provider exposes multiple backends.
+
+```yaml
+Type: DnsSelectionStrategy
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values: First, Random, Failover
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EdnsBufferSize
+Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.
+
+```yaml
+Type: Int32
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableEdns
+Enables EDNS on outgoing queries.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Fallback
+If specified, the cmdlet sequentially queries each server until a successful response is received.
+
+This option stops on the first server that returns DnsResponseCode.NoError.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, PatternServerName
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FastestCacheMinutes
+Cache duration in minutes for FastestWins strategy.
+
+```yaml
+Type: Int32
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverDnsProvider, PatternDnsProvider, PatternResolverEndpoint, PatternResolverDnsProvider
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FullResponse
+Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).
+
+If specified, the full response is provided (answer, authority, and additional sections).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HttpVersion
+Optional preferred HTTP protocol version, for example 2.0 or 3.0.
+
+```yaml
+Type: Version
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IgnoreCertificateErrors
+Ignore TLS certificate validation errors.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxCacheTtlSeconds
+Maximal TTL allowed for cached entries (seconds). 0 leaves library default.
+
+```yaml
+Type: Int32
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverDnsProvider, PatternDnsProvider, PatternResolverEndpoint, PatternResolverDnsProvider
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxConcurrency
+Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.
+
+```yaml
+Type: Int32
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxConnectionsPerServer
+Maximum HTTP connections allowed per server. When 0, the library default is used.
+
+```yaml
+Type: Int32
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxParallelism
+Limits concurrent queries across endpoints. Defaults to 4.
+
+```yaml
+Type: Int32
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverDnsProvider, PatternDnsProvider, PatternResolverEndpoint, PatternResolverDnsProvider
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+The name of the DNS record to query for
+
+```yaml
+Type: String[]
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ParseTypedTxtRecords
+Gets or sets a value indicating whether TXT records should be
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is
+specified. When false, returns simple TXT records.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Pattern
+Pattern to expand into multiple DNS queries.
+
+```yaml
+Type: String
+Parameter Sets: PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PerEndpointMaxInFlight
+Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.
+
+```yaml
+Type: Int32
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverDnsProvider, PatternDnsProvider, PatternResolverEndpoint, PatternResolverDnsProvider
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Port
+Optional port override for the -Server path. If omitted, the selected request format decides the default port.
+
+```yaml
+Type: Int32
+Parameter Sets: ServerName, PatternServerName
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProxyUri
+Optional web proxy URI for HTTP-based transports.
+
+```yaml
+Type: Uri
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RandomServer
+If specified, the order of servers defined in Server is randomized before querying.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, PatternServerName
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestDnsSec
+Request DNSSEC data (sets the DO bit).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestFormat
+Explicit request format for the -Server path, such as DnsOverUDP, DnsOverTCP, DnsOverTLS, or DnsOverHttps.
+
+```yaml
+Type: DnsRequestFormat
+Parameter Sets: ServerName, PatternServerName
+Aliases: None
+Possible values: DnsOverHttps, DnsOverHttpsJSON, DnsOverHttpsPOST, DnsOverHttpsWirePost, DnsOverHttpsJSONPOST, DnsOverUDP, DnsOverTCP, DnsOverTLS, DnsOverQuic, DnsOverHttp2, DnsOverHttp3, DnsCrypt, DnsCryptRelay, ObliviousDnsOverHttps, DnsOverGrpc, Multicast
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestNsid
+Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverDnsProvider
+One or more predefined providers (DnsEndpoint enum) to expand into endpoints for the multi-resolver.
+
+This enables strategy control (FirstSuccess/FastestWins/SequentialFallback) and other multi-resolver options.
+
+```yaml
+Type: DnsEndpoint[]
+Parameter Sets: ResolverDnsProvider, PatternResolverDnsProvider
+Aliases: DnsProviders
+Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpoint
+One or more resolver endpoints in string format. Accepted: "1.1.1.1:53", "[2606:4700:4700::1111]:53", "dns.google:53", DoH URLs like "https://dns.google/dns-query", and transport-prefixed values such as "doq@dns.quad9.net:853" or "doh3@https://dns.quad9.net/dns-query".
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint, PatternResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpointFile
+One or more files containing resolver endpoints for the multi-resolver. Blank lines and full-line comments are ignored.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint, PatternResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpointUrl
+One or more HTTP or HTTPS URLs exposing resolver endpoints for the multi-resolver.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint, PatternResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverSelectionPath
+Path to a saved resolver score snapshot whose recommended resolver should be reused for the query.
+
+```yaml
+Type: String
+Parameter Sets: ResolverSelection, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverStrategy
+Multi-resolver strategy to use when multiple endpoints are provided.
+
+```yaml
+Type: MultiResolverStrategy
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverDnsProvider, PatternDnsProvider, PatternResolverEndpoint, PatternResolverDnsProvider
+Aliases: None
+Possible values: FirstSuccess, FastestWins, SequentialFallback, RoundRobin, Random
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RespectEndpointTimeout
+Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverDnsProvider, PatternDnsProvider, PatternResolverEndpoint, PatternResolverDnsProvider
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResponseCache
+Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverDnsProvider, PatternDnsProvider, PatternResolverEndpoint, PatternResolverDnsProvider
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RetryCount
+Number of retry attempts on transient errors.
+
+```yaml
+Type: Int32
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RetryDelayMs
+Delay between retry attempts in milliseconds.
+
+```yaml
+Type: Int32
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Server to use for the query. If not specified, the default provider System (UDP) is used.
+
+Once a server is specified, the query will be sent to that server.
+
+```yaml
+Type: List`1
+Parameter Sets: ServerName, PatternServerName
+Aliases: ServerName
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeOut
+Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.
+
+```yaml
+Type: Int32
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+The type of the record to query for. If not specified, A record is queried.
+
+```yaml
+Type: DnsRecordType[]
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values: Reserved, A, NS, MD, MF, CNAME, SOA, MB, MG, MR, NULL, WKS, PTR, HINFO, MINFO, MX, TXT, RP, AFSDB, X25, ISDN, RT, NSAP, NSAP_PTR, SIG, PX, AAAA, LOC, NXT, SRV, ATMA, NAPTR, KX, CERT, A6, DNAME, SINK, OPT, APL, DS, SSHFP, IPSECKEY, RRSIG, NSEC, DNSKEY, DHCID, NSEC3, NSEC3PARAM, TLSA, SMIMEA, HIP, NINFO, RKEY, TALINK, CDS, CDNSKEY, OPENPGPKEY, CSYNC, ZONEMD, SVCB, HTTPS, SPF, LP, TKEY, TSIG, IXFR, AXFR, MAILB, MAILA, ANY, URI, CAA, AVC, DOA, AMTRELAY, RESINFO, TA, DLV
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TypedRecords
+When set, attempts to parse answers into typed record objects.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UserAgent
+Optional User-Agent header for HTTP-based transports.
+
+```yaml
+Type: String
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseTcpFallback
+Controls whether UDP queries may fall back to TCP when truncated.
+
+```yaml
+Type: Boolean
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValidateDnsSec
+Validate DNSSEC signatures. Implies requesting DNSSEC data.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ServerName, DnsProvider, ResolverEndpoint, ResolverDnsProvider, ResolverSelection, PatternDnsProvider, PatternServerName, PatternResolverEndpoint, PatternResolverDnsProvider, PatternResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- AsyncPSCmdlet

--- a/Module/Docs/Test-DnsBenchmark.md
+++ b/Module/Docs/Test-DnsBenchmark.md
@@ -13,17 +13,17 @@ Returns one object per candidate with latency, success rate, answer consistency,
 ## SYNTAX
 ### DnsProvider (Default)
 ```powershell
-Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-DnsProvider <DnsEndpoint[]>] [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <int>] [-MinSuccessfulCandidates <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-DnsProvider <DnsEndpoint[]>] [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <Int32>] [-MinSuccessfulCandidates <Int32>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
 ```
 
 ### ResolverEndpoint
 ```powershell
-Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <int>] [-MinSuccessfulCandidates <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <Int32>] [-MinSuccessfulCandidates <Int32>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
 ```
 
 ### ResolverSelection
 ```powershell
-Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] -ResolverSelectionPath <string> [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <int>] [-MinSuccessfulCandidates <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] -ResolverSelectionPath <string> [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <Int32>] [-MinSuccessfulCandidates <Int32>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 Require a minimum number of healthy candidates with at least one successful query.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
 Aliases: None
 Possible values:
@@ -125,7 +125,7 @@ Accept wildcard characters: False
 Require a minimum overall successful query percentage for the run to pass policy.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
 Aliases: None
 Possible values:

--- a/Module/Docs/Test-DnsBenchmark.md
+++ b/Module/Docs/Test-DnsBenchmark.md
@@ -1,0 +1,330 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Test-DnsBenchmark
+## SYNOPSIS
+Benchmarks one or more DNS providers or explicit resolver endpoints across repeated queries.
+
+Returns one object per candidate with latency, success rate, answer consistency, rank, and recommendation metadata. PowerShell consumers can sort, filter, format, or export the results themselves.
+
+## SYNTAX
+### DnsProvider (Default)
+```powershell
+Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-DnsProvider <DnsEndpoint[]>] [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <int>] [-MinSuccessfulCandidates <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+```
+
+### ResolverEndpoint
+```powershell
+Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <int>] [-MinSuccessfulCandidates <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+```
+
+### ResolverSelection
+```powershell
+Test-DnsBenchmark [-Name] <string[]> [[-Type] <DnsRecordType[]>] -ResolverSelectionPath <string> [-Attempts <int>] [-MaxConcurrency <int>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-MinSuccessPercent <int>] [-MinSuccessfulCandidates <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Benchmarks one or more DNS providers or explicit resolver endpoints across repeated queries.
+
+Returns one object per candidate with latency, success rate, answer consistency, rank, and recommendation metadata. PowerShell consumers can sort, filter, format, or export the results themselves.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Test-DnsBenchmark -ResolverSelectionPath 'C:\Path'
+```
+
+
+## PARAMETERS
+
+### -Attempts
+Number of attempts per domain/type combination.
+
+```yaml
+Type: Int32
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsProvider
+Built-in provider candidates to benchmark.
+
+```yaml
+Type: DnsEndpoint[]
+Parameter Sets: DnsProvider
+Aliases: None
+Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeSummary
+Emits a run-level summary object after the per-candidate benchmark results.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxConcurrency
+Maximum concurrent in-flight benchmark queries across the whole run.
+
+```yaml
+Type: Int32
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinSuccessfulCandidates
+Require a minimum number of healthy candidates with at least one successful query.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinSuccessPercent
+Require a minimum overall successful query percentage for the run to pass policy.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Domain names to benchmark.
+
+```yaml
+Type: String[]
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestDnsSec
+Request DNSSEC records by setting the DO bit.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpoint
+Explicit resolver endpoint candidates to benchmark.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpointFile
+Files containing resolver endpoint candidates to benchmark.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpointUrl
+HTTP or HTTPS URLs exposing resolver endpoint candidates to benchmark.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverSelectionPath
+Path to a saved resolver score snapshot whose recommended resolver should be reused as the single benchmark candidate.
+
+```yaml
+Type: String
+Parameter Sets: ResolverSelection
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SavePath
+Optional path where the benchmark score snapshot should be saved for later selection and reuse.
+
+```yaml
+Type: String
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SummaryOnly
+Emits only the run-level summary object and suppresses per-candidate rows.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeOut
+Per-query timeout in milliseconds.
+
+```yaml
+Type: Int32
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Record types to benchmark.
+
+```yaml
+Type: DnsRecordType[]
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values: Reserved, A, NS, MD, MF, CNAME, SOA, MB, MG, MR, NULL, WKS, PTR, HINFO, MINFO, MX, TXT, RP, AFSDB, X25, ISDN, RT, NSAP, NSAP_PTR, SIG, PX, AAAA, LOC, NXT, SRV, ATMA, NAPTR, KX, CERT, A6, DNAME, SINK, OPT, APL, DS, SSHFP, IPSECKEY, RRSIG, NSEC, DNSKEY, DHCID, NSEC3, NSEC3PARAM, TLSA, SMIMEA, HIP, NINFO, RKEY, TALINK, CDS, CDNSKEY, OPENPGPKEY, CSYNC, ZONEMD, SVCB, HTTPS, SPF, LP, TKEY, TSIG, IXFR, AXFR, MAILB, MAILA, ANY, URI, CAA, AVC, DOA, AMTRELAY, RESINFO, TA, DLV
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValidateDnsSec
+Validate DNSSEC signatures. Implies RequestDnsSec.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `DnsClientX.PowerShell.DnsBenchmarkResult`: Per-candidate DNS benchmark output for PowerShell consumers.
+- `DnsClientX.PowerShell.DnsBenchmarkSummary`: Run-level DNS benchmark summary for PowerShell consumers.
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Test-DnsProbe.md
+++ b/Module/Docs/Test-DnsProbe.md
@@ -13,17 +13,17 @@ Runs a single DNS query against each candidate, highlights answer mismatches, ap
 ## SYNTAX
 ### DnsProvider (Default)
 ```powershell
-Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] [-DnsProvider <DnsEndpoint>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <int>] [-MinSuccessCount <int>] [-MinSuccessPercent <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] [-DnsProvider <DnsEndpoint>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <Int32>] [-MinSuccessCount <Int32>] [-MinSuccessPercent <Int32>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
 ```
 
 ### ResolverEndpoint
 ```powershell
-Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <int>] [-MinSuccessCount <int>] [-MinSuccessPercent <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <Int32>] [-MinSuccessCount <Int32>] [-MinSuccessPercent <Int32>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
 ```
 
 ### ResolverSelection
 ```powershell
-Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] -ResolverSelectionPath <string> [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <int>] [-MinSuccessCount <int>] [-MinSuccessPercent <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] -ResolverSelectionPath <string> [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <Int32>] [-MinSuccessCount <Int32>] [-MinSuccessPercent <Int32>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 Require the leading answer group to reach at least this consensus percentage.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
 Aliases: None
 Possible values:
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 Require at least this many successful probe candidates.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
 Aliases: None
 Possible values:
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 Require at least this successful probe percentage across all candidates.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
 Aliases: None
 Possible values:

--- a/Module/Docs/Test-DnsProbe.md
+++ b/Module/Docs/Test-DnsProbe.md
@@ -1,0 +1,330 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Test-DnsProbe
+## SYNOPSIS
+Probes one built-in resolver profile or a custom resolver set and reports health, consensus, and recommendation data.
+
+Runs a single DNS query against each candidate, highlights answer mismatches, applies optional success and consensus policy gates, and can persist the scored result set for later resolver selection and reuse.
+
+## SYNTAX
+### DnsProvider (Default)
+```powershell
+Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] [-DnsProvider <DnsEndpoint>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <int>] [-MinSuccessCount <int>] [-MinSuccessPercent <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+```
+
+### ResolverEndpoint
+```powershell
+Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <int>] [-MinSuccessCount <int>] [-MinSuccessPercent <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+```
+
+### ResolverSelection
+```powershell
+Test-DnsProbe [-Name] <string> [[-Type] <DnsRecordType>] -ResolverSelectionPath <string> [-TimeOut <int>] [-RequestDnsSec] [-ValidateDnsSec] [-RequireConsensus] [-MinConsensusPercent <int>] [-MinSuccessCount <int>] [-MinSuccessPercent <int>] [-IncludeSummary] [-SummaryOnly] [-SavePath <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Probes one built-in resolver profile or a custom resolver set and reports health, consensus, and recommendation data.
+
+Runs a single DNS query against each candidate, highlights answer mismatches, applies optional success and consensus policy gates, and can persist the scored result set for later resolver selection and reuse.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Test-DnsProbe -ResolverSelectionPath 'C:\Path'
+```
+
+
+## PARAMETERS
+
+### -DnsProvider
+Built-in resolver profile to probe.
+
+```yaml
+Type: DnsEndpoint
+Parameter Sets: DnsProvider
+Aliases: None
+Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeSummary
+Emits a run-level summary object after the per-candidate probe rows.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinConsensusPercent
+Require the leading answer group to reach at least this consensus percentage.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinSuccessCount
+Require at least this many successful probe candidates.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinSuccessPercent
+Require at least this successful probe percentage across all candidates.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Domain name to probe.
+
+```yaml
+Type: String
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestDnsSec
+Request DNSSEC records by setting the DO bit.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequireConsensus
+Require unanimous answer consensus among successful candidates.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpoint
+Explicit resolver endpoints to probe.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpointFile
+Files containing resolver endpoints to probe.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpointUrl
+HTTP or HTTPS URLs exposing resolver endpoints to probe.
+
+```yaml
+Type: String[]
+Parameter Sets: ResolverEndpoint
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverSelectionPath
+Path to a saved resolver score snapshot whose recommended resolver should be reused as the single probe candidate.
+
+```yaml
+Type: String
+Parameter Sets: ResolverSelection
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SavePath
+Optional path where the probe score snapshot should be saved for later selection and reuse.
+
+```yaml
+Type: String
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SummaryOnly
+Emits only the run-level summary object and suppresses per-candidate rows.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeOut
+Per-query timeout in milliseconds.
+
+```yaml
+Type: Int32
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Record type to probe.
+
+```yaml
+Type: DnsRecordType
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values: Reserved, A, NS, MD, MF, CNAME, SOA, MB, MG, MR, NULL, WKS, PTR, HINFO, MINFO, MX, TXT, RP, AFSDB, X25, ISDN, RT, NSAP, NSAP_PTR, SIG, PX, AAAA, LOC, NXT, SRV, ATMA, NAPTR, KX, CERT, A6, DNAME, SINK, OPT, APL, DS, SSHFP, IPSECKEY, RRSIG, NSEC, DNSKEY, DHCID, NSEC3, NSEC3PARAM, TLSA, SMIMEA, HIP, NINFO, RKEY, TALINK, CDS, CDNSKEY, OPENPGPKEY, CSYNC, ZONEMD, SVCB, HTTPS, SPF, LP, TKEY, TSIG, IXFR, AXFR, MAILB, MAILA, ANY, URI, CAA, AVC, DOA, AMTRELAY, RESINFO, TA, DLV
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValidateDnsSec
+Validate DNSSEC signatures. Implies RequestDnsSec.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DnsProvider, ResolverEndpoint, ResolverSelection
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `DnsClientX.PowerShell.DnsProbeResult`: Per-candidate DNS probe output for PowerShell consumers.
+- `DnsClientX.PowerShell.DnsProbeSummary`: Run-level DNS probe summary for PowerShell consumers.
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Test-DnsResolverCatalog.md
+++ b/Module/Docs/Test-DnsResolverCatalog.md
@@ -1,0 +1,95 @@
+---
+external help file: DnsClientX-help.xml
+Module Name: DnsClientX
+online version: https://github.com/EvotecIT/DnsClientX/blob/master/README.md
+schema: 2.0.0
+---
+# Test-DnsResolverCatalog
+## SYNOPSIS
+Validates resolver endpoint catalog inputs without querying DNS.
+
+Checks inline resolver endpoints, resolver endpoint files, and resolver endpoint URLs using the same parser used by probe and benchmark workflows.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Test-DnsResolverCatalog [-ResolverEndpoint <string[]>] [-ResolverEndpointFile <string[]>] [-ResolverEndpointUrl <string[]>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Validates resolver endpoint catalog inputs without querying DNS.
+
+Checks inline resolver endpoints, resolver endpoint files, and resolver endpoint URLs using the same parser used by probe and benchmark workflows.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Test-DnsResolverCatalog -ResolverEndpoint @('Value')
+```
+
+
+## PARAMETERS
+
+### -ResolverEndpoint
+Inline resolver endpoint entries.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -ResolverEndpointFile
+Files containing resolver endpoint entries.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResolverEndpointUrl
+HTTP or HTTPS URLs containing resolver endpoint entries.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String[]`
+
+## OUTPUTS
+
+- `DnsClientX.ResolverEndpointValidationResult`
+
+## RELATED LINKS
+
+- None

--- a/Module/en-US/DnsClientX-help.xml
+++ b/Module/en-US/DnsClientX-help.xml
@@ -6976,9 +6976,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require a minimum number of healthy candidates with at least one successful query.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -6988,9 +6988,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require a minimum overall successful query percentage for the run to pass policy.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -7203,9 +7203,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require a minimum number of healthy candidates with at least one successful query.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -7215,9 +7215,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require a minimum overall successful query percentage for the run to pass policy.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -7466,9 +7466,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require a minimum number of healthy candidates with at least one successful query.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -7478,9 +7478,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require a minimum overall successful query percentage for the run to pass policy.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -7750,9 +7750,9 @@ specified. When false, returns simple TXT records.</maml:para>
         <maml:description>
           <maml:para>Require a minimum number of healthy candidates with at least one successful query.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -7762,9 +7762,9 @@ specified. When false, returns simple TXT records.</maml:para>
         <maml:description>
           <maml:para>Require a minimum overall successful query percentage for the run to pass policy.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -8102,9 +8102,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require the leading answer group to reach at least this consensus percentage.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8114,9 +8114,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require at least this many successful probe candidates.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8126,9 +8126,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require at least this successful probe percentage across all candidates.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8329,9 +8329,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require the leading answer group to reach at least this consensus percentage.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8341,9 +8341,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require at least this many successful probe candidates.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8353,9 +8353,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require at least this successful probe percentage across all candidates.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8592,9 +8592,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require the leading answer group to reach at least this consensus percentage.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8604,9 +8604,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require at least this many successful probe candidates.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8616,9 +8616,9 @@ specified. When false, returns simple TXT records.</maml:para>
           <maml:description>
             <maml:para>Require at least this successful probe percentage across all candidates.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8876,9 +8876,9 @@ specified. When false, returns simple TXT records.</maml:para>
         <maml:description>
           <maml:para>Require the leading answer group to reach at least this consensus percentage.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -8888,9 +8888,9 @@ specified. When false, returns simple TXT records.</maml:para>
         <maml:description>
           <maml:para>Require at least this many successful probe candidates.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -8900,9 +8900,9 @@ specified. When false, returns simple TXT records.</maml:para>
         <maml:description>
           <maml:para>Require at least this successful probe percentage across all candidates.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/Module/en-US/DnsClientX-help.xml
+++ b/Module/en-US/DnsClientX-help.xml
@@ -1,0 +1,9299 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Clear-DnsMultiResolverCache</command:name>
+      <command:verb>Clear</command:verb>
+      <command:noun>DnsMultiResolverCache</command:noun>
+      <maml:description>
+        <maml:para>Clears the multi-resolver fastest-endpoint cache used by the FastestWins strategy.</maml:para>
+        <maml:para>Clears the in-memory cache used to remember the fastest endpoint for a given set of endpoints. Use this when you change network conditions or want to force re-probing. Does not affect TTL-based response caching, which expires automatically.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Clears the multi-resolver fastest-endpoint cache used by the FastestWins strategy.</maml:para>
+      <maml:para>Clears the in-memory cache used to remember the fastest endpoint for a given set of endpoints. Use this when you change network conditions or want to force re-probing. Does not affect TTL-based response caching, which expires automatically.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="All">
+        <maml:name>Clear-DnsMultiResolverCache</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>All</maml:name>
+          <maml:description>
+            <maml:para>Clear all cached fastest-endpoint choices.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverEndpoint">
+        <maml:name>Clear-DnsMultiResolverCache</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpoint</maml:name>
+          <maml:description>
+            <maml:para>Specific endpoints to clear, e.g. "1.1.1.1:53", "[2606:4700:4700::1111]:53", or DoH URLs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverDnsProvider">
+        <maml:name>Clear-DnsMultiResolverCache</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverDnsProvider</maml:name>
+          <maml:description>
+            <maml:para>Clear cache entries for the specified predefined providers (DnsEndpoint enum).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DnsEndpoint[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="DnsProvider">
+        <maml:name>Clear-DnsMultiResolverCache</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsProvider</maml:name>
+          <maml:description>
+            <maml:para>Alternate parameter: providers to clear when using the classic -DnsProvider parameter style.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DnsEndpoint[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>All</maml:name>
+        <maml:description>
+          <maml:para>Clear all cached fastest-endpoint choices.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DnsProvider</maml:name>
+        <maml:description>
+          <maml:para>Alternate parameter: providers to clear when using the classic -DnsProvider parameter style.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DnsEndpoint[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsEndpoint[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverDnsProvider</maml:name>
+        <maml:description>
+          <maml:para>Clear cache entries for the specified predefined providers (DnsEndpoint enum).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DnsEndpoint[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsEndpoint[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpoint</maml:name>
+        <maml:description>
+          <maml:para>Specific endpoints to clear, e.g. "1.1.1.1:53", "[2606:4700:4700::1111]:53", or DoH URLs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Clear-DnsMultiResolverCache -All</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>Clear-DnsMultiResolverCache -DnsProvider @('Value')</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 3</maml:title>
+        <dev:code>Clear-DnsMultiResolverCache -ResolverDnsProvider @('Value')</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>ConvertFrom-DnsStamp</command:name>
+      <command:verb>ConvertFrom</command:verb>
+      <command:noun>DnsStamp</command:noun>
+      <maml:description>
+        <maml:para>Parses a DNS stamp into a resolver endpoint description.</maml:para>
+        <maml:para>Converts a supported sdns:// DNS stamp into the same endpoint model used by DnsClientX resolver workflows. This command does not perform a DNS query.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Parses a DNS stamp into a resolver endpoint description.</maml:para>
+      <maml:para>Converts a supported sdns:// DNS stamp into the same endpoint model used by DnsClientX resolver workflows. This command does not perform a DNS query.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>ConvertFrom-DnsStamp</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="0" aliases="None">
+          <maml:name>Stamp</maml:name>
+          <maml:description>
+            <maml:para>DNS stamp to parse.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="0" aliases="None">
+        <maml:name>Stamp</maml:name>
+        <maml:description>
+          <maml:para>DNS stamp to parse.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DnsClientX.DnsStampInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>ConvertFrom-DnsStamp -Stamp 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Find-DnsService</command:name>
+      <command:verb>Find</command:verb>
+      <command:noun>DnsService</command:noun>
+      <maml:description>
+        <maml:para>Discovers services advertised via DNS Service Discovery.</maml:para>
+        <maml:para>Wraps DiscoverServices to return services under a domain.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Discovers services advertised via DNS Service Discovery.</maml:para>
+      <maml:para>Wraps DiscoverServices to return services under a domain.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Find-DnsService</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Domain</maml:name>
+          <maml:description>
+            <maml:para>Domain name to search for advertised services.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Domain</maml:name>
+        <maml:description>
+          <maml:para>Domain name to search for advertised services.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Find-DnsService -Domain 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DnsResolverSelection</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DnsResolverSelection</command:noun>
+      <maml:description>
+        <maml:para>Loads a saved resolver score snapshot and returns the recommended resolver selection.</maml:para>
+        <maml:para>Reads a persisted resolver score snapshot, applies the shared recommendation logic, and returns either the structured selection object or the raw target string for automation use.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Loads a saved resolver score snapshot and returns the recommended resolver selection.</maml:para>
+      <maml:para>Reads a persisted resolver score snapshot, applies the shared recommendation logic, and returns either the structured selection object or the raw target string for automation use.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DnsResolverSelection</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AsString</maml:name>
+          <maml:description>
+            <maml:para>Emits only the raw selected target string instead of the structured selection object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Path to the saved resolver score snapshot.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AsString</maml:name>
+        <maml:description>
+          <maml:para>Emits only the raw selected target string instead of the structured selection object.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>Path to the saved resolver score snapshot.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DnsClientX.ResolverSelectionResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-DnsResolverSelection -Path 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DnsService</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DnsService</command:noun>
+      <maml:description>
+        <maml:para>Retrieves services advertised via DNS Service Discovery.</maml:para>
+        <maml:para>Queries the _services._dns-sd._udp tree for the specified domain and returns SRV/TXT data describing each advertised service.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves services advertised via DNS Service Discovery.</maml:para>
+      <maml:para>Queries the _services._dns-sd._udp tree for the specified domain and returns SRV/TXT data describing each advertised service.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DnsService</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Domain</maml:name>
+          <maml:description>
+            <maml:para>Domain name to search for advertised services.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Domain</maml:name>
+        <maml:description>
+          <maml:para>Domain name to search for advertised services.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-DnsService -Domain 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DnsTransportCapability</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DnsTransportCapability</command:noun>
+      <maml:description>
+        <maml:para>Returns runtime transport support information for the DnsClientX core transport surface.</maml:para>
+        <maml:para>Reports which core transports are available on the current runtime, including modern DoH3 and DoQ support on .NET 8+.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Returns runtime transport support information for the DnsClientX core transport surface.</maml:para>
+      <maml:para>Reports which core transports are available on the current runtime, including modern DoH3 and DoQ support on .NET 8+.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DnsTransportCapability</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ModernOnly</maml:name>
+          <maml:description>
+            <maml:para>Emits only modern runtime-gated transports such as DoH3 and DoQ.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ModernOnly</maml:name>
+        <maml:description>
+          <maml:para>Emits only modern runtime-gated transports such as DoH3 and DoQ.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DnsClientX.DnsTransportCapabilityInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-DnsTransportCapability -ModernOnly</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DnsZone</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DnsZone</command:noun>
+      <maml:description>
+        <maml:para>Performs a DNS zone transfer (AXFR) for a given zone.</maml:para>
+        <maml:para>Retrieves all records for the specified zone using TCP based zone transfer.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Performs a DNS zone transfer (AXFR) for a given zone.</maml:para>
+      <maml:para>Retrieves all records for the specified zone using TCP based zone transfer.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="ExplicitServer">
+        <maml:name>Get-DnsZone</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>Port number to use. Defaults to 53.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="ServerName">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>DNS server to query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Zone</maml:name>
+          <maml:description>
+            <maml:para>The zone to transfer.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Recursive">
+        <maml:name>Get-DnsZone</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsProvider</maml:name>
+          <maml:description>
+            <maml:para>Resolver profile used to discover authoritative servers when Recursive is specified and no explicit discovery server is provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsEndpoint</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeTransferSummary</maml:name>
+          <maml:description>
+            <maml:para>Emit the recursive transfer summary object before the transferred RRsets.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>Port number to use. Defaults to 53.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Recursive</maml:name>
+          <maml:description>
+            <maml:para>Discover authoritative servers first and attempt AXFR against them in order.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="ServerName">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>DNS server to query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Zone</maml:name>
+          <maml:description>
+            <maml:para>The zone to transfer.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DnsProvider</maml:name>
+        <maml:description>
+          <maml:para>Resolver profile used to discover authoritative servers when Recursive is specified and no explicit discovery server is provided.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsEndpoint</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsEndpoint</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeTransferSummary</maml:name>
+        <maml:description>
+          <maml:para>Emit the recursive transfer summary object before the transferred RRsets.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Port</maml:name>
+        <maml:description>
+          <maml:para>Port number to use. Defaults to 53.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Recursive</maml:name>
+        <maml:description>
+          <maml:para>Discover authoritative servers first and attempt AXFR against them in order.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="ServerName">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>DNS server to query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Zone</maml:name>
+        <maml:description>
+          <maml:para>The zone to transfer.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-DnsZone -DnsProvider 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>Get-DnsZone -Recursive</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DnsUpdate</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DnsUpdate</command:noun>
+      <maml:description>
+        <maml:para>Sends DNS UPDATE messages to a server.</maml:para>
+        <maml:para>Adds or removes records in a zone using RFC 2136 over TCP.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Sends DNS UPDATE messages to a server.</maml:para>
+      <maml:para>Adds or removes records in a zone using RFC 2136 over TCP.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DnsUpdate</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="4" aliases="None">
+          <maml:name>Data</maml:name>
+          <maml:description>
+            <maml:para>Record data used when adding a record.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Delete</maml:name>
+          <maml:description>
+            <maml:para>If specified, the record is removed instead of added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DeleteValue</maml:name>
+          <maml:description>
+            <maml:para>If specified, only the exact value supplied through Data is removed.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="2" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Record name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>Port number to use. Defaults to 53.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="ServerName">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>DNS server to send the update to.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TsigKey</maml:name>
+          <maml:description>
+            <maml:para>Optional typed TSIG key used to authenticate the update and its response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TsigKey</command:parameterValue>
+          <dev:type>
+            <maml:name>TsigKey</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Ttl</maml:name>
+          <maml:description>
+            <maml:para>TTL for the new record. Zero is valid under RFC 2136; the default is 300 seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="3" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Type of record.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DnsRecordType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Zone</maml:name>
+          <maml:description>
+            <maml:para>Zone to update.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="4" aliases="None">
+        <maml:name>Data</maml:name>
+        <maml:description>
+          <maml:para>Record data used when adding a record.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Delete</maml:name>
+        <maml:description>
+          <maml:para>If specified, the record is removed instead of added.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DeleteValue</maml:name>
+        <maml:description>
+          <maml:para>If specified, only the exact value supplied through Data is removed.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="2" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Record name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Port</maml:name>
+        <maml:description>
+          <maml:para>Port number to use. Defaults to 53.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="ServerName">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>DNS server to send the update to.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TsigKey</maml:name>
+        <maml:description>
+          <maml:para>Optional typed TSIG key used to authenticate the update and its response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TsigKey</command:parameterValue>
+        <dev:type>
+          <maml:name>TsigKey</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Ttl</maml:name>
+        <maml:description>
+          <maml:para>TTL for the new record. Zero is valid under RFC 2136; the default is 300 seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="3" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Type of record.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DnsRecordType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsRecordType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Zone</maml:name>
+        <maml:description>
+          <maml:para>Zone to update.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-DnsUpdate -Name 'Name'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Resolve-Dns</command:name>
+      <command:verb>Resolve</command:verb>
+      <command:noun>Dns</command:noun>
+      <maml:description>
+        <maml:para>Resolves DNS records (A, AAAA, MX, TXT, …) over UDP, TCP, DoT, DoH, QUIC, or multicast with optional multi-resolver strategies.</maml:para>
+        <maml:para>Supports single-provider queries, explicit servers with transport selection, multiple providers with FirstSuccess/FastestWins/SequentialFallback/RoundRobin, direct resolver endpoints, DNSSEC, EDNS/ECS, concurrency control, and TTL-based response caching.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Resolves DNS records (A, AAAA, MX, TXT, …) over UDP, TCP, DoT, DoH, QUIC, or multicast with optional multi-resolver strategies.</maml:para>
+      <maml:para>Supports single-provider queries, explicit servers with transport selection, multiple providers with FirstSuccess/FastestWins/SequentialFallback/RoundRobin, direct resolver endpoints, DNSSEC, EDNS/ECS, concurrency control, and TTL-based response caching.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="ServerName">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AllServers</maml:name>
+          <maml:description>
+            <maml:para>If specified, all servers listed in Server are queried sequentially and the responses are aggregated in server order.</maml:para>
+            <maml:para>When not specified, only the first server is queried for faster results.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Fallback</maml:name>
+          <maml:description>
+            <maml:para>If specified, the cmdlet sequentially queries each server until a successful response is received.</maml:para>
+            <maml:para>This option stops on the first server that returns DnsResponseCode.NoError.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>The name of the DNS record to query for</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>Optional port override for the -Server path. If omitted, the selected request format decides the default port.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RandomServer</maml:name>
+          <maml:description>
+            <maml:para>If specified, the order of servers defined in Server is randomized before querying.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestFormat</maml:name>
+          <maml:description>
+            <maml:para>Explicit request format for the -Server path, such as DnsOverUDP, DnsOverTCP, DnsOverTLS, or DnsOverHttps.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRequestFormat</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttps</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttpsJSON</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttpsPOST</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttpsWirePost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttpsJSONPOST</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverUDP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverTCP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverTLS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttp2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttp3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ObliviousDnsOverHttps</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverGrpc</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Multicast</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRequestFormat</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ServerName">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Server to use for the query. If not specified, the default provider System (UDP) is used.</maml:para>
+            <maml:para>Once a server is specified, the query will be sent to that server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">List`1</command:parameterValue>
+          <dev:type>
+            <maml:name>List`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="DnsProvider">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsProvider</maml:name>
+          <maml:description>
+            <maml:para>Predefined provider(s) (DnsEndpoint) for the query.</maml:para>
+            <maml:para>When a single provider is specified, the classic single-resolver path is used. When multiple providers are specified, the multi-resolver path is used.</maml:para>
+            <maml:para>If not specified, the default provider System (UDP) is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsEndpoint[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FastestCacheMinutes</maml:name>
+          <maml:description>
+            <maml:para>Cache duration in minutes for FastestWins strategy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxCacheTtlSeconds</maml:name>
+          <maml:description>
+            <maml:para>Maximal TTL allowed for cached entries (seconds). 0 leaves library default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxParallelism</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries across endpoints. Defaults to 4.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>The name of the DNS record to query for</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PerEndpointMaxInFlight</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverStrategy</maml:name>
+          <maml:description>
+            <maml:para>Multi-resolver strategy to use when multiple endpoints are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MultiResolverStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">FirstSuccess</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FastestWins</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SequentialFallback</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RoundRobin</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MultiResolverStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RespectEndpointTimeout</maml:name>
+          <maml:description>
+            <maml:para>Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResponseCache</maml:name>
+          <maml:description>
+            <maml:para>Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverEndpoint">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FastestCacheMinutes</maml:name>
+          <maml:description>
+            <maml:para>Cache duration in minutes for FastestWins strategy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxCacheTtlSeconds</maml:name>
+          <maml:description>
+            <maml:para>Maximal TTL allowed for cached entries (seconds). 0 leaves library default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxParallelism</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries across endpoints. Defaults to 4.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>The name of the DNS record to query for</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PerEndpointMaxInFlight</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpoint</maml:name>
+          <maml:description>
+            <maml:para>One or more resolver endpoints in string format. Accepted: "1.1.1.1:53", "[2606:4700:4700::1111]:53", "dns.google:53", DoH URLs like "https://dns.google/dns-query", and transport-prefixed values such as "doq@dns.quad9.net:853" or "doh3@https://dns.quad9.net/dns-query".</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointFile</maml:name>
+          <maml:description>
+            <maml:para>One or more files containing resolver endpoints for the multi-resolver. Blank lines and full-line comments are ignored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointUrl</maml:name>
+          <maml:description>
+            <maml:para>One or more HTTP or HTTPS URLs exposing resolver endpoints for the multi-resolver.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverStrategy</maml:name>
+          <maml:description>
+            <maml:para>Multi-resolver strategy to use when multiple endpoints are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MultiResolverStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">FirstSuccess</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FastestWins</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SequentialFallback</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RoundRobin</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MultiResolverStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RespectEndpointTimeout</maml:name>
+          <maml:description>
+            <maml:para>Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResponseCache</maml:name>
+          <maml:description>
+            <maml:para>Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverDnsProvider">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FastestCacheMinutes</maml:name>
+          <maml:description>
+            <maml:para>Cache duration in minutes for FastestWins strategy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxCacheTtlSeconds</maml:name>
+          <maml:description>
+            <maml:para>Maximal TTL allowed for cached entries (seconds). 0 leaves library default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxParallelism</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries across endpoints. Defaults to 4.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>The name of the DNS record to query for</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PerEndpointMaxInFlight</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="DnsProviders">
+          <maml:name>ResolverDnsProvider</maml:name>
+          <maml:description>
+            <maml:para>One or more predefined providers (DnsEndpoint enum) to expand into endpoints for the multi-resolver.</maml:para>
+            <maml:para>This enables strategy control (FirstSuccess/FastestWins/SequentialFallback) and other multi-resolver options.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DnsEndpoint[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverStrategy</maml:name>
+          <maml:description>
+            <maml:para>Multi-resolver strategy to use when multiple endpoints are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MultiResolverStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">FirstSuccess</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FastestWins</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SequentialFallback</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RoundRobin</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MultiResolverStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RespectEndpointTimeout</maml:name>
+          <maml:description>
+            <maml:para>Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResponseCache</maml:name>
+          <maml:description>
+            <maml:para>Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverSelection">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>The name of the DNS record to query for</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverSelectionPath</maml:name>
+          <maml:description>
+            <maml:para>Path to a saved resolver score snapshot whose recommended resolver should be reused for the query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="PatternDnsProvider">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsProvider</maml:name>
+          <maml:description>
+            <maml:para>Predefined provider(s) (DnsEndpoint) for the query.</maml:para>
+            <maml:para>When a single provider is specified, the classic single-resolver path is used. When multiple providers are specified, the multi-resolver path is used.</maml:para>
+            <maml:para>If not specified, the default provider System (UDP) is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsEndpoint[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FastestCacheMinutes</maml:name>
+          <maml:description>
+            <maml:para>Cache duration in minutes for FastestWins strategy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxCacheTtlSeconds</maml:name>
+          <maml:description>
+            <maml:para>Maximal TTL allowed for cached entries (seconds). 0 leaves library default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxParallelism</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries across endpoints. Defaults to 4.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Pattern</maml:name>
+          <maml:description>
+            <maml:para>Pattern to expand into multiple DNS queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PerEndpointMaxInFlight</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverStrategy</maml:name>
+          <maml:description>
+            <maml:para>Multi-resolver strategy to use when multiple endpoints are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MultiResolverStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">FirstSuccess</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FastestWins</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SequentialFallback</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RoundRobin</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MultiResolverStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RespectEndpointTimeout</maml:name>
+          <maml:description>
+            <maml:para>Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResponseCache</maml:name>
+          <maml:description>
+            <maml:para>Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="PatternServerName">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AllServers</maml:name>
+          <maml:description>
+            <maml:para>If specified, all servers listed in Server are queried sequentially and the responses are aggregated in server order.</maml:para>
+            <maml:para>When not specified, only the first server is queried for faster results.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Fallback</maml:name>
+          <maml:description>
+            <maml:para>If specified, the cmdlet sequentially queries each server until a successful response is received.</maml:para>
+            <maml:para>This option stops on the first server that returns DnsResponseCode.NoError.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Pattern</maml:name>
+          <maml:description>
+            <maml:para>Pattern to expand into multiple DNS queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>Optional port override for the -Server path. If omitted, the selected request format decides the default port.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RandomServer</maml:name>
+          <maml:description>
+            <maml:para>If specified, the order of servers defined in Server is randomized before querying.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestFormat</maml:name>
+          <maml:description>
+            <maml:para>Explicit request format for the -Server path, such as DnsOverUDP, DnsOverTCP, DnsOverTLS, or DnsOverHttps.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRequestFormat</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttps</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttpsJSON</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttpsPOST</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttpsWirePost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttpsJSONPOST</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverUDP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverTCP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverTLS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttp2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverHttp3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ObliviousDnsOverHttps</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsOverGrpc</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Multicast</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRequestFormat</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ServerName">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Server to use for the query. If not specified, the default provider System (UDP) is used.</maml:para>
+            <maml:para>Once a server is specified, the query will be sent to that server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">List`1</command:parameterValue>
+          <dev:type>
+            <maml:name>List`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="PatternResolverEndpoint">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FastestCacheMinutes</maml:name>
+          <maml:description>
+            <maml:para>Cache duration in minutes for FastestWins strategy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxCacheTtlSeconds</maml:name>
+          <maml:description>
+            <maml:para>Maximal TTL allowed for cached entries (seconds). 0 leaves library default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxParallelism</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries across endpoints. Defaults to 4.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Pattern</maml:name>
+          <maml:description>
+            <maml:para>Pattern to expand into multiple DNS queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PerEndpointMaxInFlight</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpoint</maml:name>
+          <maml:description>
+            <maml:para>One or more resolver endpoints in string format. Accepted: "1.1.1.1:53", "[2606:4700:4700::1111]:53", "dns.google:53", DoH URLs like "https://dns.google/dns-query", and transport-prefixed values such as "doq@dns.quad9.net:853" or "doh3@https://dns.quad9.net/dns-query".</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointFile</maml:name>
+          <maml:description>
+            <maml:para>One or more files containing resolver endpoints for the multi-resolver. Blank lines and full-line comments are ignored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointUrl</maml:name>
+          <maml:description>
+            <maml:para>One or more HTTP or HTTPS URLs exposing resolver endpoints for the multi-resolver.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverStrategy</maml:name>
+          <maml:description>
+            <maml:para>Multi-resolver strategy to use when multiple endpoints are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MultiResolverStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">FirstSuccess</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FastestWins</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SequentialFallback</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RoundRobin</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MultiResolverStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RespectEndpointTimeout</maml:name>
+          <maml:description>
+            <maml:para>Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResponseCache</maml:name>
+          <maml:description>
+            <maml:para>Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="PatternResolverDnsProvider">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FastestCacheMinutes</maml:name>
+          <maml:description>
+            <maml:para>Cache duration in minutes for FastestWins strategy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxCacheTtlSeconds</maml:name>
+          <maml:description>
+            <maml:para>Maximal TTL allowed for cached entries (seconds). 0 leaves library default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxParallelism</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries across endpoints. Defaults to 4.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Pattern</maml:name>
+          <maml:description>
+            <maml:para>Pattern to expand into multiple DNS queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PerEndpointMaxInFlight</maml:name>
+          <maml:description>
+            <maml:para>Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="DnsProviders">
+          <maml:name>ResolverDnsProvider</maml:name>
+          <maml:description>
+            <maml:para>One or more predefined providers (DnsEndpoint enum) to expand into endpoints for the multi-resolver.</maml:para>
+            <maml:para>This enables strategy control (FirstSuccess/FastestWins/SequentialFallback) and other multi-resolver options.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DnsEndpoint[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverStrategy</maml:name>
+          <maml:description>
+            <maml:para>Multi-resolver strategy to use when multiple endpoints are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MultiResolverStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">FirstSuccess</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FastestWins</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SequentialFallback</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RoundRobin</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MultiResolverStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RespectEndpointTimeout</maml:name>
+          <maml:description>
+            <maml:para>Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResponseCache</maml:name>
+          <maml:description>
+            <maml:para>Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="PatternResolverSelection">
+        <maml:name>Resolve-Dns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckingDisabled</maml:name>
+          <maml:description>
+            <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSubnet</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:description>
+            <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsSelectionStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EdnsBufferSize</maml:name>
+          <maml:description>
+            <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnableEdns</maml:name>
+          <maml:description>
+            <maml:para>Enables EDNS on outgoing queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+            <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HttpVersion</maml:name>
+          <maml:description>
+            <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+          <dev:type>
+            <maml:name>Version</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreCertificateErrors</maml:name>
+          <maml:description>
+            <maml:para>Ignore TLS certificate validation errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConnectionsPerServer</maml:name>
+          <maml:description>
+            <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ParseTypedTxtRecords</maml:name>
+          <maml:description>
+            <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Pattern</maml:name>
+          <maml:description>
+            <maml:para>Pattern to expand into multiple DNS queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProxyUri</maml:name>
+          <maml:description>
+            <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestNsid</maml:name>
+          <maml:description>
+            <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverSelectionPath</maml:name>
+          <maml:description>
+            <maml:para>Path to a saved resolver score snapshot whose recommended resolver should be reused for the query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Number of retry attempts on transient errors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryDelayMs</maml:name>
+          <maml:description>
+            <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TypedRecords</maml:name>
+          <maml:description>
+            <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserAgent</maml:name>
+          <maml:description>
+            <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTcpFallback</maml:name>
+          <maml:description>
+            <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AllServers</maml:name>
+        <maml:description>
+          <maml:para>If specified, all servers listed in Server are queried sequentially and the responses are aggregated in server order.</maml:para>
+          <maml:para>When not specified, only the first server is queried for faster results.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CheckingDisabled</maml:name>
+        <maml:description>
+          <maml:para>Sets the CD (checking disabled) bit on outgoing queries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClientSubnet</maml:name>
+        <maml:description>
+          <maml:para>Sets the EDNS Client Subnet (ECS) in CIDR notation, for example 192.0.2.0/24.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DnsProvider</maml:name>
+        <maml:description>
+          <maml:para>Predefined provider(s) (DnsEndpoint) for the query.</maml:para>
+          <maml:para>When a single provider is specified, the classic single-resolver path is used. When multiple providers are specified, the multi-resolver path is used.</maml:para>
+          <maml:para>If not specified, the default provider System (UDP) is used.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsEndpoint[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsEndpoint[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DnsSelectionStrategy</maml:name>
+        <maml:description>
+          <maml:para>How to choose among built-in provider hostnames when a single provider exposes multiple backends.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsSelectionStrategy</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">First</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Failover</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsSelectionStrategy</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>EdnsBufferSize</maml:name>
+        <maml:description>
+          <maml:para>Sets the EDNS UDP buffer size. When specified, EDNS is enabled automatically.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>EnableEdns</maml:name>
+        <maml:description>
+          <maml:para>Enables EDNS on outgoing queries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Fallback</maml:name>
+        <maml:description>
+          <maml:para>If specified, the cmdlet sequentially queries each server until a successful response is received.</maml:para>
+          <maml:para>This option stops on the first server that returns DnsResponseCode.NoError.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FastestCacheMinutes</maml:name>
+        <maml:description>
+          <maml:para>Cache duration in minutes for FastestWins strategy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FullResponse</maml:name>
+        <maml:description>
+          <maml:para>Provides the full response of the query. If not specified, only the minimal response is provided (just the answer).</maml:para>
+          <maml:para>If specified, the full response is provided (answer, authority, and additional sections).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HttpVersion</maml:name>
+        <maml:description>
+          <maml:para>Optional preferred HTTP protocol version, for example 2.0 or 3.0.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Version</command:parameterValue>
+        <dev:type>
+          <maml:name>Version</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IgnoreCertificateErrors</maml:name>
+        <maml:description>
+          <maml:para>Ignore TLS certificate validation errors.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxCacheTtlSeconds</maml:name>
+        <maml:description>
+          <maml:para>Maximal TTL allowed for cached entries (seconds). 0 leaves library default.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxConcurrency</maml:name>
+        <maml:description>
+          <maml:para>Optional cap on client-side query concurrency for single-resolver operations. When 0, the library default is used.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxConnectionsPerServer</maml:name>
+        <maml:description>
+          <maml:para>Maximum HTTP connections allowed per server. When 0, the library default is used.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxParallelism</maml:name>
+        <maml:description>
+          <maml:para>Limits concurrent queries across endpoints. Defaults to 4.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>The name of the DNS record to query for</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ParseTypedTxtRecords</maml:name>
+        <maml:description>
+          <maml:para>Gets or sets a value indicating whether TXT records should be&#xD;
+parsed into specialized types (DMARC, SPF, etc.) when TypedRecords is&#xD;
+specified. When false, returns simple TXT records.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Pattern</maml:name>
+        <maml:description>
+          <maml:para>Pattern to expand into multiple DNS queries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PerEndpointMaxInFlight</maml:name>
+        <maml:description>
+          <maml:para>Limits concurrent queries per endpoint when using the multi-resolver. Set to a positive value to cap in-flight queries per endpoint; 0 disables the cap.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Port</maml:name>
+        <maml:description>
+          <maml:para>Optional port override for the -Server path. If omitted, the selected request format decides the default port.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ProxyUri</maml:name>
+        <maml:description>
+          <maml:para>Optional web proxy URI for HTTP-based transports.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Uri</command:parameterValue>
+        <dev:type>
+          <maml:name>Uri</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RandomServer</maml:name>
+        <maml:description>
+          <maml:para>If specified, the order of servers defined in Server is randomized before querying.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RequestDnsSec</maml:name>
+        <maml:description>
+          <maml:para>Request DNSSEC data (sets the DO bit).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RequestFormat</maml:name>
+        <maml:description>
+          <maml:para>Explicit request format for the -Server path, such as DnsOverUDP, DnsOverTCP, DnsOverTLS, or DnsOverHttps.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsRequestFormat</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DnsOverHttps</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverHttpsJSON</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverHttpsPOST</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverHttpsWirePost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverHttpsJSONPOST</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverUDP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverTCP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverTLS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverHttp2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverHttp3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCrypt</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ObliviousDnsOverHttps</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsOverGrpc</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Multicast</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsRequestFormat</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RequestNsid</maml:name>
+        <maml:description>
+          <maml:para>Requests the NSID EDNS option so compatible servers may include resolver identity metadata in the response.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="DnsProviders">
+        <maml:name>ResolverDnsProvider</maml:name>
+        <maml:description>
+          <maml:para>One or more predefined providers (DnsEndpoint enum) to expand into endpoints for the multi-resolver.</maml:para>
+          <maml:para>This enables strategy control (FirstSuccess/FastestWins/SequentialFallback) and other multi-resolver options.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DnsEndpoint[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsEndpoint[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpoint</maml:name>
+        <maml:description>
+          <maml:para>One or more resolver endpoints in string format. Accepted: "1.1.1.1:53", "[2606:4700:4700::1111]:53", "dns.google:53", DoH URLs like "https://dns.google/dns-query", and transport-prefixed values such as "doq@dns.quad9.net:853" or "doh3@https://dns.quad9.net/dns-query".</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpointFile</maml:name>
+        <maml:description>
+          <maml:para>One or more files containing resolver endpoints for the multi-resolver. Blank lines and full-line comments are ignored.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpointUrl</maml:name>
+        <maml:description>
+          <maml:para>One or more HTTP or HTTPS URLs exposing resolver endpoints for the multi-resolver.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverSelectionPath</maml:name>
+        <maml:description>
+          <maml:para>Path to a saved resolver score snapshot whose recommended resolver should be reused for the query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverStrategy</maml:name>
+        <maml:description>
+          <maml:para>Multi-resolver strategy to use when multiple endpoints are provided.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">MultiResolverStrategy</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">FirstSuccess</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">FastestWins</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SequentialFallback</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RoundRobin</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>MultiResolverStrategy</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RespectEndpointTimeout</maml:name>
+        <maml:description>
+          <maml:para>Respect endpoint-level timeouts if present. When not set, the cmdlet's -TimeOut value is used.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResponseCache</maml:name>
+        <maml:description>
+          <maml:para>Enables response caching based on TTLs for repeated queries of the same (name,type). Disabled by default.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RetryCount</maml:name>
+        <maml:description>
+          <maml:para>Number of retry attempts on transient errors.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RetryDelayMs</maml:name>
+        <maml:description>
+          <maml:para>Delay between retry attempts in milliseconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ServerName">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Server to use for the query. If not specified, the default provider System (UDP) is used.</maml:para>
+          <maml:para>Once a server is specified, the query will be sent to that server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">List`1</command:parameterValue>
+        <dev:type>
+          <maml:name>List`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TimeOut</maml:name>
+        <maml:description>
+          <maml:para>Specifies the timeout for the DNS query, in milliseconds. If the DNS server does not respond within this time, the query will fail. Default is 2000 ms (2 seconds) as defined by DefaultTimeout. Increase this value for slow networks or unreliable servers.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>The type of the record to query for. If not specified, A record is queried.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsRecordType[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TypedRecords</maml:name>
+        <maml:description>
+          <maml:para>When set, attempts to parse answers into typed record objects.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UserAgent</maml:name>
+        <maml:description>
+          <maml:para>Optional User-Agent header for HTTP-based transports.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UseTcpFallback</maml:name>
+        <maml:description>
+          <maml:para>Controls whether UDP queries may fall back to TCP when truncated.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValidateDnsSec</maml:name>
+        <maml:description>
+          <maml:para>Validate DNSSEC signatures. Implies requesting DNSSEC data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Resolve-Dns -ResolverSelectionPath 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>Resolve-Dns -ResolverDnsProvider @('Value')</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>AsyncPSCmdlet</maml:linkText>
+        <maml:uri />
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Test-DnsBenchmark</command:name>
+      <command:verb>Test</command:verb>
+      <command:noun>DnsBenchmark</command:noun>
+      <maml:description>
+        <maml:para>Benchmarks one or more DNS providers or explicit resolver endpoints across repeated queries.</maml:para>
+        <maml:para>Returns one object per candidate with latency, success rate, answer consistency, rank, and recommendation metadata. PowerShell consumers can sort, filter, format, or export the results themselves.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Benchmarks one or more DNS providers or explicit resolver endpoints across repeated queries.</maml:para>
+      <maml:para>Returns one object per candidate with latency, success rate, answer consistency, rank, and recommendation metadata. PowerShell consumers can sort, filter, format, or export the results themselves.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="DnsProvider">
+        <maml:name>Test-DnsBenchmark</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Attempts</maml:name>
+          <maml:description>
+            <maml:para>Number of attempts per domain/type combination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsProvider</maml:name>
+          <maml:description>
+            <maml:para>Built-in provider candidates to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsEndpoint[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSummary</maml:name>
+          <maml:description>
+            <maml:para>Emits a run-level summary object after the per-candidate benchmark results.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Maximum concurrent in-flight benchmark queries across the whole run.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessfulCandidates</maml:name>
+          <maml:description>
+            <maml:para>Require a minimum number of healthy candidates with at least one successful query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessPercent</maml:name>
+          <maml:description>
+            <maml:para>Require a minimum overall successful query percentage for the run to pass policy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Domain names to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC records by setting the DO bit.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SavePath</maml:name>
+          <maml:description>
+            <maml:para>Optional path where the benchmark score snapshot should be saved for later selection and reuse.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SummaryOnly</maml:name>
+          <maml:description>
+            <maml:para>Emits only the run-level summary object and suppresses per-candidate rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Per-query timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Record types to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies RequestDnsSec.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverEndpoint">
+        <maml:name>Test-DnsBenchmark</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Attempts</maml:name>
+          <maml:description>
+            <maml:para>Number of attempts per domain/type combination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSummary</maml:name>
+          <maml:description>
+            <maml:para>Emits a run-level summary object after the per-candidate benchmark results.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Maximum concurrent in-flight benchmark queries across the whole run.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessfulCandidates</maml:name>
+          <maml:description>
+            <maml:para>Require a minimum number of healthy candidates with at least one successful query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessPercent</maml:name>
+          <maml:description>
+            <maml:para>Require a minimum overall successful query percentage for the run to pass policy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Domain names to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC records by setting the DO bit.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpoint</maml:name>
+          <maml:description>
+            <maml:para>Explicit resolver endpoint candidates to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointFile</maml:name>
+          <maml:description>
+            <maml:para>Files containing resolver endpoint candidates to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointUrl</maml:name>
+          <maml:description>
+            <maml:para>HTTP or HTTPS URLs exposing resolver endpoint candidates to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SavePath</maml:name>
+          <maml:description>
+            <maml:para>Optional path where the benchmark score snapshot should be saved for later selection and reuse.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SummaryOnly</maml:name>
+          <maml:description>
+            <maml:para>Emits only the run-level summary object and suppresses per-candidate rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Per-query timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Record types to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies RequestDnsSec.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverSelection">
+        <maml:name>Test-DnsBenchmark</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Attempts</maml:name>
+          <maml:description>
+            <maml:para>Number of attempts per domain/type combination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSummary</maml:name>
+          <maml:description>
+            <maml:para>Emits a run-level summary object after the per-candidate benchmark results.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxConcurrency</maml:name>
+          <maml:description>
+            <maml:para>Maximum concurrent in-flight benchmark queries across the whole run.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessfulCandidates</maml:name>
+          <maml:description>
+            <maml:para>Require a minimum number of healthy candidates with at least one successful query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessPercent</maml:name>
+          <maml:description>
+            <maml:para>Require a minimum overall successful query percentage for the run to pass policy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Domain names to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC records by setting the DO bit.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverSelectionPath</maml:name>
+          <maml:description>
+            <maml:para>Path to a saved resolver score snapshot whose recommended resolver should be reused as the single benchmark candidate.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SavePath</maml:name>
+          <maml:description>
+            <maml:para>Optional path where the benchmark score snapshot should be saved for later selection and reuse.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SummaryOnly</maml:name>
+          <maml:description>
+            <maml:para>Emits only the run-level summary object and suppresses per-candidate rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Per-query timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Record types to benchmark.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies RequestDnsSec.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Attempts</maml:name>
+        <maml:description>
+          <maml:para>Number of attempts per domain/type combination.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DnsProvider</maml:name>
+        <maml:description>
+          <maml:para>Built-in provider candidates to benchmark.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsEndpoint[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsEndpoint[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeSummary</maml:name>
+        <maml:description>
+          <maml:para>Emits a run-level summary object after the per-candidate benchmark results.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxConcurrency</maml:name>
+        <maml:description>
+          <maml:para>Maximum concurrent in-flight benchmark queries across the whole run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MinSuccessfulCandidates</maml:name>
+        <maml:description>
+          <maml:para>Require a minimum number of healthy candidates with at least one successful query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MinSuccessPercent</maml:name>
+        <maml:description>
+          <maml:para>Require a minimum overall successful query percentage for the run to pass policy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Domain names to benchmark.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RequestDnsSec</maml:name>
+        <maml:description>
+          <maml:para>Request DNSSEC records by setting the DO bit.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpoint</maml:name>
+        <maml:description>
+          <maml:para>Explicit resolver endpoint candidates to benchmark.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpointFile</maml:name>
+        <maml:description>
+          <maml:para>Files containing resolver endpoint candidates to benchmark.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpointUrl</maml:name>
+        <maml:description>
+          <maml:para>HTTP or HTTPS URLs exposing resolver endpoint candidates to benchmark.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverSelectionPath</maml:name>
+        <maml:description>
+          <maml:para>Path to a saved resolver score snapshot whose recommended resolver should be reused as the single benchmark candidate.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SavePath</maml:name>
+        <maml:description>
+          <maml:para>Optional path where the benchmark score snapshot should be saved for later selection and reuse.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SummaryOnly</maml:name>
+        <maml:description>
+          <maml:para>Emits only the run-level summary object and suppresses per-candidate rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TimeOut</maml:name>
+        <maml:description>
+          <maml:para>Per-query timeout in milliseconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Record types to benchmark.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsRecordType[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsRecordType[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValidateDnsSec</maml:name>
+        <maml:description>
+          <maml:para>Validate DNSSEC signatures. Implies RequestDnsSec.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DnsClientX.PowerShell.DnsBenchmarkResult</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Per-candidate DNS benchmark output for PowerShell consumers.</maml:para>
+        </maml:description>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DnsClientX.PowerShell.DnsBenchmarkSummary</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Run-level DNS benchmark summary for PowerShell consumers.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Test-DnsBenchmark -ResolverSelectionPath 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Test-DnsProbe</command:name>
+      <command:verb>Test</command:verb>
+      <command:noun>DnsProbe</command:noun>
+      <maml:description>
+        <maml:para>Probes one built-in resolver profile or a custom resolver set and reports health, consensus, and recommendation data.</maml:para>
+        <maml:para>Runs a single DNS query against each candidate, highlights answer mismatches, applies optional success and consensus policy gates, and can persist the scored result set for later resolver selection and reuse.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Probes one built-in resolver profile or a custom resolver set and reports health, consensus, and recommendation data.</maml:para>
+      <maml:para>Runs a single DNS query against each candidate, highlights answer mismatches, applies optional success and consensus policy gates, and can persist the scored result set for later resolver selection and reuse.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="DnsProvider">
+        <maml:name>Test-DnsProbe</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsProvider</maml:name>
+          <maml:description>
+            <maml:para>Built-in resolver profile to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsEndpoint</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSummary</maml:name>
+          <maml:description>
+            <maml:para>Emits a run-level summary object after the per-candidate probe rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinConsensusPercent</maml:name>
+          <maml:description>
+            <maml:para>Require the leading answer group to reach at least this consensus percentage.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessCount</maml:name>
+          <maml:description>
+            <maml:para>Require at least this many successful probe candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessPercent</maml:name>
+          <maml:description>
+            <maml:para>Require at least this successful probe percentage across all candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Domain name to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC records by setting the DO bit.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequireConsensus</maml:name>
+          <maml:description>
+            <maml:para>Require unanimous answer consensus among successful candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SavePath</maml:name>
+          <maml:description>
+            <maml:para>Optional path where the probe score snapshot should be saved for later selection and reuse.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SummaryOnly</maml:name>
+          <maml:description>
+            <maml:para>Emits only the run-level summary object and suppresses per-candidate rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Per-query timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Record type to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies RequestDnsSec.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverEndpoint">
+        <maml:name>Test-DnsProbe</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSummary</maml:name>
+          <maml:description>
+            <maml:para>Emits a run-level summary object after the per-candidate probe rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinConsensusPercent</maml:name>
+          <maml:description>
+            <maml:para>Require the leading answer group to reach at least this consensus percentage.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessCount</maml:name>
+          <maml:description>
+            <maml:para>Require at least this many successful probe candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessPercent</maml:name>
+          <maml:description>
+            <maml:para>Require at least this successful probe percentage across all candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Domain name to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC records by setting the DO bit.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequireConsensus</maml:name>
+          <maml:description>
+            <maml:para>Require unanimous answer consensus among successful candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpoint</maml:name>
+          <maml:description>
+            <maml:para>Explicit resolver endpoints to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointFile</maml:name>
+          <maml:description>
+            <maml:para>Files containing resolver endpoints to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointUrl</maml:name>
+          <maml:description>
+            <maml:para>HTTP or HTTPS URLs exposing resolver endpoints to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SavePath</maml:name>
+          <maml:description>
+            <maml:para>Optional path where the probe score snapshot should be saved for later selection and reuse.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SummaryOnly</maml:name>
+          <maml:description>
+            <maml:para>Emits only the run-level summary object and suppresses per-candidate rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Per-query timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Record type to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies RequestDnsSec.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ResolverSelection">
+        <maml:name>Test-DnsProbe</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSummary</maml:name>
+          <maml:description>
+            <maml:para>Emits a run-level summary object after the per-candidate probe rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinConsensusPercent</maml:name>
+          <maml:description>
+            <maml:para>Require the leading answer group to reach at least this consensus percentage.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessCount</maml:name>
+          <maml:description>
+            <maml:para>Require at least this many successful probe candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinSuccessPercent</maml:name>
+          <maml:description>
+            <maml:para>Require at least this successful probe percentage across all candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Domain name to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequestDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Request DNSSEC records by setting the DO bit.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequireConsensus</maml:name>
+          <maml:description>
+            <maml:para>Require unanimous answer consensus among successful candidates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverSelectionPath</maml:name>
+          <maml:description>
+            <maml:para>Path to a saved resolver score snapshot whose recommended resolver should be reused as the single probe candidate.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SavePath</maml:name>
+          <maml:description>
+            <maml:para>Optional path where the probe score snapshot should be saved for later selection and reuse.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SummaryOnly</maml:name>
+          <maml:description>
+            <maml:para>Emits only the run-level summary object and suppresses per-candidate rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeOut</maml:name>
+          <maml:description>
+            <maml:para>Per-query timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Record type to probe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsRecordType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsRecordType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValidateDnsSec</maml:name>
+          <maml:description>
+            <maml:para>Validate DNSSEC signatures. Implies RequestDnsSec.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DnsProvider</maml:name>
+        <maml:description>
+          <maml:para>Built-in resolver profile to probe.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsEndpoint</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsEndpoint</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeSummary</maml:name>
+        <maml:description>
+          <maml:para>Emits a run-level summary object after the per-candidate probe rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MinConsensusPercent</maml:name>
+        <maml:description>
+          <maml:para>Require the leading answer group to reach at least this consensus percentage.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MinSuccessCount</maml:name>
+        <maml:description>
+          <maml:para>Require at least this many successful probe candidates.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MinSuccessPercent</maml:name>
+        <maml:description>
+          <maml:para>Require at least this successful probe percentage across all candidates.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Domain name to probe.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RequestDnsSec</maml:name>
+        <maml:description>
+          <maml:para>Request DNSSEC records by setting the DO bit.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RequireConsensus</maml:name>
+        <maml:description>
+          <maml:para>Require unanimous answer consensus among successful candidates.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpoint</maml:name>
+        <maml:description>
+          <maml:para>Explicit resolver endpoints to probe.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpointFile</maml:name>
+        <maml:description>
+          <maml:para>Files containing resolver endpoints to probe.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpointUrl</maml:name>
+        <maml:description>
+          <maml:para>HTTP or HTTPS URLs exposing resolver endpoints to probe.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverSelectionPath</maml:name>
+        <maml:description>
+          <maml:para>Path to a saved resolver score snapshot whose recommended resolver should be reused as the single probe candidate.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SavePath</maml:name>
+        <maml:description>
+          <maml:para>Optional path where the probe score snapshot should be saved for later selection and reuse.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SummaryOnly</maml:name>
+        <maml:description>
+          <maml:para>Emits only the run-level summary object and suppresses per-candidate rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TimeOut</maml:name>
+        <maml:description>
+          <maml:para>Per-query timeout in milliseconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Record type to probe.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsRecordType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Reserved</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">A</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MF</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CNAME</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SOA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NULL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">WKS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TXT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AFSDB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">X25</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ISDN</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSAP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSAP_PTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AAAA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LOC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NXT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SRV</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ATMA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NAPTR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">KX</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CERT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">A6</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DNAME</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SINK</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OPT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">APL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SSHFP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPSECKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RRSIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DNSKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DHCID</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NSEC3PARAM</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TLSA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SMIMEA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HIP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TALINK</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CDS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CDNSKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OPENPGPKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CSYNC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ZONEMD</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SVCB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HTTPS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SPF</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TKEY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TSIG</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IXFR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AXFR</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MAILB</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MAILA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ANY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">URI</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CAA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AVC</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DOA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AMTRELAY</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RESINFO</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DLV</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DnsRecordType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValidateDnsSec</maml:name>
+        <maml:description>
+          <maml:para>Validate DNSSEC signatures. Implies RequestDnsSec.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DnsClientX.PowerShell.DnsProbeResult</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Per-candidate DNS probe output for PowerShell consumers.</maml:para>
+        </maml:description>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DnsClientX.PowerShell.DnsProbeSummary</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Run-level DNS probe summary for PowerShell consumers.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Test-DnsProbe -ResolverSelectionPath 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Test-DnsResolverCatalog</command:name>
+      <command:verb>Test</command:verb>
+      <command:noun>DnsResolverCatalog</command:noun>
+      <maml:description>
+        <maml:para>Validates resolver endpoint catalog inputs without querying DNS.</maml:para>
+        <maml:para>Checks inline resolver endpoints, resolver endpoint files, and resolver endpoint URLs using the same parser used by probe and benchmark workflows.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Validates resolver endpoint catalog inputs without querying DNS.</maml:para>
+      <maml:para>Checks inline resolver endpoints, resolver endpoint files, and resolver endpoint URLs using the same parser used by probe and benchmark workflows.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Test-DnsResolverCatalog</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>ResolverEndpoint</maml:name>
+          <maml:description>
+            <maml:para>Inline resolver endpoint entries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointFile</maml:name>
+          <maml:description>
+            <maml:para>Files containing resolver endpoint entries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ResolverEndpointUrl</maml:name>
+          <maml:description>
+            <maml:para>HTTP or HTTPS URLs containing resolver endpoint entries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>ResolverEndpoint</maml:name>
+        <maml:description>
+          <maml:para>Inline resolver endpoint entries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpointFile</maml:name>
+        <maml:description>
+          <maml:para>Files containing resolver endpoint entries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ResolverEndpointUrl</maml:name>
+        <maml:description>
+          <maml:para>HTTP or HTTPS URLs containing resolver endpoint entries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String[]</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DnsClientX.ResolverEndpointValidationResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Test-DnsResolverCatalog -ResolverEndpoint @('Value')</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+</helpItems>


### PR DESCRIPTION
## Summary

- Removes the MatejKafka.XmlDoc2CmdletDoc dependency and its build targets.
- Uses the public PSPublishModule 3.0.88 / PowerForge documentation owner.
- Regenerates Markdown and MAML and keeps binary external help discoverable with the assembly-named alias.

## Validation

- Full public-package module build completed.
- Markdown and MAML command identities match; MAML parses as XML.
- Regeneration is idempotent.
- Generated help was exercised through PowerShell 7 and Windows PowerShell 5.1.
- Repository-native .NET builds pass for the supported target frameworks.

## Scope

This PR is intentionally limited to dependency removal and functional build/package/import/Get-Help preservation. Documentation-content debt such as prose, examples, defaults, output annotations, and display enrichment is recorded separately and is not hand-edited in generated artifacts here.